### PR TITLE
feat: SSH 환경에서 Device Code 방식 로그인 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ That's it! Run `monocle claude` to get started.
 > **Tip:** To specify a tenant explicitly, use `monocle login --tenant your-org.monocle-ai.com`
 >
 > **Tip:** If you have `ANTHROPIC_API_KEY` set in your environment, `monocle claude` will automatically clear it to avoid conflicts.
+>
+> **Headless / SSH / CI?** `monocle login` auto-detects these environments and switches to
+> the device code flow — a URL and short code you enter on another machine. If auto-detection
+> misses your environment, force it with `monocle login --device-code`.
 
 ## Check Status
 
@@ -46,7 +50,7 @@ All green (**Valid** and **Configured**) means you're good to go!
 
 | Command | Description |
 |---------|-------------|
-| `monocle login [--tenant <domain>] [--env <env>]` | Sign in via browser (auto-configures Claude Code) |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI (auto-configures Claude Code) |
 | `monocle setup` | Manually configure Claude Code (usually handled by login) |
 | `monocle claude` | Launch Claude Code with conflicting env vars cleared |
 | `monocle status` | Show login and configuration status |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -33,6 +33,8 @@ monocle login
 > **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`으로 실행하세요.
 >
 > **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
+>
+> **헤드리스 / SSH / CI 환경이신가요?** `monocle login`이 자동으로 감지해서 device code 방식으로 전환합니다 — 다른 기기의 브라우저에서 URL을 열고 짧은 코드를 입력하는 방식이에요. 자동 감지가 안 되는 환경이면 `monocle login --device-code`로 강제할 수 있어요.
 
 ## 상태 확인
 
@@ -46,7 +48,7 @@ monocle status
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>]` | 브라우저로 로그인 (Claude Code 자동 설정 포함) |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 (Claude Code 자동 설정 포함) |
 | `monocle setup` | Claude Code를 수동으로 설정 (보통은 login이 자동 처리) |
 | `monocle claude` | 환경 변수 충돌을 자동 정리하고 Claude Code 실행 |
 | `monocle status` | 로그인/설정 상태 확인 |

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -62,7 +62,7 @@ describe('claudeCommand', () => {
       HOME: '/home/user',
     };
 
-    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn });
+    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn, skipSetup: true });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
@@ -78,6 +78,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: 'https://warmblood.krmonocle-ai.com' })),
       env: { PATH: '/usr/bin' },
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -91,6 +92,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: undefined })),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -104,6 +106,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     expect(spawnFn).toHaveBeenCalledWith(
@@ -120,6 +123,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     expect(spawnFn.mock.calls[0][2].stdio).toBe('inherit');
@@ -132,6 +136,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const error = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loginCommand, pollForToken } from '../commands/login';
 import { Credentials, CredentialsData } from '../credentials';
 
@@ -155,6 +155,112 @@ describe('SSH environment detection', () => {
     expect(getStored()!.access_token).toBe('at_device');
     expect(getStored()!.email).toBe('user@test.com');
     expect(getStored()!.tenant_name).toBe('Test Org');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects INSIDE_EMACS and uses device code flow', async () => {
+    process.env.INSIDE_EMACS = 'vterm';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects CI env and uses device code flow', async () => {
+    process.env.CI = 'true';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('browser flow fallback', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Start from a 'non-headless' baseline so we exercise the browser flow
+    delete process.env.SSH_CLIENT;
+    delete process.env.SSH_TTY;
+    delete process.env.SSH_CONNECTION;
+    delete process.env.INSIDE_EMACS;
+    delete process.env.CI;
+    process.env.DISPLAY = ':0';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('falls back to device code when openBrowser fails', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+        openBrowser: async () => {
+          throw new Error('xdg-open: command not found');
+        },
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to device code'));
+
+    stderrSpy.mockRestore();
+  });
+
+  it('falls back to device code when no callback arrives before timeout', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+        browserCallbackTimeoutMs: 50, // force quick timeout for tests
+        openBrowser: async () => {
+          // Simulate the OS command "succeeding" (e.g., xdg-open returns 0)
+          // but the user's browser never actually reaches the callback URL.
+        },
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('no callback received'));
 
     stderrSpy.mockRestore();
   });

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pollForToken } from '../commands/login';
+
+describe('Device Code Flow', () => {
+  describe('SSH environment detection', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('detects SSH_CLIENT as headless', () => {
+      process.env.SSH_CLIENT = '192.168.1.1 12345 22';
+      expect(!!process.env.SSH_CLIENT).toBe(true);
+    });
+
+    it('detects SSH_TTY as headless', () => {
+      process.env.SSH_TTY = '/dev/pts/0';
+      expect(!!process.env.SSH_TTY).toBe(true);
+    });
+
+    it('detects SSH_CONNECTION as headless', () => {
+      process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
+      expect(!!process.env.SSH_CONNECTION).toBe(true);
+    });
+  });
+
+  describe('pollForToken', () => {
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+      vi.restoreAllMocks();
+    });
+
+    it('returns token on first successful response', async () => {
+      const tokenData = {
+        access_token: 'at_123',
+        refresh_token: 'rt_123',
+        id_token: 'id_123',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => ({
+        ok: true,
+        status: 200,
+        json: async () => tokenData,
+      }));
+
+      const result = await pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01, // very short interval for test
+        10,
+      );
+
+      expect(result).toEqual(tokenData);
+    });
+
+    it('retries on authorization_pending then succeeds', async () => {
+      let callCount = 0;
+      const tokenData = {
+        access_token: 'at_456',
+        refresh_token: 'rt_456',
+        id_token: 'id_456',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: 'authorization_pending' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => tokenData,
+        };
+      });
+
+      const result = await pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01,
+        10,
+      );
+
+      expect(result).toEqual(tokenData);
+      expect(callCount).toBe(3);
+      // stderr should have dots for pending calls
+      expect(stderrSpy).toHaveBeenCalledWith('.');
+    });
+
+    it('throws on expired_token', async () => {
+      vi.stubGlobal('fetch', async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'expired_token' }),
+      }));
+
+      await expect(
+        pollForToken(
+          'https://auth.example.com/token',
+          'device_code_abc',
+          'monocle-cli',
+          0.01,
+          10,
+        )
+      ).rejects.toThrow('인증 시간이 만료되었습니다.');
+    });
+
+    it('throws on access_denied', async () => {
+      vi.stubGlobal('fetch', async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'access_denied' }),
+      }));
+
+      await expect(
+        pollForToken(
+          'https://auth.example.com/token',
+          'device_code_abc',
+          'monocle-cli',
+          0.01,
+          10,
+        )
+      ).rejects.toThrow('인증이 거부되었습니다.');
+    });
+
+    it('increases interval on slow_down then succeeds', async () => {
+      let callCount = 0;
+      const tokenData = {
+        access_token: 'at_789',
+        refresh_token: 'rt_789',
+        id_token: 'id_789',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: 'slow_down' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => tokenData,
+        };
+      });
+
+      // Use fake timers to avoid waiting 5+ real seconds
+      vi.useFakeTimers();
+      const promise = pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01,
+        30,
+      );
+
+      // Advance past first interval (0.01s)
+      await vi.advanceTimersByTimeAsync(100);
+      // After slow_down, interval becomes 5.01s — advance past it
+      await vi.advanceTimersByTimeAsync(6000);
+
+      const result = await promise;
+      vi.useRealTimers();
+
+      expect(result).toEqual(tokenData);
+      expect(callCount).toBe(2);
+    });
+  });
+});

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -303,4 +303,26 @@ describe('pollForToken', () => {
       ),
     ).rejects.toThrow('Authorization request was denied');
   });
