### PR TITLE
ci: OIDC 기반 npm 자동 배포 파이프라인 구축

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS
+#
+# 이 파일에 나열된 경로는 PR에서 해당 owner의 리뷰가 필수입니다.
+# 공급망 공격 방어를 위해 배포 파이프라인과 의존성 파일을 보호합니다.
+# 참고: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# 배포 워크플로우 및 GitHub 설정 전반
+/.github/               @smartbosslee
+
+# npm 배포에 직접 영향을 주는 파일
+/package.json           @smartbosslee
+/package-lock.json      @smartbosslee
+/tsconfig.json          @smartbosslee
+
+# CLI entry point (버전 문자열 포함)
+/src/cli.ts             @smartbosslee

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: npm publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '빌드/검증만 하고 실제 배포는 생략'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Sync version from tag (release event)
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${TAG_NAME#v}"
+          if ! echo "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Tag '$TAG_NAME' is not a valid SemVer (expected 'v1.2.3' or 'v1.2.3-rc.1')"
+            exit 1
+          fi
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+          echo "package.json version synced to $TAG_VERSION (CI-only, not committed)"
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm (dry run)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        run: npm publish --access public --provenance --dry-run
+
+      - name: Publish to npm
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+        run: npm publish --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 *.js.map
 *.d.ts.map
 .env
+
+# IDE
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warmblood/monocle-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "CLI authentication tool for Claude Code with Stark OIDC PKCE integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,12 +10,14 @@ import { claudeCommand } from './commands/claude';
 import { chatCommand } from './commands/chat';
 import { modelListCommand } from './commands/model-list';
 
+const { version } = require('../package.json') as { version: string };
+
 const program = new Command();
 
 program
   .name('monocle')
   .description('CLI authentication tool for Claude Code with Stark OIDC integration')
-  .version('0.4.1');
+  .version(version);
 
 program
   .command('login')


### PR DESCRIPTION
## 배경

Stark PR #631에서 본부장님이 지적하신 대로, Monocle CLI의 Device Code 로그인 기능(#16)이 devel까지만 머지된 상태이고 npm에는 배포되지 않아 실사용자가 쓸 수 없는 상황이었습니다.

단순히 `npm publish`를 한 번 실행하는 것보다 **지속 가능한 배포 체계**를 구축하는 방향으로 접근했습니다. 특히:
- 배포 권한이 현재 1명(smartbosslee)에게만 집중된 상태를 해소
- Public 저장소 특성상 필요한 공급망 보안 방어 레이어 구축
- 팀 누구나 안전한 경로로 배포 트리거 가능한 구조

## 변경사항

### `chore: .idea/ 디렉토리 gitignore에 추가`
IntelliJ 개인 설정 파일이 추적되지 않도록 제외.

### `refactor: CLI 버전을 package.json에서 동적으로 읽도록 변경`
`src/cli.ts`가 `package.json`의 version을 runtime에 읽도록 리팩토링. 이전엔 두 곳에 버전 문자열을 하드코딩해 수동 동기화가 필요했음. 이제 진실의 원천이 `package.json` 하나로 단일화됨.

### `ci: OIDC 기반 npm 자동 배포 워크플로우 추가`
- `.github/workflows/publish.yml` — Release publish 이벤트 또는 workflow_dispatch(dry run 지원)로만 발동
- `.github/CODEOWNERS` — 배포 민감 파일 보호

## 보안 방어 체계

배포 파이프라인을 **5중 방어**로 구성:

| Layer | 수단 | 현재 상태 |
|-------|------|-----------|
| 1. Release 이벤트 트리거 | `on: release: published` | 이 PR로 적용 |
| 2. Environment approval gate | `npm-production` + required reviewers | Environment 생성 완료 (smartbos + 본부장) |
| 3. Tag protection | Repository Ruleset (v*, admin bypass only) | 적용됨 (ruleset id 15261730) |
| 4. Branch protection | Repository Ruleset (devel/main, PR + CODEOWNERS 리뷰 필수) | 적용됨 (ruleset id 15261741) |
| 5. CODEOWNERS | 배포 민감 파일 owner 리뷰 강제 | 이 PR로 적용 |

추가: npm **Trusted Publisher (OIDC)** 등록으로 영구 NPM_TOKEN 제거. 매 배포마다 GitHub OIDC 토큰이 일회성으로 발급되어 npm에 인증됨.

## 릴리스 플로우 (이 PR 머지 후)

```
1. git tag v0.5.0 && git push origin v0.5.0       (Admin만 가능)
2. GitHub UI → Draft release → Publish            (workflow 발동)
3. Environment 승인 대기
4. Reviewer(smartbos or 본부장) Approve
5. lint/test/build → npm publish --provenance      (OIDC 인증)
6. npm registry에 @warmblood/monocle-cli@0.5.0 반영
```

버전 관리 방식: **git tag가 유일한 진실의 원천**. CI가 태그 이름에서 SemVer를 추출해 `package.json`을 CI 내부에서만 덮어쓴 뒤 publish함. 개발자는 `package.json`/`src/cli.ts` 버전을 수동으로 맞출 필요가 없음.

## Test plan

- [ ] lint/test 통과 확인 (현재 로컬 75개 테스트 모두 통과)
- [ ] PR 머지 후 `workflow_dispatch`로 dry run 실행 → Environment 승인 → 로그에서 `npm publish --dry-run` 성공 확인
- [ ] `v0.5.0` 태그 생성 + Release publish → 실제 npm 배포 검증
- [ ] `npx @warmblood/monocle-cli@0.5.0 --version` 출력이 `0.5.0`인지 확인
- [ ] `npx @warmblood/monocle-cli@0.5.0 login --device-code` 플로우 동작 확인

## 남은 후속 조치 (별도 이슈 권장)

- GitHub Organization 레벨 2FA 강제 설정 ON (self-approval 허용 상태에서 보안 필수 전제)
- CI status check을 Branch Ruleset에 required로 추가 (첫 PR 돌아간 후 check name 확인 가능)
- `@warmblood` npm 조직에 팀원 초대 (선택, 현재는 OIDC로 충분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)