### PR TITLE
feat: monocle claude 명령어 — 환경 변수 충돌 자동 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ monocle login --tenant your-org.monocle-ai.com
 monocle setup
 ```
 
-끝이에요! 이제 평소처럼 `claude`를 실행하시면 됩니다.
+끝이에요! 이제 `monocle claude`를 실행하시면 됩니다.
+
+> **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
 
 ## 상태 확인
 
@@ -44,13 +46,14 @@ monocle status
 
 ## 전체 명령어
 
-| 명령어 | 설명 |
-|--------|------|
-| `monocle login --tenant <domain>` | 브라우저로 로그인 |
-| `monocle setup` | Claude Code를 조직 엔드포인트에 연결 |
-| `monocle status` | 로그인/설정 상태 확인 |
-| `monocle token` | 현재 액세스 토큰 출력 (Claude Code가 내부적으로 사용) |
-| `monocle unset` | Claude Code에서 Monocle 설정 제거 |
+| 명령어                            | 설명                                                  |
+|-----------------------------------|-------------------------------------------------------|
+| `monocle login --tenant <domain>` | 브라우저로 로그인                                     |
+| `monocle setup`                   | Claude Code를 조직 엔드포인트에 연결                  |
+| `monocle claude`                  | 환경 변수 충돌을 자동 정리하고 Claude Code 실행        |
+| `monocle status`                  | 로그인/설정 상태 확인                                 |
+| `monocle token`                   | 현재 액세스 토큰 출력 (Claude Code가 내부적으로 사용)  |
+| `monocle unset`                   | Claude Code에서 Monocle 설정 제거                     |
 
 ## 문제가 생겼나요?
 
@@ -61,12 +64,7 @@ monocle status
 → 토큰은 자동으로 갱신돼요. 마지막 로그인 후 30일이 지났다면 `monocle login`을 다시 실행해 주세요.
 
 **Claude Code가 Monocle을 무시해요**
-→ 환경 변수에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Monocle보다 우선 적용돼요. 아래 명령어로 해제해 주세요:
-
-```bash
-unset ANTHROPIC_API_KEY
-unset ANTHROPIC_AUTH_TOKEN
-```
+→ 환경 변수에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Monocle보다 우선 적용돼요. `monocle claude`로 실행하면 자동으로 해결됩니다.
 
 **처음부터 다시 하고 싶어요**
 → `monocle unset` 후 `monocle setup`을 다시 실행하면 돼요.

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { claudeCommand } from '../commands/claude';
+import { Credentials, CredentialsData } from '../credentials';
+import { EventEmitter } from 'events';
+
+function makeCredentials(overrides?: Partial<CredentialsData>): CredentialsData {
+  return {
+    tenant_domain: 'example.stark.com',
+    tenant_name: 'Example Corp',
+    email: 'user@example.com',
+    access_token: 'at-valid',
+    refresh_token: 'rt-valid',
+    id_token: 'id-valid',
+    access_token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    refresh_token_expires_at: new Date(Date.now() + 30 * 86400_000).toISOString(),
+    router_url: 'https://warmblood.krmonocle-ai.com',
+    ...overrides,
+  };
+}
+
+function createMockCredentials(data: CredentialsData | null) {
+  return {
+    read: () => data,
+    write: () => {},
+    delete: () => {},
+    getCredentialsPath: () => '/fake/.monocle/credentials.json',
+    getCredentialsDir: () => '/fake/.monocle',
+    getFileMode: () => 0o600,
+  } as any as Credentials;
+}
+
+function makeMockSpawn() {
+  const child = new EventEmitter();
+  const spawnFn = vi.fn().mockReturnValue(child);
+  return { spawnFn, child };
+}
+
+describe('claudeCommand', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  it('should exit if not logged in', async () => {
+    await claudeCommand([], { credentials: createMockCredentials(null) });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Not logged in')
+    );
+  });
+
+  it('should remove ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from child env', async () => {
+    const { spawnFn } = makeMockSpawn();
+    const env = {
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'sk-ant-xxx',
+      ANTHROPIC_AUTH_TOKEN: 'bearer-xxx',
+      HOME: '/home/user',
+    };
+
+    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn });
+
+    const childEnv = spawnFn.mock.calls[0][2].env;
+    expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(childEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(childEnv.PATH).toBe('/usr/bin');
+    expect(childEnv.HOME).toBe('/home/user');
+  });
+
+  it('should set ANTHROPIC_BASE_URL from router_url', async () => {
+    const { spawnFn } = makeMockSpawn();
+
+    await claudeCommand([], {
+      credentials: createMockCredentials(makeCredentials({ router_url: 'https://warmblood.krmonocle-ai.com' })),
+      env: { PATH: '/usr/bin' },
+      spawn: spawnFn,
+    });
+
+    const childEnv = spawnFn.mock.calls[0][2].env;
+    expect(childEnv.ANTHROPIC_BASE_URL).toBe('https://warmblood.krmonocle-ai.com');
+  });
+
+  it('should fallback to tenant_domain if router_url is absent', async () => {
+    const { spawnFn } = makeMockSpawn();
+
+    await claudeCommand([], {
+      credentials: createMockCredentials(makeCredentials({ router_url: undefined })),
+      env: {},
+      spawn: spawnFn,
+    });
+
+    const childEnv = spawnFn.mock.calls[0][2].env;
+    expect(childEnv.ANTHROPIC_BASE_URL).toBe('https://example.stark.com');
+  });
+
+  it('should pass arguments through to claude', async () => {
+    const { spawnFn } = makeMockSpawn();
+
+    await claudeCommand(['--model', 'opus'], {
+      credentials: createMockCredentials(makeCredentials()),
+      env: {},
+      spawn: spawnFn,
+    });
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      'claude',
+      ['--model', 'opus'],
+      expect.any(Object)
+    );
+  });
+
+  it('should spawn claude with stdio inherit', async () => {
+    const { spawnFn } = makeMockSpawn();
+
+    await claudeCommand([], {
+      credentials: createMockCredentials(makeCredentials()),
+      env: {},
+      spawn: spawnFn,
+    });
+
+    expect(spawnFn.mock.calls[0][2].stdio).toBe('inherit');
+  });
+
+  it('should handle claude not found (ENOENT)', async () => {
+    const { spawnFn, child } = makeMockSpawn();
+
+    await claudeCommand([], {
+      credentials: createMockCredentials(makeCredentials()),
+      env: {},
+      spawn: spawnFn,
+    });
+
+    const error = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
+    error.code = 'ENOENT';
+    child.emit('error', error);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('claude` command not found')
+    );
+  });
+});

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -123,6 +123,7 @@ describe('setupCommand', () => {
     });
 
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('ANTHROPIC_API_KEY'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('monocle claude'));
     stderrSpy.mockRestore();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { tokenCommand } from './commands/token';
 import { setupCommand } from './commands/setup';
 import { unsetCommand } from './commands/unset';
 import { statusCommand } from './commands/status';