+
+  it('surfaces HTTP status and raw body when server returns non-OAuth error', async () => {
+    const htmlBody = '<!doctype html><html><head><title>Server Error (500)</title></head><body>oops</body></html>';
+    const mockFetch = async () => ({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error('not json'); },
+      text: async () => htmlBody,
+      clone: function() { return this; },
+    });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow(/HTTP 500.*non-OAuth.*Server Error/);
+  });
 });

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,191 +1,306 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { pollForToken } from '../commands/login';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loginCommand, pollForToken } from '../commands/login';
+import { Credentials, CredentialsData } from '../credentials';
 
-describe('Device Code Flow', () => {
-  describe('SSH environment detection', () => {
-    const originalEnv = process.env;
+function createMockCredentials() {
+  let stored: CredentialsData | null = null;
+  return {
+    instance: {
+      read: () => stored,
+      write: (d: CredentialsData) => { stored = d; },
+      delete: () => { stored = null; },
+      getCredentialsPath: () => '/fake/.monocle/credentials.json',
+      getCredentialsDir: () => '/fake/.monocle',
+      getFileMode: () => 0o600,
+    } as any as Credentials,
+    getStored: () => stored,
+  };
+}
 
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
+function createDeviceCodeMockFetch(tokenResponses?: Array<{ ok: boolean; status: number; json: () => Promise<any> }>) {
+  let tokenCallIndex = 0;
 
-    afterEach(() => {
-      process.env = originalEnv;
-    });
+  return async (url: string, _init?: any) => {
+    if (url.includes('.well-known/openid-configuration')) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          issuer: 'https://test.stark.com',
+          authorization_endpoint: 'https://test.stark.com/oauth/authorize',
+          token_endpoint: 'https://test.stark.com/oauth/token',
+          device_authorization_endpoint: 'https://test.stark.com/oauth/device',
+          router_url: 'https://api.monocle-ai.com',
+        }),
+      };
+    }
 
-    it('detects SSH_CLIENT as headless', () => {
-      process.env.SSH_CLIENT = '192.168.1.1 12345 22';
-      expect(!!process.env.SSH_CLIENT).toBe(true);
-    });
+    if (url.includes('/oauth/device')) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          device_code: 'dev_code_123',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://test.stark.com/device',
+          verification_uri_complete: 'https://test.stark.com/device?user_code=ABCD-1234',
+          expires_in: 600,
+          interval: 0.01, // Very short for tests
+        }),
+      };
+    }
 
-    it('detects SSH_TTY as headless', () => {
-      process.env.SSH_TTY = '/dev/pts/0';
-      expect(!!process.env.SSH_TTY).toBe(true);
-    });
+    // Token endpoint
+    if (tokenResponses && tokenCallIndex < tokenResponses.length) {
+      return tokenResponses[tokenCallIndex++];
+    }
 
