### PR TITLE
feat: scope `monocle claude` to its own invocation via --settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,21 @@ monocle login
 ```
 
 A browser window will open — sign in with your organization account.
-Claude Code will be configured automatically after login.
 
-That's it! Run `monocle claude` to get started.
+**Step 3** — Launch Claude Code through Monocle
 
+```bash
+monocle claude
+```
+
+`monocle claude` runs Claude Code with Monocle credentials scoped **only to
+that invocation**. Your global Claude Code configuration is not touched —
+plain `claude` in other terminals or IDE integrations stays unaffected.
+
+> **Tip:** Want plain `claude` (including IDE integrations and other
+> terminals) to also route through Monocle globally? Run `monocle setup`
+> once. Undo with `monocle unset`.
+>
 > **Tip:** To specify a tenant explicitly, use `monocle login --tenant your-org.monocle-ai.com`
 >
 > **Tip:** If you have `ANTHROPIC_API_KEY` set in your environment, `monocle claude` will automatically clear it to avoid conflicts.
@@ -50,9 +61,9 @@ All green (**Valid** and **Configured**) means you're good to go!
 
 | Command | Description |
 |---------|-------------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI (auto-configures Claude Code) |
-| `monocle setup` | Manually configure Claude Code (usually handled by login) |
-| `monocle claude` | Launch Claude Code with conflicting env vars cleared |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI |
+| `monocle claude` | Launch Claude Code with Monocle scoped **only to this invocation** (no global changes) |
+| `monocle setup` | Opt in to global routing — makes plain `claude` (other terminals, IDE integrations) also use Monocle |
 | `monocle status` | Show login and configuration status |
 | `monocle token` | Print current access token (used internally by Claude Code) |
 | `monocle unset` | Remove Monocle configuration from Claude Code |
@@ -65,14 +76,14 @@ All green (**Valid** and **Configured**) means you're good to go!
 **Token expired**
 → Tokens are refreshed automatically. If it's been more than 30 days since your last login, run `monocle login` again.
 
-**Auto-setup failed**
-→ Run `monocle setup` manually.
-
 **Claude Code is ignoring Monocle**
 → An `ANTHROPIC_API_KEY` environment variable takes precedence over Monocle. Use `monocle claude` to launch Claude Code — it clears the conflict automatically.
 
+**Plain `claude` doesn't use Monocle**
+→ By design. `monocle claude` is isolated to its own invocation. Run `monocle setup` if you want plain `claude` to also route through Monocle.
+
 **Want to start fresh?**
-→ Run `monocle unset`, then `monocle setup`.
+→ Run `monocle unset` to remove global routing, then re-run `monocle setup` if needed.
 
 ## Help
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -26,10 +26,21 @@ monocle login
 ```
 
 브라우저가 열리면 평소 사용하시는 회사 계정으로 로그인해 주세요.
-로그인이 완료되면 Claude Code 설정도 자동으로 진행됩니다.
 
-끝이에요! 이제 `monocle claude`를 실행하시면 됩니다.
+**Step 3** — Monocle 경유로 Claude Code 실행
 