+import { claudeCommand } from './commands/claude';
 
 const program = new Command();
 
@@ -69,6 +70,20 @@ program
   .action(async () => {
     try {
       await statusCommand();
+    } catch (err: any) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('claude')
+  .description('Launch Claude Code with Monocle authentication (clears conflicting env vars)')
+  .allowUnknownOption(true)
+  .helpOption(false)
+  .action(async (_options, cmd) => {
+    try {
+      await claudeCommand(cmd.args);
     } catch (err: any) {
       process.stderr.write(`Error: ${err.message}\n`);
       process.exit(1);

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -1,0 +1,60 @@
+import * as child_process from 'child_process';
+import { Credentials } from '../credentials';
+
+export interface ClaudeDeps {
+  credentials?: Credentials;
+  env?: Record<string, string | undefined>;
+  spawn?: typeof child_process.spawn;
+}
+
+export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const parentEnv = deps?.env ?? process.env;
+  const spawnFn = deps?.spawn ?? child_process.spawn;
+
+  const creds = credentials.read();
+  if (!creds) {
+    process.stderr.write('Not logged in. Run `monocle login --tenant <domain>` first.\n');
+    process.exit(1);
+    return;
+  }
+
+  // Build clean env — remove vars that override apiKeyHelper
+  const childEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parentEnv)) {
+    if (value !== undefined && key !== 'ANTHROPIC_API_KEY' && key !== 'ANTHROPIC_AUTH_TOKEN') {
+      childEnv[key] = value;
+    }
+  }
+
+  // Set base URL to Chat Proxy
+  if (creds.router_url) {
+    childEnv.ANTHROPIC_BASE_URL = creds.router_url;
+  } else {
+    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
+    childEnv.ANTHROPIC_BASE_URL = `${isLocal ? 'http' : 'https'}://${creds.tenant_domain}`;
+  }
+
+  const child = spawnFn('claude', args, {
+    env: childEnv,
+    stdio: 'inherit',
+  });
+
+  let exited = false;
+
+  child.on('close', (code) => {
+    if (!exited) { exited = true; process.exit(code ?? 0); }
+  });
+
+  child.on('error', (err: NodeJS.ErrnoException) => {
+    if (!exited) {
+      exited = true;
+      if (err.code === 'ENOENT') {
+        process.stderr.write('Error: `claude` command not found. Is Claude Code installed?\n');
+      } else {
+        process.stderr.write(`Error: ${err.message}\n`);
+      }
+      process.exit(1);
+    }
+  });
+}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -54,7 +54,8 @@ export async function setupCommand(deps?: SetupDeps): Promise<void> {
   if (creds.router_url) {
     routerUrl = creds.router_url;
   } else {
-    const protocol = creds.tenant_domain.startsWith('localhost') ? 'http' : 'https';
+    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
+    const protocol = isLocal ? 'http' : 'https';
     routerUrl = `${protocol}://${creds.tenant_domain}`;
     process.stderr.write('Warning: router_url not found. Using tenant domain as fallback.\n');
     process.stderr.write('Run `monocle login --tenant <domain>` to update credentials.\n');
@@ -71,12 +72,9 @@ export async function setupCommand(deps?: SetupDeps): Promise<void> {
   process.stderr.write(`  ANTHROPIC_BASE_URL: ${routerUrl}\n`);
 
   // Step 7: Warn about conflicting env vars
-  if (env.ANTHROPIC_API_KEY) {
-    process.stderr.write('\n⚠ Warning: ANTHROPIC_API_KEY environment variable is set.\n');
-    process.stderr.write('  It takes priority over apiKeyHelper. Unset it to use Monocle authentication.\n');
-  }
-  if (env.ANTHROPIC_AUTH_TOKEN) {
-    process.stderr.write('\n⚠ Warning: ANTHROPIC_AUTH_TOKEN environment variable is set.\n');
-    process.stderr.write('  It takes priority over apiKeyHelper. Unset it to use Monocle authentication.\n');
+  const conflicting = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'].filter(k => env[k]);
+  if (conflicting.length > 0) {
+    process.stderr.write(`\n⚠ Warning: ${conflicting.join(', ')} environment variable is set.\n`);
+    process.stderr.write('  Use `monocle claude` to launch Claude Code — it clears conflicting env vars automatically.\n');
   }
 }


### PR DESCRIPTION
## Summary
- `monocle claude` 명령어 추가: `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` 환경 변수를 자동 제거 후 Claude Code 실행
- `setup` 경고 메시지를 `monocle claude` 안내로 변경
- `localhost`/`127.0.0.1` 프로토콜 감지 개선

Closes #9

## Test plan
- [x] 기존 테스트 61개 전체 통과
- [ ] `ANTHROPIC_API_KEY` 설정 후 `monocle claude` 실행 시 키가 무시되는지 확인
- [ ] `monocle claude --model opus` 등 인자 전달 확인
- [ ] Claude Code 미설치 시 에러 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)