-    it('detects SSH_CONNECTION as headless', () => {
-      process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
-      expect(!!process.env.SSH_CONNECTION).toBe(true);
-    });
+    // Default: return success
+    return {
+      ok: true, status: 200,
+      json: async () => ({
+        access_token: 'at_device',
+        refresh_token: 'rt_device',
+        id_token: 'eyJhbGciOiJSUzI1NiJ9.' + Buffer.from(JSON.stringify({
+          email: 'user@test.com',
+          tenant_name: 'Test Org',
+          tenant_domain: 'test.stark.com',
+        })).toString('base64url') + '.sig',
+        expires_in: 3600,
+      }),
+    };
+  };
+}
+
+describe('SSH environment detection', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
-  describe('pollForToken', () => {
-    let stderrSpy: ReturnType<typeof vi.spyOn>;
+  it('detects SSH_CLIENT and uses device code flow', async () => {
+    process.env.SSH_CLIENT = '192.168.1.1 12345 22';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    beforeEach(() => {
-      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    });
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
 
-    afterEach(() => {
-      stderrSpy.mockRestore();
-      vi.restoreAllMocks();
-    });
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('ABCD-1234'));
 
-    it('returns token on first successful response', async () => {
-      const tokenData = {
-        access_token: 'at_123',
-        refresh_token: 'rt_123',
-        id_token: 'id_123',
+    stderrSpy.mockRestore();
+  });
+
+  it('detects SSH_TTY and uses device code flow', async () => {
+    process.env.SSH_TTY = '/dev/pts/0';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects SSH_CONNECTION and uses device code flow', async () => {
+    process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('uses device code flow when --device-code flag is set', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com', deviceCode: true },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(getStored()!.email).toBe('user@test.com');
+    expect(getStored()!.tenant_name).toBe('Test Org');
+
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('pollForToken', () => {
+  it('returns tokens on success', async () => {
+    const mockFetch = async () => ({
+      ok: true, status: 200,
+      json: async () => ({
+        access_token: 'at_success',
+        refresh_token: 'rt_success',
+        id_token: 'id_success',
         expires_in: 3600,
-      };
-
-      vi.stubGlobal('fetch', async () => ({
-        ok: true,
-        status: 200,
-        json: async () => tokenData,
-      }));
-
-      const result = await pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01, // very short interval for test
-        10,
-      );
-
-      expect(result).toEqual(tokenData);
+      }),
     });
 
-    it('retries on authorization_pending then succeeds', async () => {
-      let callCount = 0;
-      const tokenData = {
-        access_token: 'at_456',
-        refresh_token: 'rt_456',
-        id_token: 'id_456',
-        expires_in: 3600,
-      };
+    const result = await pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01, // very short interval for test
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
 
-      vi.stubGlobal('fetch', async () => {
-        callCount++;
-        if (callCount <= 2) {
-          return {
-            ok: false,
-            status: 400,
-            json: async () => ({ error: 'authorization_pending' }),
-          };
-        }
+    expect(result.access_token).toBe('at_success');
+    expect(result.refresh_token).toBe('rt_success');
+  });
+
+  it('continues polling on authorization_pending', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount < 3) {
         return {
-          ok: true,
-          status: 200,
-          json: async () => tokenData,
+          ok: false, status: 400,
+          json: async () => ({ error: 'authorization_pending' }),
         };
-      });
-
-      const result = await pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01,
-        10,
-      );
-
-      expect(result).toEqual(tokenData);
-      expect(callCount).toBe(3);
-      // stderr should have dots for pending calls
-      expect(stderrSpy).toHaveBeenCalledWith('.');
-    });
-
-    it('throws on expired_token', async () => {
-      vi.stubGlobal('fetch', async () => ({
-        ok: false,
-        status: 400,
-        json: async () => ({ error: 'expired_token' }),
-      }));
-
-      await expect(
-        pollForToken(
-          'https://auth.example.com/token',
-          'device_code_abc',
-          'monocle-cli',
-          0.01,
-          10,
-        )
-      ).rejects.toThrow('인증 시간이 만료되었습니다.');
-    });
-
-    it('throws on access_denied', async () => {
-      vi.stubGlobal('fetch', async () => ({
-        ok: false,
-        status: 400,
-        json: async () => ({ error: 'access_denied' }),
-      }));
-
-      await expect(
-        pollForToken(
-          'https://auth.example.com/token',
-          'device_code_abc',
-          'monocle-cli',
-          0.01,
-          10,
-        )
-      ).rejects.toThrow('인증이 거부되었습니다.');
-    });
-
-    it('increases interval on slow_down then succeeds', async () => {
-      let callCount = 0;
-      const tokenData = {
-        access_token: 'at_789',
-        refresh_token: 'rt_789',
-        id_token: 'id_789',
-        expires_in: 3600,
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          access_token: 'at_after_pending',
+          refresh_token: 'rt_after_pending',
+          expires_in: 3600,
+        }),
       };
+    };
 
-      vi.stubGlobal('fetch', async () => {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            ok: false,
-            status: 400,
-            json: async () => ({ error: 'slow_down' }),
-          };
-        }
+    const result = await pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01,
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
+
+    expect(callCount).toBe(3);
+    expect(result.access_token).toBe('at_after_pending');
+  });
+
+  it('increases interval on slow_down', async () => {
+    // We verify slow_down handling by checking that:
+    // 1. The function doesn't throw on slow_down
+    // 2. It eventually returns the token
+    // 3. The number of calls is correct
+    // We use a tiny initial interval and mock setTimeout behavior
+    let callCount = 0;
+
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount === 1) {
         return {
-          ok: true,
-          status: 200,
-          json: async () => tokenData,
+          ok: false, status: 400,
+          json: async () => ({ error: 'slow_down' }),
         };
-      });
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          access_token: 'at_slowed',
+          expires_in: 3600,
+        }),
+      };
+    };
 
-      // Use fake timers to avoid waiting 5+ real seconds
-      vi.useFakeTimers();
-      const promise = pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01,
-        30,
-      );
+    // Use vi.useFakeTimers to avoid actually waiting 5 seconds
+    vi.useFakeTimers();
 
-      // Advance past first interval (0.01s)
-      await vi.advanceTimersByTimeAsync(100);
-      // After slow_down, interval becomes 5.01s — advance past it
-      await vi.advanceTimersByTimeAsync(6000);
+    const resultPromise = pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01, // initial interval: 10ms
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
 
-      const result = await promise;
-      vi.useRealTimers();
+    // First sleep: 10ms (initial interval)
+    await vi.advanceTimersByTimeAsync(10);
+    // After slow_down, interval becomes 5.01s. Second sleep: 5010ms
+    await vi.advanceTimersByTimeAsync(5100);
 
-      expect(result).toEqual(tokenData);
-      expect(callCount).toBe(2);
+    const result = await resultPromise;
+
+    expect(callCount).toBe(2);
+    expect(result.access_token).toBe('at_slowed');
+
+    vi.useRealTimers();
+  });
+
+  it('throws on expired_token', async () => {
+    const mockFetch = async () => ({
+      ok: false, status: 400,
+      json: async () => ({ error: 'expired_token' }),
     });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow('Device code expired');
+  });
+
+  it('throws on access_denied', async () => {
+    const mockFetch = async () => ({
+      ok: false, status: 400,
+      json: async () => ({ error: 'access_denied' }),
+    });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow('Authorization request was denied');
   });
 });

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -1,7 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loginCommand } from '../commands/login';
 import { Credentials, CredentialsData } from '../credentials';
 import * as http from 'http';
