### PR TITLE
feat: OIDC 인증 시 테넌트 식별 개선 (#6)

### DIFF
--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -91,6 +91,7 @@ describe('loginCommand', () => {
     expect(authUrl.searchParams.get('code_challenge')).toBeTruthy();
     expect(authUrl.searchParams.get('state')).toBeTruthy();
     expect(authUrl.searchParams.get('redirect_uri')).toContain('http://127.0.0.1:');
+    expect(authUrl.searchParams.get('tenant')).toBe('test.stark.com');
 
     // Verify credentials saved
     const stored = getStored();

--- a/src/__tests__/oidc.test.ts
+++ b/src/__tests__/oidc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC } from '../oidc';
+import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain } from '../oidc';
 import * as crypto from 'crypto';
 
 describe('PKCE', () => {
@@ -43,6 +43,29 @@ describe('PKCE', () => {
     const state2 = generateState();
     expect(state1).not.toBe(state2);
     expect(state1.length).toBeGreaterThan(0);
+  });
+});
+
+describe('resolveStarkDomain', () => {
+  it('resolves stg tenant to stg Stark domain', () => {
+    expect(resolveStarkDomain('stg-warmblood091803.monocle-ai.com')).toBe('stg.monocle-ai.com');
+  });
+
+  it('resolves production tenant to base domain', () => {
+    expect(resolveStarkDomain('warmblood.monocle-ai.com')).toBe('monocle-ai.com');
+  });
+
+  it('throws on bare domain (no subdomain)', () => {
+    expect(() => resolveStarkDomain('monocle-ai.com')).toThrow('Invalid tenant domain');
+    expect(() => resolveStarkDomain('monocle-ai.com')).toThrow('Tenant must be a subdomain');
+  });
+
+  it('preserves localhost as-is', () => {
+    expect(resolveStarkDomain('localhost:8080')).toBe('localhost:8080');
+  });
+
+  it('preserves 127.0.0.1 as-is', () => {
+    expect(resolveStarkDomain('127.0.0.1:8080')).toBe('127.0.0.1:8080');
   });
 });
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -186,6 +186,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
         state: state,
+        tenant: options.tenantDomain,
       });
 
       const authUrl = `${oidc.authorization_endpoint}?${authParams.toString()}`;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as url from 'url';
 import { Credentials, CredentialsData } from '../credentials';
-import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, OIDCDeps } from '../oidc';
+import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain, OIDCDeps } from '../oidc';
 import { decodeIdTokenPayload } from '../refresh';
 
 const CLIENT_ID = 'monocle-cli';
@@ -44,8 +44,9 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
   const createServerFn = deps?.createServer ?? ((handler: any) => http.createServer(handler) as any);
 
   // Step 1: OIDC Discovery
-  process.stderr.write(`Discovering OIDC configuration for ${options.tenantDomain}...\n`);
-  const oidc = await discoverOIDC(options.tenantDomain, { fetch: fetchFn } as OIDCDeps);
+  const starkDomain = resolveStarkDomain(options.tenantDomain);
+  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
 
   // Step 2: Generate PKCE + state
   const codeVerifier = generateCodeVerifier();

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -43,6 +43,37 @@ export function generateState(): string {
 }
 
 /**
+ * Resolve the Stark (control plane) domain from a tenant domain.
+ * Tenants always run on a subdomain — bare domains are rejected.
+ *
+ * Examples:
+ *   stg-warmblood091803.monocle-ai.com → stg.monocle-ai.com
+ *   warmblood.monocle-ai.com           → monocle-ai.com
+ *   localhost:8080                      → localhost:8080
+ */
+export function resolveStarkDomain(tenantDomain: string): string {
+  if (tenantDomain.startsWith('localhost') || tenantDomain.startsWith('127.0.0.1')) {
+    return tenantDomain;
+  }
+
+  const parts = tenantDomain.split('.');
+  if (parts.length <= 2) {
+    throw new Error(
+      `Invalid tenant domain: ${tenantDomain}. Tenant must be a subdomain (e.g., mytenant.monocle-ai.com)`
+    );
+  }
+
+  const subdomain = parts[0];
+  const baseDomain = parts.slice(1).join('.');
+
+  if (subdomain.startsWith('stg-')) {
+    return `stg.${baseDomain}`;
+  }
+
+  return baseDomain;
+}
+
+/**
  * Discover OIDC endpoints from tenant domain
  */
 export async function discoverOIDC(

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -1,5 +1,5 @@
 import { Credentials, CredentialsData } from './credentials';
-import { discoverOIDC, OIDCDeps } from './oidc';
+import { discoverOIDC, resolveStarkDomain, OIDCDeps } from './oidc';
 
 export interface RefreshDeps {
   fetch?: (url: string, init?: any) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>;
@@ -29,7 +29,8 @@ export async function refreshAccessToken(
   let tokenEndpoint: string;
   let discoveredRouterUrl: string | undefined;
   try {
-    const oidc = await discoverOIDC(currentCredentials.tenant_domain, { fetch: deps?.fetch } as OIDCDeps);
+    const starkDomain = resolveStarkDomain(currentCredentials.tenant_domain);
+    const oidc = await discoverOIDC(starkDomain, { fetch: deps?.fetch } as OIDCDeps);
     tokenEndpoint = oidc.token_endpoint;
     discoveredRouterUrl = oidc.router_url;
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- 테넌트 도메인에서 Stark 컨트롤 플레인 도메인을 추출하는 `resolveStarkDomain()` 함수 추가
- Authorization Request에 `tenant` 쿼리 파라미터 추가하여 localhost redirect_uri에서도 테넌트 식별 가능하도록 개선

## 배경
monocle-cli는 `redirect_uri=http://127.0.0.1:{port}/...`를 사용하므로 Stark에서 기존 redirect_uri 기반 테넌트 식별이 불가능함. `tenant` 파라미터를 명시적으로 전송하여 해결.

## Test plan
- [x] `npx vitest run` 전체 54개 테스트 통과
- [ ] Stark에 tenant 파라미터 처리 로직 추가 후 수동 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)