### PR TITLE
feat: npm 공개 배포 — @warmblood/monocle-cli@0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Monocle CLI를 사용하면 [Claude Code](https://docs.anthropic.com/en/docs/cla
 **Step 1** — Monocle CLI 설치
 
 ```bash
-npm install -g @monocle-ai/cli
+npm install -g @warmblood/monocle-cli
 ```
 
 **Step 2** — 로그인

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@monocle-ai/cli",
+  "name": "@warmblood/monocle-cli",
   "version": "0.1.0",
   "description": "CLI authentication tool for Claude Code with Stark OIDC PKCE integration",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- 패키지명을 `@monocle-ai/cli` → `@warmblood/monocle-cli`로 변경 (회사 단일 스코프 전략)
- npm에 `@warmblood/monocle-cli@0.1.0` 공개 배포 완료
- README 설치 명령어 업데이트

## 배경
- 회사(warmblood) 아래 3개+ 제품을 운영하므로 `@warmblood` 단일 스코프로 통합 관리
- 추후 제품 독립 브랜드 필요시 `@monocle-ai/cli`로 마이그레이션 가능

## 설치 방법
```bash
npm install -g @warmblood/monocle-cli && monocle
```

## Test plan
- [x] `npm pack --dry-run`으로 포함 파일 확인
- [x] `npm publish --access public` 성공
- [x] `npm view @warmblood/monocle-cli` 정상 조회 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)