+```bash
+monocle claude
+```
+
+`monocle claude`는 Monocle 설정을 **이 실행에만** 적용한 상태로 Claude
+Code를 띄워요. 전역 Claude Code 설정은 전혀 건드리지 않아서, 다른 터미널이나
+IDE 연동의 `claude`는 그대로예요.
+
+> **Tip:** 다른 터미널이나 IDE 연동의 일반 `claude`도 Monocle을 거치게
+> 하고 싶다면 `monocle setup`을 한 번 실행하시면 돼요. 해제할 땐
+> `monocle unset`.
+>
 > **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`으로 실행하세요.
 >
 > **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
@@ -48,9 +59,9 @@ monocle status
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 (Claude Code 자동 설정 포함) |
-| `monocle setup` | Claude Code를 수동으로 설정 (보통은 login이 자동 처리) |
-| `monocle claude` | 환경 변수 충돌을 자동 정리하고 Claude Code 실행 |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 |
+| `monocle claude` | Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행 (전역 설정 변경 없음) |
+| `monocle setup` | 전역 라우팅 opt-in — 다른 터미널/IDE 연동의 일반 `claude`도 Monocle을 거치게 설정 |
 | `monocle status` | 로그인/설정 상태 확인 |
 | `monocle token` | 현재 액세스 토큰 출력 (Claude Code가 내부적으로 사용) |
 | `monocle unset` | Claude Code에서 Monocle 설정 제거 |
@@ -63,14 +74,14 @@ monocle status
 **토큰이 만료됐대요**
 → 토큰은 자동으로 갱신돼요. 마지막 로그인 후 30일이 지났다면 `monocle login`을 다시 실행해 주세요.
 
-**자동 설정이 실패했대요**
-→ `monocle setup`을 수동으로 실행해 주세요.
-
 **Claude Code가 Monocle을 무시해요**
 → 환경 변수에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Monocle보다 우선 적용돼요. `monocle claude`로 실행하면 자동으로 해결됩니다.
 
+**일반 `claude`가 Monocle을 안 쓰네요**
+→ 의도된 동작이에요. `monocle claude`는 자기 실행에만 Monocle을 적용해요. 일반 `claude`도 Monocle로 향하게 하려면 `monocle setup`을 한 번 실행해 주세요.
+
 **처음부터 다시 하고 싶어요**
-→ `monocle unset` 후 `monocle setup`을 다시 실행하면 돼요.
+→ `monocle unset`으로 전역 라우팅을 제거하시고, 필요하면 `monocle setup`을 다시 실행하시면 돼요.
 
 ## 도움이 필요하신가요?
 

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -62,7 +62,7 @@ describe('claudeCommand', () => {
       HOME: '/home/user',
     };
 
-    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn, skipSetup: true });
+    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
@@ -78,7 +78,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: 'https://warmblood.krmonocle-ai.com' })),
       env: { PATH: '/usr/bin' },
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -92,28 +91,26 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: undefined })),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_BASE_URL).toBe('https://example.stark.com');
   });
 
-  it('should pass arguments through to claude', async () => {
+  it('should pass --settings with apiKeyHelper and forward user args', async () => {
     const { spawnFn } = makeMockSpawn();
 
     await claudeCommand(['--model', 'opus'], {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
-    expect(spawnFn).toHaveBeenCalledWith(
-      'claude',
-      ['--model', 'opus'],
-      expect.any(Object)
-    );
+    const callArgs = spawnFn.mock.calls[0][1] as string[];
+    expect(callArgs[0]).toBe('--settings');
+    const parsed = JSON.parse(callArgs[1]);
+    expect(parsed.apiKeyHelper).toBe('monocle token');
+    expect(callArgs.slice(2)).toEqual(['--model', 'opus']);
   });
 
   it('should spawn claude with stdio inherit', async () => {
@@ -123,7 +120,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     expect(spawnFn.mock.calls[0][2].stdio).toBe('inherit');
@@ -136,7 +132,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const error = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -1,15 +1,10 @@
 import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import { Credentials } from '../credentials';
-import { setupCommand } from './setup';
 
 export interface ClaudeDeps {
   credentials?: Credentials;
   env?: Record<string, string | undefined>;
   spawn?: typeof child_process.spawn;
-  skipSetup?: boolean;
 }
 
 export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<void> {
@@ -24,39 +19,31 @@ export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<
     return;
   }
 
-  // Ensure Claude Code is configured (auto-setup if needed)
-  if (!deps?.skipSetup) {
-    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-    let needsSetup = true;
-    try {
-      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      needsSetup = settings.apiKeyHelper !== 'monocle token';
-    } catch {
-      // File doesn't exist or invalid JSON
-    }
-    if (needsSetup) {
-      process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
-      await setupCommand();
-    }
+  // Resolve router URL (base URL for the Chat Proxy)
+  let routerUrl: string;
+  if (creds.router_url) {
+    routerUrl = creds.router_url;
+  } else {
+    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${creds.tenant_domain}`;
   }
 
-  // Build clean env — remove vars that override apiKeyHelper
+  // Inline settings scoped to this child only — avoids mutating ~/.claude/settings.json.
+  // `apiKeyHelper` keeps tokens fresh across long sessions by re-invoking `monocle token`.
+  const inlineSettings = JSON.stringify({
+    apiKeyHelper: 'monocle token',
+  });
+
+  // Build child env — strip conflicting vars, inject base URL.
   const childEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
     if (value !== undefined && key !== 'ANTHROPIC_API_KEY' && key !== 'ANTHROPIC_AUTH_TOKEN') {
       childEnv[key] = value;
     }
   }
+  childEnv.ANTHROPIC_BASE_URL = routerUrl;
 