+
+// These tests exercise the browser flow. Make sure the environment doesn't
+// trigger headless auto-detection (SSH, Emacs, CI, linux-without-DISPLAY).
+const originalEnv = { ...process.env };
+beforeEach(() => {
+  delete process.env.SSH_CLIENT;
+  delete process.env.SSH_TTY;
+  delete process.env.SSH_CONNECTION;
+  delete process.env.INSIDE_EMACS;
+  delete process.env.CI;
+  process.env.DISPLAY = ':0';
+});
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
 
 function createMockCredentials() {
   let stored: CredentialsData | null = null;

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -58,6 +58,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: createMockFetch() as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           capturedAuthUrl = url;
           // Simulate callback
@@ -141,6 +142,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: mockFetch as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           const urlObj = new URL(url);
           const redirectUri = urlObj.searchParams.get('redirect_uri')!;
@@ -170,6 +172,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: createMockFetch() as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           const urlObj = new URL(url);
           const redirectUri = urlObj.searchParams.get('redirect_uri')!;

--- a/src/__tests__/unset.test.ts
+++ b/src/__tests__/unset.test.ts
@@ -22,7 +22,7 @@ describe('unsetCommand', () => {
     expect(settings.otherSetting).toBe('keep');
     expect(settings.env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(settings.env.OTHER_VAR).toBe('keep');
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 
@@ -55,7 +55,7 @@ describe('unsetCommand', () => {
       writeFileSync: () => {},
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 
@@ -69,7 +69,7 @@ describe('unsetCommand', () => {
       writeFileSync: () => {},
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,9 +20,10 @@ program
   .description('Authenticate with Stark OIDC provider')
   .option('--tenant <domain>', 'Stark tenant domain (e.g., example.monocle-ai.com)')
   .option('--env <environment>', 'Environment: prod, stg, local (default: prod)', 'prod')
+  .option('--device-code', 'Use Device Authorization Grant (for headless/SSH environments)')
   .action(async (options) => {
     try {
-      await loginCommand({ tenantDomain: options.tenant, env: options.env });
+      await loginCommand({ tenantDomain: options.tenant, env: options.env, deviceCode: options.deviceCode });
     } catch (err: any) {
       process.stderr.write(`Error: ${err.message}\n`);
       process.exit(1);

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny ANSI color helper. No dependencies.
+ *
+ * Honors NO_COLOR (https://no-color.org) and only colorizes when stderr is a TTY.
+ * Tone choices follow brew / gh CLI: muted, no neon. Cyan for accents, green for
+ * success, yellow for warnings, dim for hints.
+ */
+
+function colorEnabled(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR) return true;
+  return Boolean(process.stderr.isTTY);
+}
+
+function wrap(open: string, close: string): (s: string) => string {
+  return (s: string) => (colorEnabled() ? `\x1b[${open}m${s}\x1b[${close}m` : s);
+}
+
+export const c = {
+  bold: wrap('1', '22'),
+  dim: wrap('2', '22'),
+  green: wrap('32', '39'),
+  yellow: wrap('33', '39'),
+  cyan: wrap('36', '39'),
+  red: wrap('31', '39'),
+};

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -9,6 +9,7 @@ export interface ClaudeDeps {
   credentials?: Credentials;
   env?: Record<string, string | undefined>;
   spawn?: typeof child_process.spawn;
+  skipSetup?: boolean;
 }
 
 export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<void> {
@@ -24,17 +25,19 @@ export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<
   }
 
   // Ensure Claude Code is configured (auto-setup if needed)
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-  let needsSetup = true;
-  try {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-    needsSetup = settings.apiKeyHelper !== 'monocle token';
-  } catch {
-    // File doesn't exist or invalid JSON
-  }
-  if (needsSetup) {
-    process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
-    await setupCommand();
+  if (!deps?.skipSetup) {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    let needsSetup = true;
+    try {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      needsSetup = settings.apiKeyHelper !== 'monocle token';
+    } catch {
+      // File doesn't exist or invalid JSON
+    }
+    if (needsSetup) {
+      process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
+      await setupCommand();
+    }
   }
 
   // Build clean env — remove vars that override apiKeyHelper

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,6 +12,7 @@ const REFRESH_TOKEN_TTL_DAYS = 30;
 export interface LoginOptions {
   tenantDomain?: string;
   env?: string;
+  deviceCode?: boolean;
 }
 
 export interface LoginDeps {
@@ -39,7 +40,159 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function pollForToken(
+  tokenEndpoint: string,
+  deviceCode: string,
+  clientId: string,
+  interval: number,
+  expiresIn: number,
+): Promise<{access_token: string; refresh_token: string; id_token: string; expires_in: number}> {
+  const deadline = Date.now() + expiresIn * 1000;
+
+  while (Date.now() < deadline) {
+    await sleep(interval * 1000);
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: clientId,
+    });
+
+    const response = await globalThis.fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (response.ok) {
+      return await response.json() as any;
+    }
+
+    const error = await response.json() as any;
+
+    switch (error.error) {
+      case 'authorization_pending':
+        process.stderr.write('.');
+        continue;
+      case 'slow_down':
+        interval += 5;
+        continue;
+      case 'expired_token':
+        throw new Error('인증 시간이 만료되었습니다.');
+      case 'access_denied':
+        throw new Error('인증이 거부되었습니다.');
+      default:
+        throw new Error(error.error_description || error.error);
+    }
+  }
+
+  throw new Error('인증 시간이 만료되었습니다.');
+}
+
+async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): Promise<void> {
+  const credentials = new Credentials();
+
+  // Resolve Stark domain + discover OIDC
+  const env = options.env ?? 'prod';
+  const starkDomain = options.tenantDomain
+    ? resolveStarkDomain(options.tenantDomain)
+    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
+  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  const oidc = await discoverOIDC(starkDomain);
+
+  if (!oidc.device_authorization_endpoint) {
+    throw new Error('이 OIDC 프로바이더는 Device Authorization Grant를 지원하지 않습니다.');
+  }
+
+  // Request device code
+  const body = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+  });
+
+  const deviceResponse = await globalThis.fetch(oidc.device_authorization_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  if (!deviceResponse.ok) {
+    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
+  }
+
+  const deviceData = await deviceResponse.json() as any;
+  const { device_code, user_code, verification_uri, expires_in, interval } = deviceData;
+
+  process.stderr.write(`\n아래 URL을 브라우저에서 열고 코드를 입력하세요:\n`);
+  process.stderr.write(`  URL:  ${verification_uri}\n`);
+  process.stderr.write(`  코드: ${user_code}\n\n`);
+  process.stderr.write(`인증 대기 중`);
+
+  // Poll for token
+  const tokenData = await pollForToken(
+    oidc.token_endpoint,
+    device_code,
+    CLIENT_ID,
+    interval ?? 5,
+    expires_in ?? 600,
+  );
+
+  process.stderr.write('\n');
+
+  // Decode ID token
+  let email = 'unknown';
+  let tenantDomain = options.tenantDomain ?? '';
+  let tenantName = tenantDomain;
+  if (tokenData.id_token) {
+    try {
+      const payload = decodeIdTokenPayload(tokenData.id_token);
+      email = payload.email ?? 'unknown';
+      tenantDomain = payload.tenant_domain ?? tenantDomain;
+      tenantName = payload.tenant_name ?? tenantDomain;
+    } catch {
+      // Use defaults
+    }
+  }
+
+  // Save credentials
+  const now = new Date();
+  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
+  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  const creds: CredentialsData = {
+    tenant_domain: tenantDomain,
+    tenant_name: tenantName,
+    email,
+    access_token: tokenData.access_token,
+    refresh_token: tokenData.refresh_token ?? '',
+    id_token: tokenData.id_token ?? '',
+    access_token_expires_at: accessTokenExpiresAt.toISOString(),
+    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+    router_url: oidc.router_url,
+  };
+
+  credentials.write(creds);
+
+  process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
+
+  // Auto-setup Claude Code
+  process.stderr.write('\nConfiguring Claude Code...\n');
+  setupCommand().catch(() => {
+    process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+  });
+}
+
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
+  // Headless detection
+  const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
+  if (isHeadless) {
+    return deviceCodeLogin(options);
+  }
+
   const credentials = deps?.credentials ?? new Credentials();
   const fetchFn = deps?.fetch ?? globalThis.fetch;
   const openBrowser = deps?.openBrowser ?? defaultOpenBrowser;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import { Credentials, CredentialsData } from '../credentials';
 import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain, STARK_DOMAINS, OIDCDeps } from '../oidc';
 import { decodeIdTokenPayload } from '../refresh';
 import { setupCommand } from './setup';
+import { c } from '../colors';
 
 const CLIENT_ID = 'monocle-cli';
 const SCOPES = 'openid profile email';
@@ -99,7 +100,7 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
   const starkDomain = options.tenantDomain
     ? resolveStarkDomain(options.tenantDomain)
     : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  process.stderr.write(`${c.dim(`Discovering OIDC configuration for ${starkDomain}...`)}\n`);
   const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
 
   // Step 2: Generate PKCE + state
@@ -227,13 +228,13 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
           server.close();
 
           // Step 11: Terminal output
-          process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
+          process.stderr.write(`${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
 
           // Step 12: Auto-setup Claude Code
           if (!deps?.skipSetup) {
-            process.stderr.write('\nConfiguring Claude Code...\n');
+            process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
             setupCommand().catch(() => {
-              process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+              process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
             });
           }
 
@@ -408,7 +409,7 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
   const starkDomain = options.tenantDomain
     ? resolveStarkDomain(options.tenantDomain)
     : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  process.stderr.write(`${c.dim(`Discovering OIDC configuration for ${starkDomain}...`)}\n`);
   const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
 
   if (!oidc.device_authorization_endpoint) {
@@ -438,13 +439,13 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
 
   // Step 3: Display verification instructions
   process.stderr.write('\n');
-  process.stderr.write('To authenticate, visit the following URL in a browser:\n\n');
-  process.stderr.write(`  ${deviceData.verification_uri}\n\n`);
-  process.stderr.write(`Enter the code: ${deviceData.user_code}\n\n`);
+  process.stderr.write(`${c.bold('To authenticate, visit:')}\n\n`);
+  process.stderr.write(`  ${c.cyan(deviceData.verification_uri)}\n\n`);
+  process.stderr.write(`  ${c.dim('Code:')} ${c.bold(deviceData.user_code)}\n\n`);
   if (deviceData.verification_uri_complete) {
-    process.stderr.write(`Or open this URL directly:\n  ${deviceData.verification_uri_complete}\n\n`);
+    process.stderr.write(`${c.dim('Or open this URL directly:')}\n  ${c.cyan(deviceData.verification_uri_complete)}\n\n`);
   }
-  process.stderr.write('Waiting for authorization...\n');
+  process.stderr.write(`${c.dim('Waiting for authorization...')}\n`);
 
   // Step 4: Poll for token
   const tokenData = await pollForToken(
@@ -488,13 +489,13 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
   };
 
   credentials.write(creds);
-  process.stderr.write(`\nLogged in as ${email} (${tenantName})\n`);
+  process.stderr.write(`\n${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
 
   // Auto-setup Claude Code
   if (!deps?.skipSetup) {
-    process.stderr.write('\nConfiguring Claude Code...\n');
+    process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
     setupCommand().catch(() => {
-      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+      process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
     });
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -8,6 +8,7 @@ import { setupCommand } from './setup';
 const CLIENT_ID = 'monocle-cli';
 const SCOPES = 'openid profile email';
 const REFRESH_TOKEN_TTL_DAYS = 30;
+const BROWSER_CALLBACK_TIMEOUT_MS = 90_000;
 
 export interface LoginOptions {
   tenantDomain?: string;
@@ -25,6 +26,7 @@ export interface LoginDeps {
     address: () => { port: number } | null;
   };
   skipSetup?: boolean;
+  browserCallbackTimeoutMs?: number;
 }
 
 const SUCCESS_HTML = `<!DOCTYPE html>
@@ -41,16 +43,56 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
+/**
+ * Internal sentinel indicating the browser flow is unavailable in this environment
+ * and the caller should fall back to device code. Not a real user-visible error.
+ */
+class BrowserFlowUnavailableError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'BrowserFlowUnavailableError';
+  }
+}
+
+/**
+ * Detect environments where a local browser almost certainly cannot be used:
+ * SSH, Emacs inner shell, CI, and Linux console without DISPLAY.
+ * When any of these fire, skip browser flow entirely and go to device code.
+ */
+function detectHeadless(options: LoginOptions): boolean {
+  if (options.deviceCode) return true;
+  if (process.env.SSH_CLIENT || process.env.SSH_TTY || process.env.SSH_CONNECTION) return true;
+  if (process.env.INSIDE_EMACS) return true;
+  if (process.env.CI) return true;
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return true;
+  return false;
+}
+
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
-  const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
-  if (isHeadless) {
+  if (detectHeadless(options)) {
     return deviceCodeLogin(options, deps);
   }
 
+  // Ambiguous environment: try browser flow, fall back to device code if:
+  //   - openBrowser exec fails (command not found, non-zero exit)
+  //   - callback not received within BROWSER_CALLBACK_TIMEOUT_MS
+  try {
+    return await browserCodeLogin(options, deps);
+  } catch (err) {
+    if (err instanceof BrowserFlowUnavailableError) {
+      process.stderr.write(`\nBrowser flow unavailable: ${err.message}\nFalling back to device code...\n\n`);
+      return deviceCodeLogin(options, deps);
+    }
+    throw err;
+  }
+}
+
+async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise<void> {
   const credentials = deps?.credentials ?? new Credentials();
   const fetchFn = deps?.fetch ?? globalThis.fetch;
   const openBrowser = deps?.openBrowser ?? defaultOpenBrowser;
   const createServerFn = deps?.createServer ?? ((handler: any) => http.createServer(handler) as any);
+  const timeoutMs = deps?.browserCallbackTimeoutMs ?? BROWSER_CALLBACK_TIMEOUT_MS;
 
   // Step 1: OIDC Discovery
   const env = options.env ?? 'prod';
@@ -67,6 +109,16 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
 
   // Step 3: Start local HTTP server on random port
   return new Promise<void>((resolve, reject) => {
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      fn();
+    };
+
     const server = createServerFn((req: http.IncomingMessage, res: http.ServerResponse) => {
       const parsed = url.parse(req.url ?? '', true);
 
@@ -83,7 +135,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML(String(query.error_description || query.error)));
         server.close();
-        reject(new Error(`Authorization failed: ${query.error_description || query.error}`));
+        settle(() => reject(new Error(`Authorization failed: ${query.error_description || query.error}`)));
         return;
       }
 
@@ -92,7 +144,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('State mismatch - possible CSRF attack'));
         server.close();
-        reject(new Error('State mismatch - possible CSRF attack'));
+        settle(() => reject(new Error('State mismatch - possible CSRF attack')));
         return;
       }
 
@@ -101,7 +153,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('No authorization code received'));
         server.close();
-        reject(new Error('No authorization code received'));
+        settle(() => reject(new Error('No authorization code received')));
         return;
       }
 
@@ -185,13 +237,13 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
             });
           }
 
-          resolve();
+          settle(() => resolve());
         })
         .catch((err: Error) => {
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.end(ERROR_HTML(err.message));
           server.close();
-          reject(err);
+          settle(() => reject(err));
         });
     });
 
@@ -219,8 +271,20 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
       process.stderr.write(`Opening browser for authentication...\n`);
       process.stderr.write(`If the browser doesn't open, visit: ${authUrl}\n`);
 
-      openBrowser(authUrl).catch(() => {
-        // Browser open failed, URL already printed above
+      // Timeout: no callback → browser flow isn't working, signal fallback
+      timeoutHandle = setTimeout(() => {
+        server.close();
+        settle(() => reject(new BrowserFlowUnavailableError(
+          `no callback received within ${Math.round(timeoutMs / 1000)}s`
+        )));
+      }, timeoutMs);
+
+      // If opening the browser fails at the OS level, signal fallback immediately
+      openBrowser(authUrl).catch((err: Error) => {
+        server.close();
+        settle(() => reject(new BrowserFlowUnavailableError(
+          `failed to launch browser: ${err.message}`
+        )));
       });
     });
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -296,7 +296,20 @@ export async function pollForToken(
       return await response.json() as TokenResponse;
     }
 
-    const errorData = await response.json().catch(() => ({ error: 'unknown' }));
+    // Clone so we can fall back to text() for diagnostic if json() fails
+    // (real Response body can only be read once — see whatwg/fetch)
+    const cloned = (response as any).clone?.() ?? response;
+    let rawBody = '';
+    let errorData: { error?: string; error_description?: string } = {};
+    try {
+      errorData = await response.json();
+    } catch {
+      try {
+        rawBody = await (cloned as any).text?.() ?? '';
+      } catch {
+        // Body unavailable
+      }
+    }
     const error = errorData.error;
 
     if (error === 'authorization_pending') {
@@ -308,8 +321,14 @@ export async function pollForToken(
       throw new Error('Device code expired. Please run login again.');
     } else if (error === 'access_denied') {
       throw new Error('Authorization request was denied by the user.');
-    } else {
+    } else if (error) {
       throw new Error(`Token polling failed: ${error} - ${errorData.error_description ?? ''}`);
+    } else {
+      const snippet = rawBody.slice(0, 200).replace(/\s+/g, ' ').trim();
+      throw new Error(
+        `Token polling failed: server returned HTTP ${response.status} with non-OAuth response. ` +
+        `Body: ${snippet || '(empty)'}`
+      );
     }
   }
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -41,156 +41,7 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function pollForToken(
-  tokenEndpoint: string,
-  deviceCode: string,
-  clientId: string,
-  interval: number,
-  expiresIn: number,
-): Promise<{access_token: string; refresh_token: string; id_token: string; expires_in: number}> {
-  const deadline = Date.now() + expiresIn * 1000;
-
-  while (Date.now() < deadline) {
-    await sleep(interval * 1000);
-
-    const body = new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-      device_code: deviceCode,
-      client_id: clientId,
-    });
-
-    const response = await globalThis.fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body.toString(),
-    });
-
-    if (response.ok) {
-      return await response.json() as any;
-    }
-
-    const error = await response.json() as any;
-
-    switch (error.error) {
-      case 'authorization_pending':
-        process.stderr.write('.');
-        continue;
-      case 'slow_down':
-        interval += 5;
-        continue;
-      case 'expired_token':
-        throw new Error('인증 시간이 만료되었습니다.');
-      case 'access_denied':
-        throw new Error('인증이 거부되었습니다.');
-      default:
-        throw new Error(error.error_description || error.error);
-    }
-  }
-
-  throw new Error('인증 시간이 만료되었습니다.');
-}
-
-async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}, deps?: LoginDeps): Promise<void> {
-  const credentials = new Credentials();
-
-  // Resolve Stark domain + discover OIDC
-  const env = options.env ?? 'prod';
-  const starkDomain = options.tenantDomain
-    ? resolveStarkDomain(options.tenantDomain)
-    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
-  const oidc = await discoverOIDC(starkDomain);
-
-  if (!oidc.device_authorization_endpoint) {
-    throw new Error('이 OIDC 프로바이더는 Device Authorization Grant를 지원하지 않습니다.');
-  }
-
-  // Request device code
-  const body = new URLSearchParams({
-    client_id: CLIENT_ID,
-    scope: SCOPES,
-  });
-
-  const deviceResponse = await globalThis.fetch(oidc.device_authorization_endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-  });
-
-  if (!deviceResponse.ok) {
-    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
-  }
-
-  const deviceData = await deviceResponse.json() as any;
-  const { device_code, user_code, verification_uri, expires_in, interval } = deviceData;
-
-  process.stderr.write(`\n아래 URL을 브라우저에서 열고 코드를 입력하세요:\n`);
-  process.stderr.write(`  URL:  ${verification_uri}\n`);
-  process.stderr.write(`  코드: ${user_code}\n\n`);
-  process.stderr.write(`인증 대기 중`);
-
-  // Poll for token
-  const tokenData = await pollForToken(
-    oidc.token_endpoint,
-    device_code,
-    CLIENT_ID,
-    interval ?? 5,
-    expires_in ?? 600,
-  );
-
-  process.stderr.write('\n');
-
-  // Decode ID token
-  let email = 'unknown';
-  let tenantDomain = options.tenantDomain ?? '';
-  let tenantName = tenantDomain;
-  if (tokenData.id_token) {
-    try {
-      const payload = decodeIdTokenPayload(tokenData.id_token);
-      email = payload.email ?? 'unknown';
-      tenantDomain = payload.tenant_domain ?? tenantDomain;
-      tenantName = payload.tenant_name ?? tenantDomain;
-    } catch {
-      // Use defaults
-    }
-  }
-
-  // Save credentials
-  const now = new Date();
-  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
-  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
-
-  const creds: CredentialsData = {
-    tenant_domain: tenantDomain,
-    tenant_name: tenantName,
-    email,
-    access_token: tokenData.access_token,
-    refresh_token: tokenData.refresh_token ?? '',
-    id_token: tokenData.id_token ?? '',
-    access_token_expires_at: accessTokenExpiresAt.toISOString(),
-    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
-    router_url: oidc.router_url,
-  };
-
-  credentials.write(creds);
-
-  process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
-
-  // Auto-setup Claude Code
-  if (!deps?.skipSetup) {
-    process.stderr.write('\nConfiguring Claude Code...\n');
-    setupCommand().catch(() => {
-      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-    });
-  }
-}
-
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
-  // Headless detection
   const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
   if (isHeadless) {
     return deviceCodeLogin(options, deps);
@@ -392,4 +243,175 @@ async function defaultOpenBrowser(url: string): Promise<void> {
       else resolve();
     });
   });
+}
+
+export interface DeviceAuthResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function pollForToken(
+  tokenEndpoint: string,
+  deviceCode: string,
+  interval: number,
+  expiresIn: number,
+  clientId: string,
+  fetchFn: (url: string, init?: any) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>,
+): Promise<TokenResponse> {
+  const deadline = Date.now() + expiresIn * 1000;
+  let currentInterval = interval;
+
+  while (Date.now() < deadline) {
+    await sleep(currentInterval * 1000);
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: clientId,
+    });
+
+    const response = await fetchFn(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (response.ok) {
+      return await response.json() as TokenResponse;
+    }
+
+    const errorData = await response.json().catch(() => ({ error: 'unknown' }));
+    const error = errorData.error;
+
+    if (error === 'authorization_pending') {
+      continue;
+    } else if (error === 'slow_down') {
+      currentInterval += 5;
+      continue;
+    } else if (error === 'expired_token') {
+      throw new Error('Device code expired. Please run login again.');
+    } else if (error === 'access_denied') {
+      throw new Error('Authorization request was denied by the user.');
+    } else {
+      throw new Error(`Token polling failed: ${error} - ${errorData.error_description ?? ''}`);
+    }
+  }
+
+  throw new Error('Device code expired. Please run login again.');
+}
+
+async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  // Step 1: OIDC Discovery
+  const env = options.env ?? 'prod';
+  const starkDomain = options.tenantDomain
+    ? resolveStarkDomain(options.tenantDomain)
+    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
+  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
+
+  if (!oidc.device_authorization_endpoint) {
+    throw new Error(
+      'This OIDC provider does not support the Device Authorization Grant. ' +
+      'Remove --device-code flag or use a browser-capable environment.'
+    );
+  }
+
+  // Step 2: Request device code
+  const deviceBody = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+  });
+
+  const deviceResponse = await fetchFn(oidc.device_authorization_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: deviceBody.toString(),
+  });
+
+  if (!deviceResponse.ok) {
+    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
+  }
+
+  const deviceData: DeviceAuthResponse = await deviceResponse.json();
+
+  // Step 3: Display verification instructions
+  process.stderr.write('\n');
+  process.stderr.write('To authenticate, visit the following URL in a browser:\n\n');
+  process.stderr.write(`  ${deviceData.verification_uri}\n\n`);
+  process.stderr.write(`Enter the code: ${deviceData.user_code}\n\n`);
+  if (deviceData.verification_uri_complete) {
+    process.stderr.write(`Or open this URL directly:\n  ${deviceData.verification_uri_complete}\n\n`);
+  }
+  process.stderr.write('Waiting for authorization...\n');
+
+  // Step 4: Poll for token
+  const tokenData = await pollForToken(
+    oidc.token_endpoint,
+    deviceData.device_code,
+    deviceData.interval ?? 5,
+    deviceData.expires_in,
+    CLIENT_ID,
+    fetchFn,
+  );
+
+  // Step 5: Decode ID token and save credentials
+  let email = 'unknown';
+  let tenantDomain = options.tenantDomain ?? '';
+  let tenantName = tenantDomain;
+  if (tokenData.id_token) {
+    try {
+      const payload = decodeIdTokenPayload(tokenData.id_token);
+      email = payload.email ?? 'unknown';
+      tenantDomain = payload.tenant_domain ?? tenantDomain;
+      tenantName = payload.tenant_name ?? tenantDomain;
+    } catch {
+      // Use defaults
+    }
+  }
+
+  const now = new Date();
+  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
+  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  const creds: CredentialsData = {
+    tenant_domain: tenantDomain,
+    tenant_name: tenantName,
+    email,
+    access_token: tokenData.access_token,
+    refresh_token: tokenData.refresh_token ?? '',
+    id_token: tokenData.id_token ?? '',
+    access_token_expires_at: accessTokenExpiresAt.toISOString(),
+    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+    router_url: oidc.router_url,
+  };
+
+  credentials.write(creds);
+  process.stderr.write(`\nLogged in as ${email} (${tenantName})\n`);
+
+  // Auto-setup Claude Code
+  if (!deps?.skipSetup) {
+    process.stderr.write('\nConfiguring Claude Code...\n');
+    setupCommand().catch(() => {
+      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+    });
+  }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -24,6 +24,7 @@ export interface LoginDeps {
     close: (cb?: () => void) => void;
     address: () => { port: number } | null;
   };
