### PR TITLE
ci: dry run을 별도 job으로 분리

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,36 @@ permissions:
   id-token: write
 
 jobs:
+  dry-run:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm (dry run)
+        run: npm publish --access public --provenance --dry-run
+
   publish:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
     runs-on: ubuntu-latest
     environment: npm-production
     steps:
@@ -57,10 +86,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm (dry run)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
-        run: npm publish --access public --provenance --dry-run
-
       - name: Publish to npm
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
         run: npm publish --access public --provenance


### PR DESCRIPTION
## 배경

PR #20 머지 후 첫 번째 dry run 실행(#1)이 아래 에러로 실패:

\`\`\`
Branch "devel" is not allowed to deploy to npm-production
due to environment protection rules
\`\`\`

\`npm-production\` Environment의 "Deployment branches and tags" 설정이 \`v*\` 태그만 허용하도록 되어 있어, devel 브랜치에서 \`workflow_dispatch\`로 dry run을 돌리면 Environment가 거부한다.

## 문제의 개념적 진단

**Environment는 "배포 게이트"이지 "테스트 게이트"가 아니다.** \`npm publish --dry-run\`은 npm registry에 아무것도 올리지 않는 검증 전용 명령이고, 이를 실행하기 위해 Environment 승인(+ 특정 ref 제한)을 거칠 이유가 없다.

기존 구조는 "하나의 job이 dry run과 publish를 모두 처리"했기 때문에 Environment가 양쪽에 공통으로 적용돼 이 문제가 생겼다.

## 변경 내용

publish.yml의 단일 \`publish\` job을 두 개로 분리:

| Job | Environment | 트리거 조건 | 목적 |
|-----|-------------|-----------|------|
| \`dry-run\` | 없음 | \`workflow_dispatch\` + \`dry_run=true\` | 검증 (npm 비전파) |
| \`publish\` | \`npm-production\` | \`release\` 이벤트 OR \`workflow_dispatch\` + \`dry_run=false\` | 실배포 (승인 게이트 거침) |

## 보안 영향

**감소 없음.** 실제로 npm에 전파되는 경로(\`publish\` job)는 여전히 다음 모든 게이트를 거친다:
- Environment required reviewers (smartbos + 본부장)
- Environment deployment branches/tags (\`v*\` 태그만)
- Trusted Publisher OIDC (특정 repo + workflow + environment만)
- Tag Ruleset (Admin만 \`v*\` 태그 생성)

\`dry-run\` job은 npm에 아무것도 보내지 않으므로 추가 게이트가 불필요하다.

## 대안 비교

| 대안 | 장점 | 단점 |
|------|------|------|
| A. 매번 Environment에 devel 임시 허용 | 설정이 깨끗 | 반복 조작, 잊으면 영구적 완화 |
| B. devel을 영구 허용 | 운영 단순 | 의도에 부합하지 않음 (Environment가 dry run 진입점까지 관할) |
| **C (이 PR)**. Job 분리 | 의도에 부합, 영구 해결 | workflow 약간 중복 |

## Test plan

- [ ] PR 머지 후 \`workflow_dispatch\`로 devel 브랜치에서 dry run 실행
- [ ] dry-run job이 Environment 승인 없이 바로 실행되는지 확인
- [ ] lint/test/build/\`npm publish --dry-run\` 전 스텝 통과 확인
- [ ] OIDC 인증이 dry-run job에서도 정상 동작하는지 확인 (provenance 생성 테스트)

## 후속 (선택)

lint/test/build 중복이 거슬리면 composite action(\`.github/actions/setup-and-verify\`)으로 추출 가능. 현재 2회 중복은 감수하고 명확성을 택함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)