-  // Set base URL to Chat Proxy
-  if (creds.router_url) {
-    childEnv.ANTHROPIC_BASE_URL = creds.router_url;
-  } else {
-    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
-    childEnv.ANTHROPIC_BASE_URL = `${isLocal ? 'http' : 'https'}://${creds.tenant_domain}`;
-  }
-
-  const child = spawnFn('claude', args, {
+  const child = spawnFn('claude', ['--settings', inlineSettings, ...args], {
     env: childEnv,
     stdio: 'inherit',
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,7 +3,6 @@ import * as url from 'url';
 import { Credentials, CredentialsData } from '../credentials';
 import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain, STARK_DOMAINS, OIDCDeps } from '../oidc';
 import { decodeIdTokenPayload } from '../refresh';
-import { setupCommand } from './setup';
 import { c } from '../colors';
 
 const CLIENT_ID = 'monocle-cli';
@@ -26,7 +25,6 @@ export interface LoginDeps {
     close: (cb?: () => void) => void;
     address: () => { port: number } | null;
   };
-  skipSetup?: boolean;
   browserCallbackTimeoutMs?: number;
 }
 
@@ -229,14 +227,8 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
 
           // Step 11: Terminal output
           process.stderr.write(`${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
-
-          // Step 12: Auto-setup Claude Code
-          if (!deps?.skipSetup) {
-            process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
-            setupCommand().catch(() => {
-              process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
-            });
-          }
+          process.stderr.write(`\n${c.dim('Launch Claude Code through Monocle with:')} ${c.bold('monocle claude')}\n`);
+          process.stderr.write(`${c.dim('(To route plain')} ${c.bold('claude')} ${c.dim('globally through Monocle, run')} ${c.bold('monocle setup')}${c.dim('.)')}\n`);
 
           settle(() => resolve());
         })
@@ -490,12 +482,6 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
 
   credentials.write(creds);
   process.stderr.write(`\n${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
-
-  // Auto-setup Claude Code
-  if (!deps?.skipSetup) {
-    process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
-    setupCommand().catch(() => {
-      process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
-    });
-  }
+  process.stderr.write(`\n${c.dim('Launch Claude Code through Monocle with:')} ${c.bold('monocle claude')}\n`);
+  process.stderr.write(`${c.dim('(To route plain')} ${c.bold('claude')} ${c.dim('globally through Monocle, run')} ${c.bold('monocle setup')}${c.dim('.)')}\n`);
 }


### PR DESCRIPTION
## Summary

Makes `monocle claude` an isolated launch: Monocle's `apiKeyHelper` and base URL now apply **only to the spawned child process**, not to the user-global `~/.claude/settings.json`. Plain `claude` in other terminals or IDE integrations is no longer affected by using Monocle.

## Changes

- **`monocle claude`**: spawns `claude --settings '{"apiKeyHelper":"monocle token"}' <user args…>` with `ANTHROPIC_BASE_URL` on the child env. No more auto-`setup`, no more global settings mutation. `apiKeyHelper` is preserved so tokens keep auto-refreshing during long sessions.
- **`monocle login`**: the auto-`setupCommand()` call is removed from both the browser flow and the device-code flow. After login, the CLI prints a hint: `Launch Claude Code through Monocle with: monocle claude`, plus a note that `monocle setup` opts into global routing.
- **`monocle setup` / `monocle unset`**: unchanged. Still write/remove entries in `~/.claude/settings.json`. They are now the only paths that mutate the global file — an explicit opt-in/opt-out.
- **Invariant**: `~/.claude/settings.json` is never touched unless the user explicitly runs `monocle setup` or `monocle unset`.
- Tests updated for the new spawn args; `skipSetup` dep removed (no longer meaningful).
- READMEs (English + Korean) reworked: new "Step 3 — Launch Claude Code through Monocle" section, `monocle setup` reframed as opt-in global routing, stale "Auto-setup failed" troubleshooting removed.

## Reference

Claude Code supports `--settings '<json-or-path>'` for per-invocation settings that merge without mutating any file. See https://code.claude.com/docs/en/cli-reference.md.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes (75 tests)
- [ ] `monocle login` against a real tenant logs in without touching `~/.claude/settings.json`
- [ ] `monocle claude` launches Claude Code with Monocle routing, while `~/.claude/settings.json` remains unmodified (verify via `stat` before/after)
- [ ] Plain `claude` launched in another terminal does NOT route through Monocle (unless the user explicitly ran `monocle setup`)
- [ ] `monocle setup` still opts into global routing as before; `monocle unset` still removes it
- [ ] Long-running sessions keep working past the access-token TTL (apiKeyHelper via `--settings` should keep refreshing)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)