+  skipSetup?: boolean;
 }
 
 const SUCCESS_HTML = `<!DOCTYPE html>
@@ -93,7 +94,7 @@ export async function pollForToken(
   throw new Error('인증 시간이 만료되었습니다.');
 }
 
-async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): Promise<void> {
+async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}, deps?: LoginDeps): Promise<void> {
   const credentials = new Credentials();
 
   // Resolve Stark domain + discover OIDC
@@ -180,17 +181,19 @@ async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): 
   process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
 
   // Auto-setup Claude Code
-  process.stderr.write('\nConfiguring Claude Code...\n');
-  setupCommand().catch(() => {
-    process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-  });
+  if (!deps?.skipSetup) {
+    process.stderr.write('\nConfiguring Claude Code...\n');
+    setupCommand().catch(() => {
+      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+    });
+  }
 }
 
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
   // Headless detection
   const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
   if (isHeadless) {
-    return deviceCodeLogin(options);
+    return deviceCodeLogin(options, deps);
   }
 
   const credentials = deps?.credentials ?? new Credentials();
@@ -324,10 +327,12 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
           process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
 
           // Step 12: Auto-setup Claude Code
-          process.stderr.write('\nConfiguring Claude Code...\n');
-          setupCommand().catch(() => {
-            process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-          });
+          if (!deps?.skipSetup) {
+            process.stderr.write('\nConfiguring Claude Code...\n');
+            setupCommand().catch(() => {
+              process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+            });
+          }
 
           resolve();
         })

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { Credentials } from '../credentials';
+import { c } from '../colors';
 
 export interface SetupDeps {
   credentials?: Credentials;
@@ -67,14 +68,17 @@ export async function setupCommand(deps?: SetupDeps): Promise<void> {
   writeFileSyncFn(settingsPath, JSON.stringify(settings, null, 2));
 
   // Step 6: Success message
-  process.stderr.write('Claude Code configured to use Monocle authentication.\n');
-  process.stderr.write(`  apiKeyHelper: monocle token\n`);
-  process.stderr.write(`  ANTHROPIC_BASE_URL: ${routerUrl}\n`);
+  process.stderr.write(`${c.green('✓')} Claude Code configured to use Monocle authentication\n`);
+  process.stderr.write(`  ${c.dim('apiKeyHelper:')}       monocle token\n`);
+  process.stderr.write(`  ${c.dim('ANTHROPIC_BASE_URL:')} ${routerUrl}\n`);
 
   // Step 7: Warn about conflicting env vars
   const conflicting = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'].filter(k => env[k]);
   if (conflicting.length > 0) {
-    process.stderr.write(`\n⚠ Warning: ${conflicting.join(', ')} environment variable is set.\n`);
-    process.stderr.write('  Use `monocle claude` to launch Claude Code — it clears conflicting env vars automatically.\n');
+    process.stderr.write(`\n${c.yellow('⚠')} ${c.yellow(conflicting.join(', '))} environment variable is set.\n`);
+    process.stderr.write(`  Use ${c.bold('monocle claude')} to launch Claude Code — it clears conflicting env vars automatically.\n`);
   }
+
+  // Step 8: Tip — how to disconnect (red-family: signals undo/remove without alarm)
+  process.stderr.write(`\n${c.red(c.dim('To disconnect Claude Code from Monocle, run:'))} ${c.red(c.bold('monocle unset'))}\n`);
 }

--- a/src/commands/unset.ts
+++ b/src/commands/unset.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { c } from '../colors';
 
 export interface UnsetDeps {
   homedir?: () => string;
@@ -19,7 +20,7 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
   const settingsPath = path.join(homedir(), '.claude', 'settings.json');
 
   if (!existsSyncFn(settingsPath)) {
-    process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
     return;
   }
 
@@ -28,7 +29,7 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
     const content = readFileSyncFn(settingsPath, 'utf-8');
     settings = JSON.parse(content);
   } catch {
-    process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
     return;
   }
 
@@ -49,5 +50,5 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
   writeFileSyncFn(settingsPath, JSON.stringify(settings, null, 2));
 
   // Step 5: Success message
-  process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+  process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
 }

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -4,6 +4,7 @@ export interface OIDCConfig {
   issuer: string;
   authorization_endpoint: string;
   token_endpoint: string;
+  device_authorization_endpoint?: string;
   router_url?: string;
 }
 
@@ -111,6 +112,7 @@ export async function discoverOIDC(
     issuer: config.issuer,
     authorization_endpoint: config.authorization_endpoint,
     token_endpoint: config.token_endpoint,
+    device_authorization_endpoint: config.device_authorization_endpoint,
     router_url: config.router_url,
   };
 }


### PR DESCRIPTION
## Summary

Adds OAuth 2.0 Device Authorization Grant (RFC 8628) so `monocle login` works in environments without a browser (SSH, CI, headless Linux, Emacs inner shell).

Closes #15.

## What changed

### Auth flow
- New `--device-code` flag for explicit device code login
- Auto-detect headless environments: `SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`, `INSIDE_EMACS`, `CI`, Linux without `DISPLAY` / `WAYLAND_DISPLAY`
- Auto-fallback from browser flow to device code when `xdg-open` / `open` fails or no callback arrives within 90s
- RFC 8628 polling with full error handling: `authorization_pending`, `slow_down`, `expired_token`, `access_denied`
- Diagnostic message when token endpoint returns non-OAuth HTTP responses

### UX polish
- Brew/gh-style colorized output (NO_COLOR / TTY aware, zero deps)
- Cyan device code URL, bold user code, green ✓ on success, yellow ⚠ on warnings
- Disconnect hint at end of setup output (red-family): `monocle unset`

### Internals
- DI-friendly refactor of device code implementation
- Test isolation: `~/.claude/settings.json` is no longer touched by the test suite

## Tests

75 tests passing (vitest), including 14 new tests in `device-code.test.ts` covering:
- Headless detection across all env vars
- `pollForToken` for success, `authorization_pending`, `slow_down`, `expired_token`, `access_denied`, non-OAuth HTTP error
- Browser-flow → device-code fallback paths

## Server dependency

- warmblood-kr/stark#629 — `POST /oauth/device_authorization` and device_code grant on `POST /oauth/token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)