### PR TITLE
feat: add `monocle model list` and `monocle model chat` commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,7 @@ model
 model
   .command('chat')
   .description('Chat with LLM via Monocle router (interactive REPL or pipe from stdin)')
-  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-5-20250514')
+  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-6')
   .option('--system-prompt <text>', 'System prompt text')
   .option('--system-prompt-file <path>', 'Load system prompt from file')
   .option('--max-tokens <n>', 'Maximum output tokens', '4096')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import { setupCommand } from './commands/setup';
 import { unsetCommand } from './commands/unset';
 import { statusCommand } from './commands/status';
 import { claudeCommand } from './commands/claude';
+import { chatCommand } from './commands/chat';
+import { modelListCommand } from './commands/model-list';
 
 const program = new Command();
 
@@ -85,6 +87,38 @@ program
   .action(async (_options, cmd) => {
     try {
       await claudeCommand(cmd.args);
+    } catch (err: any) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    }
+  });
+
+const model = program
+  .command('model')
+  .description('Manage and interact with LLM models');
+
+model
+  .command('list')
+  .description('List available models from the Monocle router')
+  .action(async () => {
+    try {
+      await modelListCommand();
+    } catch (err: any) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    }
+  });
+
+model
+  .command('chat')
+  .description('Chat with LLM via Monocle router (interactive REPL or pipe from stdin)')
+  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-5-20250514')
+  .option('--system-prompt <text>', 'System prompt text')
+  .option('--system-prompt-file <path>', 'Load system prompt from file')
+  .option('--max-tokens <n>', 'Maximum output tokens', '4096')
+  .action(async (options) => {
+    try {
+      await chatCommand(options);
     } catch (err: any) {
       process.stderr.write(`Error: ${err.message}\n`);
       process.exit(1);

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -21,7 +21,7 @@ export interface ChatDeps {
 }
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
-const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const DEFAULT_MAX_TOKENS = 4096;
 
 async function getAccessToken(

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,0 +1,204 @@
+import * as fs from 'fs';
+import * as readline from 'readline';
+import { Credentials } from '../credentials';
+import { refreshAccessToken, RefreshDeps } from '../refresh';
+
+export interface ChatOptions {
+  model?: string;
+  systemPrompt?: string;
+  systemPromptFile?: string;
+  maxTokens?: string;
+}
+
+export interface ChatDeps {
+  credentials?: Credentials;
+  refreshDeps?: RefreshDeps;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+}
+
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
+const DEFAULT_MAX_TOKENS = 4096;
+
+async function getAccessToken(
+  credentials: Credentials,
+  deps?: ChatDeps,
+): Promise<{ token: string; routerUrl: string }> {
+  const now = deps?.now ?? (() => new Date());
+  const stderr = deps?.stderr ?? process.stderr;
+
+  const creds = credentials.read();
+  if (!creds) {
+    stderr.write('Not logged in. Run `monocle login --tenant <domain>` first.\n');
+    process.exit(1);
+  }
+
+  let activeCreds = creds;
+  const expiresAt = new Date(creds.access_token_expires_at).getTime();
+  if (now().getTime() + EXPIRY_BUFFER_MS > expiresAt) {
+    const result = await refreshAccessToken(creds, {
+      credentials,
+      ...deps?.refreshDeps,
+    });
+    if (!result.success || !result.credentials) {
+      stderr.write(`Token refresh failed: ${result.error}\n`);
+      process.exit(1);
+    }
+    activeCreds = result.credentials;
+  }
+
+  let routerUrl: string;
+  if (activeCreds.router_url) {
+    routerUrl = activeCreds.router_url;
+  } else {
+    const isLocal =
+      activeCreds.tenant_domain.startsWith('localhost') ||
+      activeCreds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${activeCreds.tenant_domain}`;
+  }
+
+  return { token: activeCreds.access_token, routerUrl };
+}
+
+async function callChat(
+  routerUrl: string,
+  token: string,
+  model: string,
+  systemPrompt: string | undefined,
+  userMessage: string,
+  maxTokens: number,
+  deps?: ChatDeps,
+): Promise<string> {
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  const messages: Array<{ role: string; content: string }> = [];
+  if (systemPrompt) {
+    messages.push({ role: 'system', content: systemPrompt });
+  }
+  messages.push({ role: 'user', content: userMessage });
+
+  const response = await fetchFn(`${routerUrl}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: maxTokens,
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as any;
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+export async function chatCommand(
+  options: ChatOptions,
+  deps?: ChatDeps,
+): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const stdout = deps?.stdout ?? process.stdout;
+  const stderr = deps?.stderr ?? process.stderr;
+
+  const model = options.model ?? DEFAULT_MODEL;
+  const maxTokens = parseInt(options.maxTokens ?? String(DEFAULT_MAX_TOKENS), 10);
+
+  // Resolve system prompt
+  let systemPrompt: string | undefined;
+  if (options.systemPromptFile) {
+    if (!fs.existsSync(options.systemPromptFile)) {
+      stderr.write(`System prompt file not found: ${options.systemPromptFile}\n`);
+      process.exit(1);
+    }
+    systemPrompt = fs.readFileSync(options.systemPromptFile, 'utf-8');
+  } else if (options.systemPrompt) {
+    systemPrompt = options.systemPrompt;
+  }
+
+  // Get auth
+  const { token, routerUrl } = await getAccessToken(credentials, deps);
+
+  // Check if stdin is piped (non-interactive)
+  if (!process.stdin.isTTY) {
+    const input = await readStdin();
+    if (!input.trim()) {
+      stderr.write('No input provided via stdin.\n');
+      process.exit(1);
+    }
+    stderr.write(`Using model: ${model}\n`);
+    stderr.write(`Router: ${routerUrl}\n`);
+    const result = await callChat(routerUrl, token, model, systemPrompt, input.trim(), maxTokens, deps);
+    stdout.write(result);
+    stdout.write('\n');
+    return;
+  }
+
+  // Interactive REPL mode
+  stderr.write(`Monocle Chat (model: ${model})\n`);
+  stderr.write(`Router: ${routerUrl}\n`);
+  if (systemPrompt) {
+    stderr.write(`System prompt loaded (${systemPrompt.length} chars)\n`);
+  }
+  stderr.write('Type your message. Press Ctrl+D to exit.\n');
+  stderr.write('---\n');
+
+  const rl = readline.createInterface({
+    input: deps?.stdin ?? process.stdin,
+    output: deps?.stderr ?? process.stderr,
+    prompt: '> ',
+  });
+
+  rl.prompt();
+
+  rl.on('line', async (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      rl.prompt();
+      return;
+    }
+
+    if (trimmed === '/quit' || trimmed === '/exit') {
+      rl.close();
+      return;
+    }
+
+    try {
+      stderr.write('\n');
+      const result = await callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps);
+      stdout.write(result);
+      stdout.write('\n\n');
+    } catch (err: any) {
+      stderr.write(`Error: ${err.message}\n`);
+    }
+
+    rl.prompt();
+  });
+
+  rl.on('close', () => {
+    stderr.write('\nBye.\n');
+  });
+}

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -141,6 +141,28 @@ export async function chatCommand(
 
   // Get auth
   const { token, routerUrl } = await getAccessToken(credentials, deps);
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  // Validate model ID against available models
+  try {
+    const modelsResp = await fetchFn(`${routerUrl}/v1/models`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (modelsResp.ok) {
+      const modelsData = (await modelsResp.json()) as { data: Array<{ id: string }> };
+      const availableIds = modelsData.data.map((m) => m.id);
+      if (!availableIds.includes(model)) {
+        stderr.write(`Error: Model "${model}" not found.\n`);
+        stderr.write(`Available models:\n`);
+        for (const id of availableIds) {
+          stderr.write(`  ${id}\n`);
+        }
+        process.exit(1);
+      }
+    }
+  } catch {
+    // Non-fatal — proceed even if model list fails
+  }
 
   // Check if stdin is piped (non-interactive)
   if (!process.stdin.isTTY) {
@@ -174,7 +196,7 @@ export async function chatCommand(
 
   rl.prompt();
 
-  rl.on('line', async (line: string) => {
+  rl.on('line', (line: string) => {
     const trimmed = line.trim();
     if (!trimmed) {
       rl.prompt();
@@ -186,19 +208,29 @@ export async function chatCommand(
       return;
     }
 
-    try {
-      stderr.write('\n');
-      const result = await callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps);
-      stdout.write(result);
-      stdout.write('\n\n');
-    } catch (err: any) {
-      stderr.write(`Error: ${err.message}\n`);
-    }
+    // Pause input while waiting for API response
+    rl.pause();
+    stderr.write('\n');
 
-    rl.prompt();
+    callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps)
+      .then((result) => {
+        stdout.write(result);
+        stdout.write('\n\n');
+      })
+      .catch((err: any) => {
+        stderr.write(`Error: ${err.message}\n\n`);
+      })
+      .finally(() => {
+        rl.resume();
+        rl.prompt();
+      });
   });
 
-  rl.on('close', () => {
-    stderr.write('\nBye.\n');
+  // Keep process alive until REPL closes
+  await new Promise<void>((resolve) => {
+    rl.on('close', () => {
+      stderr.write('\nBye.\n');
+      resolve();
+    });
   });
 }

--- a/src/commands/model-list.ts
+++ b/src/commands/model-list.ts
@@ -1,0 +1,91 @@
+import { Credentials } from '../credentials';
+import { refreshAccessToken, RefreshDeps } from '../refresh';
+
+export interface ModelListDeps {
+  credentials?: Credentials;
+  refreshDeps?: RefreshDeps;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+}
+
+interface ModelInfo {
+  id: string;
+  name?: string;
+  owned_by?: string;
+  context_window?: number;
+}
+
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+export async function modelListCommand(deps?: ModelListDeps): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+  const now = deps?.now ?? (() => new Date());
+
+  const creds = credentials.read();
+  if (!creds) {
+    process.stderr.write('Not logged in. Run `monocle login --tenant <domain>` first.\n');
+    process.exit(1);
+  }
+
+  let activeCreds = creds;
+  const expiresAt = new Date(creds.access_token_expires_at).getTime();
+  if (now().getTime() + EXPIRY_BUFFER_MS > expiresAt) {
+    const result = await refreshAccessToken(creds, {
+      credentials,
+      ...deps?.refreshDeps,
+    });
+    if (!result.success || !result.credentials) {
+      process.stderr.write(`Token refresh failed: ${result.error}\n`);
+      process.exit(1);
+    }
+    activeCreds = result.credentials;
+  }
+
+  let routerUrl: string;
+  if (activeCreds.router_url) {
+    routerUrl = activeCreds.router_url;
+  } else {
+    const isLocal =
+      activeCreds.tenant_domain.startsWith('localhost') ||
+      activeCreds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${activeCreds.tenant_domain}`;
+  }
+
+  const response = await fetchFn(`${routerUrl}/v1/models`, {
+    headers: {
+      Authorization: `Bearer ${activeCreds.access_token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as { data: ModelInfo[] };
+  const models = data.data ?? [];
+
+  if (models.length === 0) {
+    process.stderr.write('No models available.\n');
+    return;
+  }
+
+  // Table output
+  const idWidth = Math.max(10, ...models.map((m) => m.id.length));
+  const nameWidth = Math.max(6, ...models.map((m) => (m.name ?? '').length));
+
+  process.stdout.write(
+    `${'MODEL ID'.padEnd(idWidth)}  ${'NAME'.padEnd(nameWidth)}  ${'OWNER'.padEnd(10)}  CONTEXT\n`,
+  );
+  process.stdout.write(`${'─'.repeat(idWidth)}  ${'─'.repeat(nameWidth)}  ${'─'.repeat(10)}  ${'─'.repeat(9)}\n`);
+
+  for (const model of models) {
+    const ctx = model.context_window ? `${(model.context_window / 1000).toFixed(0)}k` : '-';
+    process.stdout.write(
+      `${model.id.padEnd(idWidth)}  ${(model.name ?? '').padEnd(nameWidth)}  ${(model.owned_by ?? '').padEnd(10)}  ${ctx}\n`,
+    );
+  }
+
+  process.stderr.write(`\n${models.length} model(s) available.\n`);
+}


### PR DESCRIPTION
## Summary

- Add `monocle model list` — lists available models from the router (`GET /v1/models`) in a formatted table
- Add `monocle model chat` — interactive REPL or piped stdin for LLM chat via the router (`POST /v1/chat/completions`)
- Validates model ID against available models before starting chat
- Default model: `claude-sonnet-4-6`

## Usage

```bash
# List available models
monocle model list

# Interactive REPL
monocle model chat

# With system prompt file
monocle model chat --system-prompt-file prompt.md

# Piped input (one-shot)
echo "hello" | monocle model chat

# Pipeline with data collector
uv run collector | monocle model chat --system-prompt-file prompt-system.md
```

## Test plan

- [ ] `monocle model list` shows available models
- [ ] `monocle model chat` opens interactive REPL, responds to input
- [ ] `echo "hi" | monocle model chat` returns one-shot response
- [ ] `monocle model chat --model invalid-id` shows error with available model list
- [ ] `monocle model chat --system-prompt-file path` loads system prompt

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)