### PR TITLE
release: devel을 main으로 병합 (v0.5.0 준비)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS
+#
+# 이 파일에 나열된 경로는 PR에서 해당 owner의 리뷰가 필수입니다.
+# 공급망 공격 방어를 위해 배포 파이프라인과 의존성 파일을 보호합니다.
+# 참고: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# 배포 워크플로우 및 GitHub 설정 전반
+/.github/               @smartbosslee
+
+# npm 배포에 직접 영향을 주는 파일
+/package.json           @smartbosslee
+/package-lock.json      @smartbosslee
+/tsconfig.json          @smartbosslee
+
+# CLI entry point (버전 문자열 포함)
+/src/cli.ts             @smartbosslee

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: npm publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '빌드/검증만 하고 실제 배포는 생략'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Sync version from tag (release event)
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${TAG_NAME#v}"
+          if ! echo "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Tag '$TAG_NAME' is not a valid SemVer (expected 'v1.2.3' or 'v1.2.3-rc.1')"
+            exit 1
+          fi
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+          echo "package.json version synced to $TAG_VERSION (CI-only, not committed)"
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm (dry run)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        run: npm publish --access public --provenance --dry-run
+
+      - name: Publish to npm
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,36 @@ permissions:
   id-token: write
 
 jobs:
+  dry-run:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm (dry run)
+        run: npm publish --access public --provenance --dry-run
+
   publish:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
     runs-on: ubuntu-latest
     environment: npm-production
     steps:
@@ -57,10 +86,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm (dry run)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
-        run: npm publish --access public --provenance --dry-run
-
       - name: Publish to npm
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
         run: npm publish --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 *.js.map
 *.d.ts.map
 .env
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ All green (**Valid** and **Configured**) means you're good to go!
 **Want to start fresh?**
 → Run `monocle unset`, then `monocle setup`.
 
+## Using Monocle from your own app
+
+Want to call Monocle's OpenAI-compatible API from your own code (Python,
+Node.js, `curl`)? See **Using Monocle with the OpenAI SDK**
+— [English](./docs/openai-sdk.md) · [한국어](./docs/openai-sdk.ko.md).
+
 ## Help
 
 Contact your organization admin or open an issue in this repository.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ That's it! Run `monocle claude` to get started.
 > **Tip:** To specify a tenant explicitly, use `monocle login --tenant your-org.monocle-ai.com`
 >
 > **Tip:** If you have `ANTHROPIC_API_KEY` set in your environment, `monocle claude` will automatically clear it to avoid conflicts.
+>
+> **Headless / SSH / CI?** `monocle login` auto-detects these environments and switches to
+> the device code flow — a URL and short code you enter on another machine. If auto-detection
+> misses your environment, force it with `monocle login --device-code`.
 
 ## Check Status
 
@@ -46,7 +50,7 @@ All green (**Valid** and **Configured**) means you're good to go!
 
 | Command | Description |
 |---------|-------------|
-| `monocle login [--tenant <domain>] [--env <env>]` | Sign in via browser (auto-configures Claude Code) |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI (auto-configures Claude Code) |
 | `monocle setup` | Manually configure Claude Code (usually handled by login) |
 | `monocle claude` | Launch Claude Code with conflicting env vars cleared |
 | `monocle status` | Show login and configuration status |

--- a/README.md
+++ b/README.md
@@ -26,10 +26,21 @@ monocle login
 ```
 
 A browser window will open — sign in with your organization account.
-Claude Code will be configured automatically after login.
 
-That's it! Run `monocle claude` to get started.
+**Step 3** — Launch Claude Code through Monocle
 
+```bash
+monocle claude
+```
+
+`monocle claude` runs Claude Code with Monocle credentials scoped **only to
+that invocation**. Your global Claude Code configuration is not touched —
+plain `claude` in other terminals or IDE integrations stays unaffected.
+
+> **Tip:** Want plain `claude` (including IDE integrations and other
+> terminals) to also route through Monocle globally? Run `monocle setup`
+> once. Undo with `monocle unset`.
+>
 > **Tip:** To specify a tenant explicitly, use `monocle login --tenant your-org.monocle-ai.com`
 >
 > **Tip:** If you have `ANTHROPIC_API_KEY` set in your environment, `monocle claude` will automatically clear it to avoid conflicts.
@@ -50,9 +61,9 @@ All green (**Valid** and **Configured**) means you're good to go!
 
 | Command | Description |
 |---------|-------------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI (auto-configures Claude Code) |
-| `monocle setup` | Manually configure Claude Code (usually handled by login) |
-| `monocle claude` | Launch Claude Code with conflicting env vars cleared |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI |
+| `monocle claude` | Launch Claude Code with Monocle scoped **only to this invocation** (no global changes) |
+| `monocle setup` | Opt in to global routing — makes plain `claude` (other terminals, IDE integrations) also use Monocle |
 | `monocle status` | Show login and configuration status |
 | `monocle token` | Print current access token (used internally by Claude Code) |
 | `monocle unset` | Remove Monocle configuration from Claude Code |
@@ -65,14 +76,14 @@ All green (**Valid** and **Configured**) means you're good to go!
 **Token expired**
 → Tokens are refreshed automatically. If it's been more than 30 days since your last login, run `monocle login` again.
 
-**Auto-setup failed**
-→ Run `monocle setup` manually.
-
 **Claude Code is ignoring Monocle**
 → An `ANTHROPIC_API_KEY` environment variable takes precedence over Monocle. Use `monocle claude` to launch Claude Code — it clears the conflict automatically.
 
+**Plain `claude` doesn't use Monocle**
+→ By design. `monocle claude` is isolated to its own invocation. Run `monocle setup` if you want plain `claude` to also route through Monocle.
+
 **Want to start fresh?**
-→ Run `monocle unset`, then `monocle setup`.
+→ Run `monocle unset` to remove global routing, then re-run `monocle setup` if needed.
 
 ## Help
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -26,10 +26,21 @@ monocle login
 ```
 
 브라우저가 열리면 평소 사용하시는 회사 계정으로 로그인해 주세요.
-로그인이 완료되면 Claude Code 설정도 자동으로 진행됩니다.
 
-끝이에요! 이제 `monocle claude`를 실행하시면 됩니다.
+**Step 3** — Monocle 경유로 Claude Code 실행
 
+```bash
+monocle claude
+```
+
+`monocle claude`는 Monocle 설정을 **이 실행에만** 적용한 상태로 Claude
+Code를 띄워요. 전역 Claude Code 설정은 전혀 건드리지 않아서, 다른 터미널이나
+IDE 연동의 `claude`는 그대로예요.
+
+> **Tip:** 다른 터미널이나 IDE 연동의 일반 `claude`도 Monocle을 거치게
+> 하고 싶다면 `monocle setup`을 한 번 실행하시면 돼요. 해제할 땐
+> `monocle unset`.
+>
 > **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`으로 실행하세요.
 >
 > **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
@@ -48,9 +59,9 @@ monocle status
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 (Claude Code 자동 설정 포함) |
-| `monocle setup` | Claude Code를 수동으로 설정 (보통은 login이 자동 처리) |
-| `monocle claude` | 환경 변수 충돌을 자동 정리하고 Claude Code 실행 |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 |
+| `monocle claude` | Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행 (전역 설정 변경 없음) |
+| `monocle setup` | 전역 라우팅 opt-in — 다른 터미널/IDE 연동의 일반 `claude`도 Monocle을 거치게 설정 |
 | `monocle status` | 로그인/설정 상태 확인 |
 | `monocle token` | 현재 액세스 토큰 출력 (Claude Code가 내부적으로 사용) |
 | `monocle unset` | Claude Code에서 Monocle 설정 제거 |
@@ -63,14 +74,14 @@ monocle status
 **토큰이 만료됐대요**
 → 토큰은 자동으로 갱신돼요. 마지막 로그인 후 30일이 지났다면 `monocle login`을 다시 실행해 주세요.
 
-**자동 설정이 실패했대요**
-→ `monocle setup`을 수동으로 실행해 주세요.
-
 **Claude Code가 Monocle을 무시해요**
 → 환경 변수에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Monocle보다 우선 적용돼요. `monocle claude`로 실행하면 자동으로 해결됩니다.
 
+**일반 `claude`가 Monocle을 안 쓰네요**
+→ 의도된 동작이에요. `monocle claude`는 자기 실행에만 Monocle을 적용해요. 일반 `claude`도 Monocle로 향하게 하려면 `monocle setup`을 한 번 실행해 주세요.
+
 **처음부터 다시 하고 싶어요**
-→ `monocle unset` 후 `monocle setup`을 다시 실행하면 돼요.
+→ `monocle unset`으로 전역 라우팅을 제거하시고, 필요하면 `monocle setup`을 다시 실행하시면 돼요.
 
 ## 도움이 필요하신가요?
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -33,6 +33,8 @@ monocle login
 > **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`으로 실행하세요.
 >
 > **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
+>
+> **헤드리스 / SSH / CI 환경이신가요?** `monocle login`이 자동으로 감지해서 device code 방식으로 전환합니다 — 다른 기기의 브라우저에서 URL을 열고 짧은 코드를 입력하는 방식이에요. 자동 감지가 안 되는 환경이면 `monocle login --device-code`로 강제할 수 있어요.
 
 ## 상태 확인
 
@@ -46,7 +48,7 @@ monocle status
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>]` | 브라우저로 로그인 (Claude Code 자동 설정 포함) |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 (Claude Code 자동 설정 포함) |
 | `monocle setup` | Claude Code를 수동으로 설정 (보통은 login이 자동 처리) |
 | `monocle claude` | 환경 변수 충돌을 자동 정리하고 Claude Code 실행 |
 | `monocle status` | 로그인/설정 상태 확인 |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -72,6 +72,12 @@ monocle status
 **처음부터 다시 하고 싶어요**
 → `monocle unset` 후 `monocle setup`을 다시 실행하면 돼요.
 
+## 직접 만든 앱에서 Monocle 쓰기
+
+Python, Node.js, `curl` 같은 도구로 Monocle의 OpenAI 호환 API를 호출하고
+싶으신가요? **OpenAI SDK로 Monocle 사용하기** 가이드를 참고해 주세요
+— [한국어](./openai-sdk.ko.md) · [English](./openai-sdk.md).
+
 ## 도움이 필요하신가요?
 
 조직의 관리자에게 문의하시거나 이 저장소에 이슈를 등록해 주세요.

--- a/docs/openai-sdk.ko.md
+++ b/docs/openai-sdk.ko.md
@@ -1,0 +1,252 @@
+# OpenAI SDK로 Monocle 사용하기
+
+[English](./openai-sdk.md)
+
+Monocle은 **OpenAI 호환** Chat Completions API를 제공해요. OpenAI 프로토콜을
+지원하는 도구나 라이브러리라면 두 가지만 설정해 주면 바로 Monocle과 통신할
+수 있어요.
+
+1. Monocle 라우터를 가리키는 **base URL**
+2. Monocle OIDC 로그인으로 발급받은 **액세스 토큰**
+
+이 문서에서는 `monocle` CLI로 이 두 가지를 얻어서 공식 OpenAI SDK
+(Python, Node.js)나 단순 HTTP 클라이언트에 연결하는 방법을 안내해요.
+
+---
+
+## 시작하기 전에
+
+- **Node.js** 18 이상 (CLI 설치/실행에 필요해요)
+- 로그인할 수 있는 Monocle 테넌트 (예: `your-org.monocle-ai.com`)
+
+CLI 설치 후 로그인:
+
+```bash
+npm install -g @warmblood/monocle-cli
+monocle login
+```
+
+상태 확인:
+
+```bash
+monocle status
+```
+
+---
+
+## 인증 정보가 저장되는 위치
+
+`monocle login`이 성공하면 CLI가 아래 경로에 인증 정보를 저장해요.
+
+```
+~/.monocle/credentials.json   (파일 권한 0600)
+```
+
+파일 내용은 다음과 같아요 (일부 생략):
+
+```json
+{
+  "tenant_domain": "your-org.monocle-ai.com",
+  "tenant_name": "your-org",
+  "email": "you@your-org.com",
+  "access_token": "<JWT>",
+  "refresh_token": "<opaque>",
+  "id_token": "<JWT>",
+  "access_token_expires_at": "2026-04-19T12:00:00.000Z",
+  "refresh_token_expires_at": "2026-05-19T12:00:00.000Z",
+  "router_url": "https://api.monocle-ai.com"
+}
+```
+
+- `access_token`은 수명이 짧은 JWT(RFC 9068 `at+JWT`)예요. API 호출 시
+  `Authorization: Bearer <access_token>` 헤더로 전달해요.
+- `router_url`이 **base URL**이에요. 로그인 시 OIDC discovery로 설정되며,
+  프로덕션 테넌트의 경우 보통 `https://api.monocle-ai.com`이에요.
+- `refresh_token`은 액세스 토큰이 만료되었을 때 새 토큰을 발급받는 데
+  사용해요. CLI가 자동으로 처리해 주니 아래 섹션을 참고하세요.
+
+---
+
+## SDK에 전달할 토큰 얻기
+
+두 가지 방법이 있어요. 코드가 어떻게 실행되는지에 따라 골라 쓰세요.
+
+### 방법 1 (권장) — `monocle token`
+
+CLI가 현재 액세스 토큰을 stdout으로 출력해 주는데, 만료 5분 전이면 자동으로
+갱신해서 돌려줘요.
+
+```bash
+monocle token
+```
+
+셸에서 쓰기:
+
+```bash
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)"
+```
+
+애플리케이션 코드에서 요청 직전마다 이 명령을 호출해서 토큰을 받아 써도 돼요.
+CLI의 자동 갱신 로직을 그대로 재사용하기 때문에 가장 안전하고 간단한
+방법이에요.
+
+### 방법 2 — `credentials.json`을 직접 읽기
+
+서브프로세스를 띄우고 싶지 않을 때(예: 장시간 실행되는 서버) 유용해요.
+파일을 읽어서 `access_token`을 쓰고, 요청이 **401**을 반환하면 다시 읽는
+방식이에요. `access_token_expires_at`이 이미 지났다면 `monocle token`을
+호출해서 갱신하거나, OIDC `token_endpoint`에 직접 요청해서 갱신 로직을
+구현해야 해요. 대부분의 앱에서는 **방법 1이 더 간단하고 안전해요**.
+
+---
+
+## 사용 가능한 모델 목록 보기
+
+Monocle은 OpenAI 호환 `GET /v1/models` 엔드포인트를 제공해요. CLI가 이를
+감싸서 보여줘요.
+
+```bash
+monocle model list
+```
+
+출력 예시:
+
+```
+MODEL ID              NAME                  OWNER       CONTEXT
+────────────────────  ────────────────────  ──────────  ─────────
+claude-sonnet-4-6     Claude Sonnet 4.6     anthropic   200k
+claude-opus-4-7       Claude Opus 4.7       anthropic   200k
+gpt-4o                GPT-4o                openai      128k
+```
+
+`MODEL ID` 컬럼에 있는 값이 SDK에 `model`로 전달할 값이에요.
+
+---
+
+## Python — OpenAI SDK
+
+```bash
+pip install openai
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)"
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MONOCLE_API_KEY"],
+    base_url=f"{os.environ['MONOCLE_BASE_URL']}/v1",
+)
+
+resp = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[
+        {"role": "system", "content": "너는 간결한 어시스턴트야."},
+        {"role": "user", "content": "OAuth 2.0을 한 문장으로 요약해 줘."},
+    ],
+)
+
+print(resp.choices[0].message.content)
+```
+
+스트리밍도 OpenAI와 똑같은 방식으로 쓸 수 있어요.
+
+```python
+stream = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "1부터 5까지 세어 줘."}],
+    stream=True,
+)
+for chunk in stream:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="", flush=True)
+```
+
+---
+
+## Node.js / TypeScript — OpenAI SDK
+
+```bash
+npm install openai
+```
+
+```ts
+import OpenAI from "openai";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const apiKey = execSync("monocle token").toString().trim();
+const creds = JSON.parse(
+  readFileSync(join(homedir(), ".monocle", "credentials.json"), "utf8"),
+);
+const baseURL = `${creds.router_url}/v1`;
+
+const client = new OpenAI({ apiKey, baseURL });
+
+const resp = await client.chat.completions.create({
+  model: "claude-sonnet-4-6",
+  messages: [{ role: "user", content: "한 단어로 인사해 줘." }],
+});
+
+console.log(resp.choices[0].message.content);
+```
+
+---
+
+## 순수 HTTP
+
+OpenAI 호환 API이기 때문에 `curl`로도 바로 호출할 수 있어요.
+
+```bash
+curl https://api.monocle-ai.com/v1/chat/completions \
+  -H "Authorization: Bearer $(monocle token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "messages": [{"role": "user", "content": "ping"}]
+  }'
+```
+
+---
+
+## 장시간 실행 앱에서 토큰을 갱신하는 방법
+
+액세스 토큰은 보통 한 시간 이내에 만료돼요. 세 가지 패턴 중에서 고르세요.
+
+1. **요청마다 셸 호출** — 필요할 때마다 `monocle token`을 실행해요. 빠르고
+   언제나 유효한 토큰을 돌려줘서 가장 간단해요.
+2. **캐시 + 401 시 갱신** — 토큰을 캐시해 두고, 응답이 `401 Unauthorized`면
+   `monocle token`을 다시 호출해서 한 번 재시도하는 방식이에요.
+3. **OIDC refresh를 직접 구현** — `refresh_token`을 OIDC `token_endpoint`에
+   POST해서 새 토큰을 받아와요. CLI를 실행할 수 없는 환경에서만 필요해요.
+
+`monocle login`이 발급하는 refresh token은 30일 동안 유효해요. 그 이후에는
+사용자가 다시 대화형으로 로그인해야 해요.
+
+---
+
+## 문제가 생겼나요?
+
+**`401 Unauthorized`**
+→ 액세스 토큰이 만료됐거나 거부된 거예요. `monocle status`로 확인하시고,
+만료되었다면 `monocle token`(자동 갱신) 혹은 `monocle login`(재로그인)을
+실행해 주세요.
+
+**`404 model_not_found`**
+→ 전달한 `model` ID가 테넌트에 없어요. `monocle model list`로 사용 가능한
+모델 ID를 확인해 주세요.
+
+**`Not logged in`**
+→ `monocle login`을 먼저 실행해 주세요. 헤드리스/CI 환경이면
+`monocle login --device-code`를 쓰시면 돼요.
+
+**base URL 연결 오류**
+→ `~/.monocle/credentials.json`의 `router_url`이 관리자가 알려 준 값과
+같은지 확인해 주세요. 프로덕션 테넌트는 보통
+`https://api.monocle-ai.com`이에요.

--- a/docs/openai-sdk.md
+++ b/docs/openai-sdk.md
@@ -1,0 +1,254 @@
+# Using Monocle with the OpenAI SDK
+
+[한국어](./openai-sdk.ko.md)
+
+Monocle exposes an **OpenAI-compatible** Chat Completions API, so any tool or
+library that speaks the OpenAI protocol can talk to Monocle with two pieces of
+configuration:
+
+1. A **base URL** that points at the Monocle router.
+2. An **access token** issued by Monocle OIDC login.
+
+This guide shows how to obtain both using the `monocle` CLI and how to wire
+them into the official OpenAI SDKs (Python and Node.js) or a plain HTTP
+client.
+
+---
+
+## Prerequisites
+
+- **Node.js** 18+ (required to install and run the CLI).
+- A Monocle tenant you can log in to (e.g. `your-org.monocle-ai.com`).
+
+Install the CLI and log in:
+
+```bash
+npm install -g @warmblood/monocle-cli
+monocle login
+```
+
+Verify:
+
+```bash
+monocle status
+```
+
+---
+
+## Where your credentials live
+
+After `monocle login` succeeds, the CLI writes your credentials to:
+
+```
+~/.monocle/credentials.json   (file mode 0600)
+```
+
+The file contains (abridged):
+
+```json
+{
+  "tenant_domain": "your-org.monocle-ai.com",
+  "tenant_name": "your-org",
+  "email": "you@your-org.com",
+  "access_token": "<JWT>",
+  "refresh_token": "<opaque>",
+  "id_token": "<JWT>",
+  "access_token_expires_at": "2026-04-19T12:00:00.000Z",
+  "refresh_token_expires_at": "2026-05-19T12:00:00.000Z",
+  "router_url": "https://api.monocle-ai.com"
+}
+```
+
+- `access_token` is a short-lived JWT (RFC 9068 `at+JWT`) — you pass it to the
+  API as `Authorization: Bearer <access_token>`.
+- `router_url` is your **base URL**. It is set by OIDC discovery during
+  login; for production tenants this is typically
+  `https://api.monocle-ai.com`.
+- `refresh_token` is used to mint a new access token when the current one
+  expires. The CLI handles this for you (see below).
+
+---
+
+## Getting a token for your SDK
+
+You have two options. Pick based on how your code runs.
+
+### Option 1 (recommended) — `monocle token`
+
+The CLI prints the current access token to stdout, refreshing it
+automatically if it is within 5 minutes of expiry:
+
+```bash
+monocle token
+```
+
+Use it from shell:
+
+```bash
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)"
+```
+
+Or from application code by shelling out before each request. This is the
+simplest way to stay correct — you inherit the CLI's refresh logic for free.
+
+### Option 2 — read `credentials.json` directly
+
+Useful when you want to avoid spawning a subprocess (e.g. in a long-running
+server). You read the file, use `access_token`, and re-read when a request
+returns **401**. If `access_token_expires_at` has passed, either call
+`monocle token` to refresh or implement refresh against the OIDC
+`token_endpoint` yourself. For most apps, **Option 1 is simpler and
+correct**.
+
+---
+
+## Listing available models
+
+Monocle exposes `GET /v1/models` (OpenAI-compatible). The CLI wraps it:
+
+```bash
+monocle model list
+```
+
+Example output:
+
+```
+MODEL ID              NAME                  OWNER       CONTEXT
+────────────────────  ────────────────────  ──────────  ─────────
+claude-sonnet-4-6     Claude Sonnet 4.6     anthropic   200k
+claude-opus-4-7       Claude Opus 4.7       anthropic   200k
+gpt-4o                GPT-4o                openai      128k
+```
+
+The `MODEL ID` column is the value you pass as `model` to the SDK.
+
+---
+
+## Python — OpenAI SDK
+
+```bash
+pip install openai
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)"
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MONOCLE_API_KEY"],
+    base_url=f"{os.environ['MONOCLE_BASE_URL']}/v1",
+)
+
+resp = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[
+        {"role": "system", "content": "You are a concise assistant."},
+        {"role": "user", "content": "Summarize OAuth 2.0 in one sentence."},
+    ],
+)
+
+print(resp.choices[0].message.content)
+```
+
+Streaming works the same as with OpenAI:
+
+```python
+stream = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Count to five."}],
+    stream=True,
+)
+for chunk in stream:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="", flush=True)
+```
+
+---
+
+## Node.js / TypeScript — OpenAI SDK
+
+```bash
+npm install openai
+```
+
+```ts
+import OpenAI from "openai";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const apiKey = execSync("monocle token").toString().trim();
+const creds = JSON.parse(
+  readFileSync(join(homedir(), ".monocle", "credentials.json"), "utf8"),
+);
+const baseURL = `${creds.router_url}/v1`;
+
+const client = new OpenAI({ apiKey, baseURL });
+
+const resp = await client.chat.completions.create({
+  model: "claude-sonnet-4-6",
+  messages: [{ role: "user", content: "Say hello in one word." }],
+});
+
+console.log(resp.choices[0].message.content);
+```
+
+---
+
+## Plain HTTP
+
+The API is OpenAI-compatible, so `curl` works directly:
+
+```bash
+curl https://api.monocle-ai.com/v1/chat/completions \
+  -H "Authorization: Bearer $(monocle token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "messages": [{"role": "user", "content": "ping"}]
+  }'
+```
+
+---
+
+## Keeping tokens fresh in long-running apps
+
+Access tokens expire (typically within the hour). Three patterns:
+
+1. **Shell out per request** — call `monocle token` every time you need a
+   token. It is fast and always returns a valid token. Simplest.
+2. **Cache and refresh on 401** — cache the token, and on a `401
+   Unauthorized` response, call `monocle token` again and retry once.
+3. **Implement OIDC refresh yourself** — POST the `refresh_token` to the
+   OIDC `token_endpoint`. Only needed if you cannot run the CLI in your
+   environment.
+
+`monocle login` keeps the refresh token valid for 30 days. After that, the
+user must log in again interactively.
+
+---
+
+## Troubleshooting
+
+**`401 Unauthorized`**
+→ Your access token expired or was rejected. Run `monocle status`; if it's
+expired, run `monocle token` (auto-refresh) or `monocle login` (full
+re-login).
+
+**`404 model_not_found`**
+→ The `model` ID you passed isn't available on your tenant. Run `monocle
+model list` to see valid IDs.
+
+**`Not logged in`**
+→ Run `monocle login` first. On headless / CI environments use `monocle
+login --device-code`.
+
+**Connection errors to the base URL**
+→ Confirm `router_url` in `~/.monocle/credentials.json` matches what your
+admin gave you. Production tenants typically use
+`https://api.monocle-ai.com`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warmblood/monocle-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "CLI authentication tool for Claude Code with Stark OIDC PKCE integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -62,7 +62,7 @@ describe('claudeCommand', () => {
       HOME: '/home/user',
     };
 
-    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn });
+    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn, skipSetup: true });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
@@ -78,6 +78,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: 'https://warmblood.krmonocle-ai.com' })),
       env: { PATH: '/usr/bin' },
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -91,6 +92,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: undefined })),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -104,6 +106,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     expect(spawnFn).toHaveBeenCalledWith(
@@ -120,6 +123,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     expect(spawnFn.mock.calls[0][2].stdio).toBe('inherit');
@@ -132,6 +136,7 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
+      skipSetup: true,
     });
 
     const error = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -62,7 +62,7 @@ describe('claudeCommand', () => {
       HOME: '/home/user',
     };
 
-    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn, skipSetup: true });
+    await claudeCommand([], { credentials: createMockCredentials(makeCredentials()), env, spawn: spawnFn });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
@@ -78,7 +78,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: 'https://warmblood.krmonocle-ai.com' })),
       env: { PATH: '/usr/bin' },
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
@@ -92,28 +91,26 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials({ router_url: undefined })),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const childEnv = spawnFn.mock.calls[0][2].env;
     expect(childEnv.ANTHROPIC_BASE_URL).toBe('https://example.stark.com');
   });
 
-  it('should pass arguments through to claude', async () => {
+  it('should pass --settings with apiKeyHelper and forward user args', async () => {
     const { spawnFn } = makeMockSpawn();
 
     await claudeCommand(['--model', 'opus'], {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
-    expect(spawnFn).toHaveBeenCalledWith(
-      'claude',
-      ['--model', 'opus'],
-      expect.any(Object)
-    );
+    const callArgs = spawnFn.mock.calls[0][1] as string[];
+    expect(callArgs[0]).toBe('--settings');
+    const parsed = JSON.parse(callArgs[1]);
+    expect(parsed.apiKeyHelper).toBe('monocle token');
+    expect(callArgs.slice(2)).toEqual(['--model', 'opus']);
   });
 
   it('should spawn claude with stdio inherit', async () => {
@@ -123,7 +120,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     expect(spawnFn.mock.calls[0][2].stdio).toBe('inherit');
@@ -136,7 +132,6 @@ describe('claudeCommand', () => {
       credentials: createMockCredentials(makeCredentials()),
       env: {},
       spawn: spawnFn,
-      skipSetup: true,
     });
 
     const error = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loginCommand, pollForToken } from '../commands/login';
 import { Credentials, CredentialsData } from '../credentials';
 
@@ -155,6 +155,112 @@ describe('SSH environment detection', () => {
     expect(getStored()!.access_token).toBe('at_device');
     expect(getStored()!.email).toBe('user@test.com');
     expect(getStored()!.tenant_name).toBe('Test Org');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects INSIDE_EMACS and uses device code flow', async () => {
+    process.env.INSIDE_EMACS = 'vterm';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects CI env and uses device code flow', async () => {
+    process.env.CI = 'true';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('browser flow fallback', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Start from a 'non-headless' baseline so we exercise the browser flow
+    delete process.env.SSH_CLIENT;
+    delete process.env.SSH_TTY;
+    delete process.env.SSH_CONNECTION;
+    delete process.env.INSIDE_EMACS;
+    delete process.env.CI;
+    process.env.DISPLAY = ':0';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('falls back to device code when openBrowser fails', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+        openBrowser: async () => {
+          throw new Error('xdg-open: command not found');
+        },
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to device code'));
+
+    stderrSpy.mockRestore();
+  });
+
+  it('falls back to device code when no callback arrives before timeout', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+        browserCallbackTimeoutMs: 50, // force quick timeout for tests
+        openBrowser: async () => {
+          // Simulate the OS command "succeeding" (e.g., xdg-open returns 0)
+          // but the user's browser never actually reaches the callback URL.
+        },
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('no callback received'));
 
     stderrSpy.mockRestore();
   });

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pollForToken } from '../commands/login';
+
+describe('Device Code Flow', () => {
+  describe('SSH environment detection', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('detects SSH_CLIENT as headless', () => {
+      process.env.SSH_CLIENT = '192.168.1.1 12345 22';
+      expect(!!process.env.SSH_CLIENT).toBe(true);
+    });
+
+    it('detects SSH_TTY as headless', () => {
+      process.env.SSH_TTY = '/dev/pts/0';
+      expect(!!process.env.SSH_TTY).toBe(true);
+    });
+
+    it('detects SSH_CONNECTION as headless', () => {
+      process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
+      expect(!!process.env.SSH_CONNECTION).toBe(true);
+    });
+  });
+
+  describe('pollForToken', () => {
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+      vi.restoreAllMocks();
+    });
+
+    it('returns token on first successful response', async () => {
+      const tokenData = {
+        access_token: 'at_123',
+        refresh_token: 'rt_123',
+        id_token: 'id_123',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => ({
+        ok: true,
+        status: 200,
+        json: async () => tokenData,
+      }));
+
+      const result = await pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01, // very short interval for test
+        10,
+      );
+
+      expect(result).toEqual(tokenData);
+    });
+
+    it('retries on authorization_pending then succeeds', async () => {
+      let callCount = 0;
+      const tokenData = {
+        access_token: 'at_456',
+        refresh_token: 'rt_456',
+        id_token: 'id_456',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: 'authorization_pending' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => tokenData,
+        };
+      });
+
+      const result = await pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01,
+        10,
+      );
+
+      expect(result).toEqual(tokenData);
+      expect(callCount).toBe(3);
+      // stderr should have dots for pending calls
+      expect(stderrSpy).toHaveBeenCalledWith('.');
+    });
+
+    it('throws on expired_token', async () => {
+      vi.stubGlobal('fetch', async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'expired_token' }),
+      }));
+
+      await expect(
+        pollForToken(
+          'https://auth.example.com/token',
+          'device_code_abc',
+          'monocle-cli',
+          0.01,
+          10,
+        )
+      ).rejects.toThrow('인증 시간이 만료되었습니다.');
+    });
+
+    it('throws on access_denied', async () => {
+      vi.stubGlobal('fetch', async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'access_denied' }),
+      }));
+
+      await expect(
+        pollForToken(
+          'https://auth.example.com/token',
+          'device_code_abc',
+          'monocle-cli',
+          0.01,
+          10,
+        )
+      ).rejects.toThrow('인증이 거부되었습니다.');
+    });
+
+    it('increases interval on slow_down then succeeds', async () => {
+      let callCount = 0;
+      const tokenData = {
+        access_token: 'at_789',
+        refresh_token: 'rt_789',
+        id_token: 'id_789',
+        expires_in: 3600,
+      };
+
+      vi.stubGlobal('fetch', async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: 'slow_down' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => tokenData,
+        };
+      });
+
+      // Use fake timers to avoid waiting 5+ real seconds
+      vi.useFakeTimers();
+      const promise = pollForToken(
+        'https://auth.example.com/token',
+        'device_code_abc',
+        'monocle-cli',
+        0.01,
+        30,
+      );
+
+      // Advance past first interval (0.01s)
+      await vi.advanceTimersByTimeAsync(100);
+      // After slow_down, interval becomes 5.01s — advance past it
+      await vi.advanceTimersByTimeAsync(6000);
+
+      const result = await promise;
+      vi.useRealTimers();
+
+      expect(result).toEqual(tokenData);
+      expect(callCount).toBe(2);
+    });
+  });
+});

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -303,4 +303,26 @@ describe('pollForToken', () => {
       ),
     ).rejects.toThrow('Authorization request was denied');
   });
+
+  it('surfaces HTTP status and raw body when server returns non-OAuth error', async () => {
+    const htmlBody = '<!doctype html><html><head><title>Server Error (500)</title></head><body>oops</body></html>';
+    const mockFetch = async () => ({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error('not json'); },
+      text: async () => htmlBody,
+      clone: function() { return this; },
+    });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow(/HTTP 500.*non-OAuth.*Server Error/);
+  });
 });

--- a/src/__tests__/device-code.test.ts
+++ b/src/__tests__/device-code.test.ts
@@ -1,191 +1,306 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { pollForToken } from '../commands/login';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loginCommand, pollForToken } from '../commands/login';
+import { Credentials, CredentialsData } from '../credentials';
 
-describe('Device Code Flow', () => {
-  describe('SSH environment detection', () => {
-    const originalEnv = process.env;
+function createMockCredentials() {
+  let stored: CredentialsData | null = null;
+  return {
+    instance: {
+      read: () => stored,
+      write: (d: CredentialsData) => { stored = d; },
+      delete: () => { stored = null; },
+      getCredentialsPath: () => '/fake/.monocle/credentials.json',
+      getCredentialsDir: () => '/fake/.monocle',
+      getFileMode: () => 0o600,
+    } as any as Credentials,
+    getStored: () => stored,
+  };
+}
 
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
+function createDeviceCodeMockFetch(tokenResponses?: Array<{ ok: boolean; status: number; json: () => Promise<any> }>) {
+  let tokenCallIndex = 0;
 
-    afterEach(() => {
-      process.env = originalEnv;
-    });
+  return async (url: string, _init?: any) => {
+    if (url.includes('.well-known/openid-configuration')) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          issuer: 'https://test.stark.com',
+          authorization_endpoint: 'https://test.stark.com/oauth/authorize',
+          token_endpoint: 'https://test.stark.com/oauth/token',
+          device_authorization_endpoint: 'https://test.stark.com/oauth/device',
+          router_url: 'https://api.monocle-ai.com',
+        }),
+      };
+    }
 
-    it('detects SSH_CLIENT as headless', () => {
-      process.env.SSH_CLIENT = '192.168.1.1 12345 22';
-      expect(!!process.env.SSH_CLIENT).toBe(true);
-    });
+    if (url.includes('/oauth/device')) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          device_code: 'dev_code_123',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://test.stark.com/device',
+          verification_uri_complete: 'https://test.stark.com/device?user_code=ABCD-1234',
+          expires_in: 600,
+          interval: 0.01, // Very short for tests
+        }),
+      };
+    }
 
-    it('detects SSH_TTY as headless', () => {
-      process.env.SSH_TTY = '/dev/pts/0';
-      expect(!!process.env.SSH_TTY).toBe(true);
-    });
+    // Token endpoint
+    if (tokenResponses && tokenCallIndex < tokenResponses.length) {
+      return tokenResponses[tokenCallIndex++];
+    }
 
-    it('detects SSH_CONNECTION as headless', () => {
-      process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
-      expect(!!process.env.SSH_CONNECTION).toBe(true);
-    });
+    // Default: return success
+    return {
+      ok: true, status: 200,
+      json: async () => ({
+        access_token: 'at_device',
+        refresh_token: 'rt_device',
+        id_token: 'eyJhbGciOiJSUzI1NiJ9.' + Buffer.from(JSON.stringify({
+          email: 'user@test.com',
+          tenant_name: 'Test Org',
+          tenant_domain: 'test.stark.com',
+        })).toString('base64url') + '.sig',
+        expires_in: 3600,
+      }),
+    };
+  };
+}
+
+describe('SSH environment detection', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
-  describe('pollForToken', () => {
-    let stderrSpy: ReturnType<typeof vi.spyOn>;
+  it('detects SSH_CLIENT and uses device code flow', async () => {
+    process.env.SSH_CLIENT = '192.168.1.1 12345 22';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    beforeEach(() => {
-      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    });
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
 
-    afterEach(() => {
-      stderrSpy.mockRestore();
-      vi.restoreAllMocks();
-    });
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('ABCD-1234'));
 
-    it('returns token on first successful response', async () => {
-      const tokenData = {
-        access_token: 'at_123',
-        refresh_token: 'rt_123',
-        id_token: 'id_123',
+    stderrSpy.mockRestore();
+  });
+
+  it('detects SSH_TTY and uses device code flow', async () => {
+    process.env.SSH_TTY = '/dev/pts/0';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('detects SSH_CONNECTION and uses device code flow', async () => {
+    process.env.SSH_CONNECTION = '192.168.1.1 12345 192.168.1.2 22';
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com' },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('uses device code flow when --device-code flag is set', async () => {
+    const { instance, getStored } = createMockCredentials();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await loginCommand(
+      { tenantDomain: 'test.stark.com', deviceCode: true },
+      {
+        credentials: instance,
+        fetch: createDeviceCodeMockFetch() as any,
+        skipSetup: true,
+      },
+    );
+
+    expect(getStored()).not.toBeNull();
+    expect(getStored()!.access_token).toBe('at_device');
+    expect(getStored()!.email).toBe('user@test.com');
+    expect(getStored()!.tenant_name).toBe('Test Org');
+
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('pollForToken', () => {
+  it('returns tokens on success', async () => {
+    const mockFetch = async () => ({
+      ok: true, status: 200,
+      json: async () => ({
+        access_token: 'at_success',
+        refresh_token: 'rt_success',
+        id_token: 'id_success',
         expires_in: 3600,
-      };
-
-      vi.stubGlobal('fetch', async () => ({
-        ok: true,
-        status: 200,
-        json: async () => tokenData,
-      }));
-
-      const result = await pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01, // very short interval for test
-        10,
-      );
-
-      expect(result).toEqual(tokenData);
+      }),
     });
 
-    it('retries on authorization_pending then succeeds', async () => {
-      let callCount = 0;
-      const tokenData = {
-        access_token: 'at_456',
-        refresh_token: 'rt_456',
-        id_token: 'id_456',
-        expires_in: 3600,
-      };
+    const result = await pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01, // very short interval for test
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
 
-      vi.stubGlobal('fetch', async () => {
-        callCount++;
-        if (callCount <= 2) {
-          return {
-            ok: false,
-            status: 400,
-            json: async () => ({ error: 'authorization_pending' }),
-          };
-        }
+    expect(result.access_token).toBe('at_success');
+    expect(result.refresh_token).toBe('rt_success');
+  });
+
+  it('continues polling on authorization_pending', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount < 3) {
         return {
-          ok: true,
-          status: 200,
-          json: async () => tokenData,
+          ok: false, status: 400,
+          json: async () => ({ error: 'authorization_pending' }),
         };
-      });
-
-      const result = await pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01,
-        10,
-      );
-
-      expect(result).toEqual(tokenData);
-      expect(callCount).toBe(3);
-      // stderr should have dots for pending calls
-      expect(stderrSpy).toHaveBeenCalledWith('.');
-    });
-
-    it('throws on expired_token', async () => {
-      vi.stubGlobal('fetch', async () => ({
-        ok: false,
-        status: 400,
-        json: async () => ({ error: 'expired_token' }),
-      }));
-
-      await expect(
-        pollForToken(
-          'https://auth.example.com/token',
-          'device_code_abc',
-          'monocle-cli',
-          0.01,
-          10,
-        )
-      ).rejects.toThrow('인증 시간이 만료되었습니다.');
-    });
-
-    it('throws on access_denied', async () => {
-      vi.stubGlobal('fetch', async () => ({
-        ok: false,
-        status: 400,
-        json: async () => ({ error: 'access_denied' }),
-      }));
-
-      await expect(
-        pollForToken(
-          'https://auth.example.com/token',
-          'device_code_abc',
-          'monocle-cli',
-          0.01,
-          10,
-        )
-      ).rejects.toThrow('인증이 거부되었습니다.');
-    });
-
-    it('increases interval on slow_down then succeeds', async () => {
-      let callCount = 0;
-      const tokenData = {
-        access_token: 'at_789',
-        refresh_token: 'rt_789',
-        id_token: 'id_789',
-        expires_in: 3600,
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          access_token: 'at_after_pending',
+          refresh_token: 'rt_after_pending',
+          expires_in: 3600,
+        }),
       };
+    };
 
-      vi.stubGlobal('fetch', async () => {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            ok: false,
-            status: 400,
-            json: async () => ({ error: 'slow_down' }),
-          };
-        }
+    const result = await pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01,
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
+
+    expect(callCount).toBe(3);
+    expect(result.access_token).toBe('at_after_pending');
+  });
+
+  it('increases interval on slow_down', async () => {
+    // We verify slow_down handling by checking that:
+    // 1. The function doesn't throw on slow_down
+    // 2. It eventually returns the token
+    // 3. The number of calls is correct
+    // We use a tiny initial interval and mock setTimeout behavior
+    let callCount = 0;
+
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount === 1) {
         return {
-          ok: true,
-          status: 200,
-          json: async () => tokenData,
+          ok: false, status: 400,
+          json: async () => ({ error: 'slow_down' }),
         };
-      });
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          access_token: 'at_slowed',
+          expires_in: 3600,
+        }),
+      };
+    };
 
-      // Use fake timers to avoid waiting 5+ real seconds
-      vi.useFakeTimers();
-      const promise = pollForToken(
-        'https://auth.example.com/token',
-        'device_code_abc',
-        'monocle-cli',
-        0.01,
-        30,
-      );
+    // Use vi.useFakeTimers to avoid actually waiting 5 seconds
+    vi.useFakeTimers();
 
-      // Advance past first interval (0.01s)
-      await vi.advanceTimersByTimeAsync(100);
-      // After slow_down, interval becomes 5.01s — advance past it
-      await vi.advanceTimersByTimeAsync(6000);
+    const resultPromise = pollForToken(
+      'https://test.stark.com/oauth/token',
+      'dev_code',
+      0.01, // initial interval: 10ms
+      600,
+      'monocle-cli',
+      mockFetch as any,
+    );
 
-      const result = await promise;
-      vi.useRealTimers();
+    // First sleep: 10ms (initial interval)
+    await vi.advanceTimersByTimeAsync(10);
+    // After slow_down, interval becomes 5.01s. Second sleep: 5010ms
+    await vi.advanceTimersByTimeAsync(5100);
 
-      expect(result).toEqual(tokenData);
-      expect(callCount).toBe(2);
+    const result = await resultPromise;
+
+    expect(callCount).toBe(2);
+    expect(result.access_token).toBe('at_slowed');
+
+    vi.useRealTimers();
+  });
+
+  it('throws on expired_token', async () => {
+    const mockFetch = async () => ({
+      ok: false, status: 400,
+      json: async () => ({ error: 'expired_token' }),
     });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow('Device code expired');
+  });
+
+  it('throws on access_denied', async () => {
+    const mockFetch = async () => ({
+      ok: false, status: 400,
+      json: async () => ({ error: 'access_denied' }),
+    });
+
+    await expect(
+      pollForToken(
+        'https://test.stark.com/oauth/token',
+        'dev_code',
+        0.01,
+        600,
+        'monocle-cli',
+        mockFetch as any,
+      ),
+    ).rejects.toThrow('Authorization request was denied');
   });
 });

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -1,7 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loginCommand } from '../commands/login';
 import { Credentials, CredentialsData } from '../credentials';
 import * as http from 'http';
+
+// These tests exercise the browser flow. Make sure the environment doesn't
+// trigger headless auto-detection (SSH, Emacs, CI, linux-without-DISPLAY).
+const originalEnv = { ...process.env };
+beforeEach(() => {
+  delete process.env.SSH_CLIENT;
+  delete process.env.SSH_TTY;
+  delete process.env.SSH_CONNECTION;
+  delete process.env.INSIDE_EMACS;
+  delete process.env.CI;
+  process.env.DISPLAY = ':0';
+});
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
 
 function createMockCredentials() {
   let stored: CredentialsData | null = null;

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -58,6 +58,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: createMockFetch() as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           capturedAuthUrl = url;
           // Simulate callback
@@ -141,6 +142,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: mockFetch as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           const urlObj = new URL(url);
           const redirectUri = urlObj.searchParams.get('redirect_uri')!;
@@ -170,6 +172,7 @@ describe('loginCommand', () => {
       {
         credentials: instance,
         fetch: createMockFetch() as any,
+        skipSetup: true,
         openBrowser: async (url: string) => {
           const urlObj = new URL(url);
           const redirectUri = urlObj.searchParams.get('redirect_uri')!;

--- a/src/__tests__/unset.test.ts
+++ b/src/__tests__/unset.test.ts
@@ -22,7 +22,7 @@ describe('unsetCommand', () => {
     expect(settings.otherSetting).toBe('keep');
     expect(settings.env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(settings.env.OTHER_VAR).toBe('keep');
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 
@@ -55,7 +55,7 @@ describe('unsetCommand', () => {
       writeFileSync: () => {},
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 
@@ -69,7 +69,7 @@ describe('unsetCommand', () => {
       writeFileSync: () => {},
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Monocle configuration removed'));
     stderrSpy.mockRestore();
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,7 @@ model
 model
   .command('chat')
   .description('Chat with LLM via Monocle router (interactive REPL or pipe from stdin)')
-  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-5-20250514')
+  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-6')
   .option('--system-prompt <text>', 'System prompt text')
   .option('--system-prompt-file <path>', 'Load system prompt from file')
   .option('--max-tokens <n>', 'Maximum output tokens', '4096')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,12 +10,14 @@ import { claudeCommand } from './commands/claude';
 import { chatCommand } from './commands/chat';
 import { modelListCommand } from './commands/model-list';
 
+const { version } = require('../package.json') as { version: string };
+
 const program = new Command();
 
 program
   .name('monocle')
   .description('CLI authentication tool for Claude Code with Stark OIDC integration')
-  .version('0.4.1');
+  .version(version);
 
 program
   .command('login')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,9 +20,10 @@ program
   .description('Authenticate with Stark OIDC provider')
   .option('--tenant <domain>', 'Stark tenant domain (e.g., example.monocle-ai.com)')
   .option('--env <environment>', 'Environment: prod, stg, local (default: prod)', 'prod')
+  .option('--device-code', 'Use Device Authorization Grant (for headless/SSH environments)')
   .action(async (options) => {
     try {
-      await loginCommand({ tenantDomain: options.tenant, env: options.env });
+      await loginCommand({ tenantDomain: options.tenant, env: options.env, deviceCode: options.deviceCode });
     } catch (err: any) {
       process.stderr.write(`Error: ${err.message}\n`);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import { setupCommand } from './commands/setup';
 import { unsetCommand } from './commands/unset';
 import { statusCommand } from './commands/status';
 import { claudeCommand } from './commands/claude';
+import { chatCommand } from './commands/chat';
+import { modelListCommand } from './commands/model-list';
 
 const program = new Command();
 
@@ -85,6 +87,38 @@ program
   .action(async (_options, cmd) => {
     try {
       await claudeCommand(cmd.args);
+    } catch (err: any) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    }
+  });
+
+const model = program
+  .command('model')
+  .description('Manage and interact with LLM models');
+
+model
+  .command('list')
+  .description('List available models from the Monocle router')
+  .action(async () => {
+    try {
+      await modelListCommand();
+    } catch (err: any) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    }
+  });
+
+model
+  .command('chat')
+  .description('Chat with LLM via Monocle router (interactive REPL or pipe from stdin)')
+  .option('--model <model>', 'Model ID to use', 'claude-sonnet-4-5-20250514')
+  .option('--system-prompt <text>', 'System prompt text')
+  .option('--system-prompt-file <path>', 'Load system prompt from file')
+  .option('--max-tokens <n>', 'Maximum output tokens', '4096')
+  .action(async (options) => {
+    try {
+      await chatCommand(options);
     } catch (err: any) {
       process.stderr.write(`Error: ${err.message}\n`);
       process.exit(1);

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny ANSI color helper. No dependencies.
+ *
+ * Honors NO_COLOR (https://no-color.org) and only colorizes when stderr is a TTY.
+ * Tone choices follow brew / gh CLI: muted, no neon. Cyan for accents, green for
+ * success, yellow for warnings, dim for hints.
+ */
+
+function colorEnabled(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR) return true;
+  return Boolean(process.stderr.isTTY);
+}
+
+function wrap(open: string, close: string): (s: string) => string {
+  return (s: string) => (colorEnabled() ? `\x1b[${open}m${s}\x1b[${close}m` : s);
+}
+
+export const c = {
+  bold: wrap('1', '22'),
+  dim: wrap('2', '22'),
+  green: wrap('32', '39'),
+  yellow: wrap('33', '39'),
+  cyan: wrap('36', '39'),
+  red: wrap('31', '39'),
+};

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -21,7 +21,7 @@ export interface ChatDeps {
 }
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
-const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const DEFAULT_MAX_TOKENS = 4096;
 
 async function getAccessToken(

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,0 +1,204 @@
+import * as fs from 'fs';
+import * as readline from 'readline';
+import { Credentials } from '../credentials';
+import { refreshAccessToken, RefreshDeps } from '../refresh';
+
+export interface ChatOptions {
+  model?: string;
+  systemPrompt?: string;
+  systemPromptFile?: string;
+  maxTokens?: string;
+}
+
+export interface ChatDeps {
+  credentials?: Credentials;
+  refreshDeps?: RefreshDeps;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+}
+
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
+const DEFAULT_MAX_TOKENS = 4096;
+
+async function getAccessToken(
+  credentials: Credentials,
+  deps?: ChatDeps,
+): Promise<{ token: string; routerUrl: string }> {
+  const now = deps?.now ?? (() => new Date());
+  const stderr = deps?.stderr ?? process.stderr;
+
+  const creds = credentials.read();
+  if (!creds) {
+    stderr.write('Not logged in. Run `monocle login --tenant <domain>` first.\n');
+    process.exit(1);
+  }
+
+  let activeCreds = creds;
+  const expiresAt = new Date(creds.access_token_expires_at).getTime();
+  if (now().getTime() + EXPIRY_BUFFER_MS > expiresAt) {
+    const result = await refreshAccessToken(creds, {
+      credentials,
+      ...deps?.refreshDeps,
+    });
+    if (!result.success || !result.credentials) {
+      stderr.write(`Token refresh failed: ${result.error}\n`);
+      process.exit(1);
+    }
+    activeCreds = result.credentials;
+  }
+
+  let routerUrl: string;
+  if (activeCreds.router_url) {
+    routerUrl = activeCreds.router_url;
+  } else {
+    const isLocal =
+      activeCreds.tenant_domain.startsWith('localhost') ||
+      activeCreds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${activeCreds.tenant_domain}`;
+  }
+
+  return { token: activeCreds.access_token, routerUrl };
+}
+
+async function callChat(
+  routerUrl: string,
+  token: string,
+  model: string,
+  systemPrompt: string | undefined,
+  userMessage: string,
+  maxTokens: number,
+  deps?: ChatDeps,
+): Promise<string> {
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  const messages: Array<{ role: string; content: string }> = [];
+  if (systemPrompt) {
+    messages.push({ role: 'system', content: systemPrompt });
+  }
+  messages.push({ role: 'user', content: userMessage });
+
+  const response = await fetchFn(`${routerUrl}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: maxTokens,
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as any;
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+export async function chatCommand(
+  options: ChatOptions,
+  deps?: ChatDeps,
+): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const stdout = deps?.stdout ?? process.stdout;
+  const stderr = deps?.stderr ?? process.stderr;
+
+  const model = options.model ?? DEFAULT_MODEL;
+  const maxTokens = parseInt(options.maxTokens ?? String(DEFAULT_MAX_TOKENS), 10);
+
+  // Resolve system prompt
+  let systemPrompt: string | undefined;
+  if (options.systemPromptFile) {
+    if (!fs.existsSync(options.systemPromptFile)) {
+      stderr.write(`System prompt file not found: ${options.systemPromptFile}\n`);
+      process.exit(1);
+    }
+    systemPrompt = fs.readFileSync(options.systemPromptFile, 'utf-8');
+  } else if (options.systemPrompt) {
+    systemPrompt = options.systemPrompt;
+  }
+
+  // Get auth
+  const { token, routerUrl } = await getAccessToken(credentials, deps);
+
+  // Check if stdin is piped (non-interactive)
+  if (!process.stdin.isTTY) {
+    const input = await readStdin();
+    if (!input.trim()) {
+      stderr.write('No input provided via stdin.\n');
+      process.exit(1);
+    }
+    stderr.write(`Using model: ${model}\n`);
+    stderr.write(`Router: ${routerUrl}\n`);
+    const result = await callChat(routerUrl, token, model, systemPrompt, input.trim(), maxTokens, deps);
+    stdout.write(result);
+    stdout.write('\n');
+    return;
+  }
+
+  // Interactive REPL mode
+  stderr.write(`Monocle Chat (model: ${model})\n`);
+  stderr.write(`Router: ${routerUrl}\n`);
+  if (systemPrompt) {
+    stderr.write(`System prompt loaded (${systemPrompt.length} chars)\n`);
+  }
+  stderr.write('Type your message. Press Ctrl+D to exit.\n');
+  stderr.write('---\n');
+
+  const rl = readline.createInterface({
+    input: deps?.stdin ?? process.stdin,
+    output: deps?.stderr ?? process.stderr,
+    prompt: '> ',
+  });
+
+  rl.prompt();
+
+  rl.on('line', async (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      rl.prompt();
+      return;
+    }
+
+    if (trimmed === '/quit' || trimmed === '/exit') {
+      rl.close();
+      return;
+    }
+
+    try {
+      stderr.write('\n');
+      const result = await callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps);
+      stdout.write(result);
+      stdout.write('\n\n');
+    } catch (err: any) {
+      stderr.write(`Error: ${err.message}\n`);
+    }
+
+    rl.prompt();
+  });
+
+  rl.on('close', () => {
+    stderr.write('\nBye.\n');
+  });
+}

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -141,6 +141,28 @@ export async function chatCommand(
 
   // Get auth
   const { token, routerUrl } = await getAccessToken(credentials, deps);
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  // Validate model ID against available models
+  try {
+    const modelsResp = await fetchFn(`${routerUrl}/v1/models`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (modelsResp.ok) {
+      const modelsData = (await modelsResp.json()) as { data: Array<{ id: string }> };
+      const availableIds = modelsData.data.map((m) => m.id);
+      if (!availableIds.includes(model)) {
+        stderr.write(`Error: Model "${model}" not found.\n`);
+        stderr.write(`Available models:\n`);
+        for (const id of availableIds) {
+          stderr.write(`  ${id}\n`);
+        }
+        process.exit(1);
+      }
+    }
+  } catch {
+    // Non-fatal — proceed even if model list fails
+  }
 
   // Check if stdin is piped (non-interactive)
   if (!process.stdin.isTTY) {
@@ -174,7 +196,7 @@ export async function chatCommand(
 
   rl.prompt();
 
-  rl.on('line', async (line: string) => {
+  rl.on('line', (line: string) => {
     const trimmed = line.trim();
     if (!trimmed) {
       rl.prompt();
@@ -186,19 +208,29 @@ export async function chatCommand(
       return;
     }
 
-    try {
-      stderr.write('\n');
-      const result = await callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps);
-      stdout.write(result);
-      stdout.write('\n\n');
-    } catch (err: any) {
-      stderr.write(`Error: ${err.message}\n`);
-    }
+    // Pause input while waiting for API response
+    rl.pause();
+    stderr.write('\n');
 
-    rl.prompt();
+    callChat(routerUrl, token, model, systemPrompt, trimmed, maxTokens, deps)
+      .then((result) => {
+        stdout.write(result);
+        stdout.write('\n\n');
+      })
+      .catch((err: any) => {
+        stderr.write(`Error: ${err.message}\n\n`);
+      })
+      .finally(() => {
+        rl.resume();
+        rl.prompt();
+      });
   });
 
-  rl.on('close', () => {
-    stderr.write('\nBye.\n');
+  // Keep process alive until REPL closes
+  await new Promise<void>((resolve) => {
+    rl.on('close', () => {
+      stderr.write('\nBye.\n');
+      resolve();
+    });
   });
 }

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -9,6 +9,7 @@ export interface ClaudeDeps {
   credentials?: Credentials;
   env?: Record<string, string | undefined>;
   spawn?: typeof child_process.spawn;
+  skipSetup?: boolean;
 }
 
 export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<void> {
@@ -24,17 +25,19 @@ export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<
   }
 
   // Ensure Claude Code is configured (auto-setup if needed)
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-  let needsSetup = true;
-  try {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-    needsSetup = settings.apiKeyHelper !== 'monocle token';
-  } catch {
-    // File doesn't exist or invalid JSON
-  }
-  if (needsSetup) {
-    process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
-    await setupCommand();
+  if (!deps?.skipSetup) {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    let needsSetup = true;
+    try {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      needsSetup = settings.apiKeyHelper !== 'monocle token';
+    } catch {
+      // File doesn't exist or invalid JSON
+    }
+    if (needsSetup) {
+      process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
+      await setupCommand();
+    }
   }
 
   // Build clean env — remove vars that override apiKeyHelper

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -1,15 +1,10 @@
 import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import { Credentials } from '../credentials';
-import { setupCommand } from './setup';
 
 export interface ClaudeDeps {
   credentials?: Credentials;
   env?: Record<string, string | undefined>;
   spawn?: typeof child_process.spawn;
-  skipSetup?: boolean;
 }
 
 export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<void> {
@@ -24,39 +19,31 @@ export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<
     return;
   }
 
-  // Ensure Claude Code is configured (auto-setup if needed)
-  if (!deps?.skipSetup) {
-    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-    let needsSetup = true;
-    try {
-      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      needsSetup = settings.apiKeyHelper !== 'monocle token';
-    } catch {
-      // File doesn't exist or invalid JSON
-    }
-    if (needsSetup) {
-      process.stderr.write('Claude Code not configured for Monocle. Running setup...\n');
-      await setupCommand();
-    }
+  // Resolve router URL (base URL for the Chat Proxy)
+  let routerUrl: string;
+  if (creds.router_url) {
+    routerUrl = creds.router_url;
+  } else {
+    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${creds.tenant_domain}`;
   }
 
-  // Build clean env — remove vars that override apiKeyHelper
+  // Inline settings scoped to this child only — avoids mutating ~/.claude/settings.json.
+  // `apiKeyHelper` keeps tokens fresh across long sessions by re-invoking `monocle token`.
+  const inlineSettings = JSON.stringify({
+    apiKeyHelper: 'monocle token',
+  });
+
+  // Build child env — strip conflicting vars, inject base URL.
   const childEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
     if (value !== undefined && key !== 'ANTHROPIC_API_KEY' && key !== 'ANTHROPIC_AUTH_TOKEN') {
       childEnv[key] = value;
     }
   }
+  childEnv.ANTHROPIC_BASE_URL = routerUrl;
 
-  // Set base URL to Chat Proxy
-  if (creds.router_url) {
-    childEnv.ANTHROPIC_BASE_URL = creds.router_url;
-  } else {
-    const isLocal = creds.tenant_domain.startsWith('localhost') || creds.tenant_domain.startsWith('127.0.0.1');
-    childEnv.ANTHROPIC_BASE_URL = `${isLocal ? 'http' : 'https'}://${creds.tenant_domain}`;
-  }
-
-  const child = spawnFn('claude', args, {
+  const child = spawnFn('claude', ['--settings', inlineSettings, ...args], {
     env: childEnv,
     stdio: 'inherit',
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,6 +12,7 @@ const REFRESH_TOKEN_TTL_DAYS = 30;
 export interface LoginOptions {
   tenantDomain?: string;
   env?: string;
+  deviceCode?: boolean;
 }
 
 export interface LoginDeps {
@@ -39,7 +40,159 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function pollForToken(
+  tokenEndpoint: string,
+  deviceCode: string,
+  clientId: string,
+  interval: number,
+  expiresIn: number,
+): Promise<{access_token: string; refresh_token: string; id_token: string; expires_in: number}> {
+  const deadline = Date.now() + expiresIn * 1000;
+
+  while (Date.now() < deadline) {
+    await sleep(interval * 1000);
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: clientId,
+    });
+
+    const response = await globalThis.fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (response.ok) {
+      return await response.json() as any;
+    }
+
+    const error = await response.json() as any;
+
+    switch (error.error) {
+      case 'authorization_pending':
+        process.stderr.write('.');
+        continue;
+      case 'slow_down':
+        interval += 5;
+        continue;
+      case 'expired_token':
+        throw new Error('인증 시간이 만료되었습니다.');
+      case 'access_denied':
+        throw new Error('인증이 거부되었습니다.');
+      default:
+        throw new Error(error.error_description || error.error);
+    }
+  }
+
+  throw new Error('인증 시간이 만료되었습니다.');
+}
+
+async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): Promise<void> {
+  const credentials = new Credentials();
+
+  // Resolve Stark domain + discover OIDC
+  const env = options.env ?? 'prod';
+  const starkDomain = options.tenantDomain
+    ? resolveStarkDomain(options.tenantDomain)
+    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
+  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  const oidc = await discoverOIDC(starkDomain);
+
+  if (!oidc.device_authorization_endpoint) {
+    throw new Error('이 OIDC 프로바이더는 Device Authorization Grant를 지원하지 않습니다.');
+  }
+
+  // Request device code
+  const body = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+  });
+
+  const deviceResponse = await globalThis.fetch(oidc.device_authorization_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  if (!deviceResponse.ok) {
+    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
+  }
+
+  const deviceData = await deviceResponse.json() as any;
+  const { device_code, user_code, verification_uri, expires_in, interval } = deviceData;
+
+  process.stderr.write(`\n아래 URL을 브라우저에서 열고 코드를 입력하세요:\n`);
+  process.stderr.write(`  URL:  ${verification_uri}\n`);
+  process.stderr.write(`  코드: ${user_code}\n\n`);
+  process.stderr.write(`인증 대기 중`);
+
+  // Poll for token
+  const tokenData = await pollForToken(
+    oidc.token_endpoint,
+    device_code,
+    CLIENT_ID,
+    interval ?? 5,
+    expires_in ?? 600,
+  );
+
+  process.stderr.write('\n');
+
+  // Decode ID token
+  let email = 'unknown';
+  let tenantDomain = options.tenantDomain ?? '';
+  let tenantName = tenantDomain;
+  if (tokenData.id_token) {
+    try {
+      const payload = decodeIdTokenPayload(tokenData.id_token);
+      email = payload.email ?? 'unknown';
+      tenantDomain = payload.tenant_domain ?? tenantDomain;
+      tenantName = payload.tenant_name ?? tenantDomain;
+    } catch {
+      // Use defaults
+    }
+  }
+
+  // Save credentials
+  const now = new Date();
+  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
+  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  const creds: CredentialsData = {
+    tenant_domain: tenantDomain,
+    tenant_name: tenantName,
+    email,
+    access_token: tokenData.access_token,
+    refresh_token: tokenData.refresh_token ?? '',
+    id_token: tokenData.id_token ?? '',
+    access_token_expires_at: accessTokenExpiresAt.toISOString(),
+    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+    router_url: oidc.router_url,
+  };
+
+  credentials.write(creds);
+
+  process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
+
+  // Auto-setup Claude Code
+  process.stderr.write('\nConfiguring Claude Code...\n');
+  setupCommand().catch(() => {
+    process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+  });
+}
+
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
+  // Headless detection
+  const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
+  if (isHeadless) {
+    return deviceCodeLogin(options);
+  }
+
   const credentials = deps?.credentials ?? new Credentials();
   const fetchFn = deps?.fetch ?? globalThis.fetch;
   const openBrowser = deps?.openBrowser ?? defaultOpenBrowser;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import { Credentials, CredentialsData } from '../credentials';
 import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain, STARK_DOMAINS, OIDCDeps } from '../oidc';
 import { decodeIdTokenPayload } from '../refresh';
 import { setupCommand } from './setup';
+import { c } from '../colors';
 
 const CLIENT_ID = 'monocle-cli';
 const SCOPES = 'openid profile email';
@@ -99,7 +100,7 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
   const starkDomain = options.tenantDomain
     ? resolveStarkDomain(options.tenantDomain)
     : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  process.stderr.write(`${c.dim(`Discovering OIDC configuration for ${starkDomain}...`)}\n`);
   const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
 
   // Step 2: Generate PKCE + state
@@ -227,13 +228,13 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
           server.close();
 
           // Step 11: Terminal output
-          process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
+          process.stderr.write(`${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
 
           // Step 12: Auto-setup Claude Code
           if (!deps?.skipSetup) {
-            process.stderr.write('\nConfiguring Claude Code...\n');
+            process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
             setupCommand().catch(() => {
-              process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+              process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
             });
           }
 
@@ -408,7 +409,7 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
   const starkDomain = options.tenantDomain
     ? resolveStarkDomain(options.tenantDomain)
     : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  process.stderr.write(`${c.dim(`Discovering OIDC configuration for ${starkDomain}...`)}\n`);
   const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
 
   if (!oidc.device_authorization_endpoint) {
@@ -438,13 +439,13 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
 
   // Step 3: Display verification instructions
   process.stderr.write('\n');
-  process.stderr.write('To authenticate, visit the following URL in a browser:\n\n');
-  process.stderr.write(`  ${deviceData.verification_uri}\n\n`);
-  process.stderr.write(`Enter the code: ${deviceData.user_code}\n\n`);
+  process.stderr.write(`${c.bold('To authenticate, visit:')}\n\n`);
+  process.stderr.write(`  ${c.cyan(deviceData.verification_uri)}\n\n`);
+  process.stderr.write(`  ${c.dim('Code:')} ${c.bold(deviceData.user_code)}\n\n`);
   if (deviceData.verification_uri_complete) {
-    process.stderr.write(`Or open this URL directly:\n  ${deviceData.verification_uri_complete}\n\n`);
+    process.stderr.write(`${c.dim('Or open this URL directly:')}\n  ${c.cyan(deviceData.verification_uri_complete)}\n\n`);
   }
-  process.stderr.write('Waiting for authorization...\n');
+  process.stderr.write(`${c.dim('Waiting for authorization...')}\n`);
 
   // Step 4: Poll for token
   const tokenData = await pollForToken(
@@ -488,13 +489,13 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
   };
 
   credentials.write(creds);
-  process.stderr.write(`\nLogged in as ${email} (${tenantName})\n`);
+  process.stderr.write(`\n${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
 
   // Auto-setup Claude Code
   if (!deps?.skipSetup) {
-    process.stderr.write('\nConfiguring Claude Code...\n');
+    process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
     setupCommand().catch(() => {
-      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+      process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
     });
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,7 +3,6 @@ import * as url from 'url';
 import { Credentials, CredentialsData } from '../credentials';
 import { generateCodeVerifier, generateCodeChallenge, generateState, discoverOIDC, resolveStarkDomain, STARK_DOMAINS, OIDCDeps } from '../oidc';
 import { decodeIdTokenPayload } from '../refresh';
-import { setupCommand } from './setup';
 import { c } from '../colors';
 
 const CLIENT_ID = 'monocle-cli';
@@ -26,7 +25,6 @@ export interface LoginDeps {
     close: (cb?: () => void) => void;
     address: () => { port: number } | null;
   };
-  skipSetup?: boolean;
   browserCallbackTimeoutMs?: number;
 }
 
@@ -229,14 +227,8 @@ async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promis
 
           // Step 11: Terminal output
           process.stderr.write(`${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
-
-          // Step 12: Auto-setup Claude Code
-          if (!deps?.skipSetup) {
-            process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
-            setupCommand().catch(() => {
-              process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
-            });
-          }
+          process.stderr.write(`\n${c.dim('Launch Claude Code through Monocle with:')} ${c.bold('monocle claude')}\n`);
+          process.stderr.write(`${c.dim('(To route plain')} ${c.bold('claude')} ${c.dim('globally through Monocle, run')} ${c.bold('monocle setup')}${c.dim('.)')}\n`);
 
           settle(() => resolve());
         })
@@ -490,12 +482,6 @@ async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise
 
   credentials.write(creds);
   process.stderr.write(`\n${c.green('✓')} Logged in as ${c.bold(email)} ${c.dim(`(${tenantName})`)}\n`);
-
-  // Auto-setup Claude Code
-  if (!deps?.skipSetup) {
-    process.stderr.write(`\n${c.dim('Configuring Claude Code...')}\n`);
-    setupCommand().catch(() => {
-      process.stderr.write(`${c.yellow('⚠')} Auto-setup failed. Run ${c.bold('monocle setup')} manually.\n`);
-    });
-  }
+  process.stderr.write(`\n${c.dim('Launch Claude Code through Monocle with:')} ${c.bold('monocle claude')}\n`);
+  process.stderr.write(`${c.dim('(To route plain')} ${c.bold('claude')} ${c.dim('globally through Monocle, run')} ${c.bold('monocle setup')}${c.dim('.)')}\n`);
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -8,6 +8,7 @@ import { setupCommand } from './setup';
 const CLIENT_ID = 'monocle-cli';
 const SCOPES = 'openid profile email';
 const REFRESH_TOKEN_TTL_DAYS = 30;
+const BROWSER_CALLBACK_TIMEOUT_MS = 90_000;
 
 export interface LoginOptions {
   tenantDomain?: string;
@@ -25,6 +26,7 @@ export interface LoginDeps {
     address: () => { port: number } | null;
   };
   skipSetup?: boolean;
+  browserCallbackTimeoutMs?: number;
 }
 
 const SUCCESS_HTML = `<!DOCTYPE html>
@@ -41,16 +43,56 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
+/**
+ * Internal sentinel indicating the browser flow is unavailable in this environment
+ * and the caller should fall back to device code. Not a real user-visible error.
+ */
+class BrowserFlowUnavailableError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'BrowserFlowUnavailableError';
+  }
+}
+
+/**
+ * Detect environments where a local browser almost certainly cannot be used:
+ * SSH, Emacs inner shell, CI, and Linux console without DISPLAY.
+ * When any of these fire, skip browser flow entirely and go to device code.
+ */
+function detectHeadless(options: LoginOptions): boolean {
+  if (options.deviceCode) return true;
+  if (process.env.SSH_CLIENT || process.env.SSH_TTY || process.env.SSH_CONNECTION) return true;
+  if (process.env.INSIDE_EMACS) return true;
+  if (process.env.CI) return true;
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return true;
+  return false;
+}
+
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
-  const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
-  if (isHeadless) {
+  if (detectHeadless(options)) {
     return deviceCodeLogin(options, deps);
   }
 
+  // Ambiguous environment: try browser flow, fall back to device code if:
+  //   - openBrowser exec fails (command not found, non-zero exit)
+  //   - callback not received within BROWSER_CALLBACK_TIMEOUT_MS
+  try {
+    return await browserCodeLogin(options, deps);
+  } catch (err) {
+    if (err instanceof BrowserFlowUnavailableError) {
+      process.stderr.write(`\nBrowser flow unavailable: ${err.message}\nFalling back to device code...\n\n`);
+      return deviceCodeLogin(options, deps);
+    }
+    throw err;
+  }
+}
+
+async function browserCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise<void> {
   const credentials = deps?.credentials ?? new Credentials();
   const fetchFn = deps?.fetch ?? globalThis.fetch;
   const openBrowser = deps?.openBrowser ?? defaultOpenBrowser;
   const createServerFn = deps?.createServer ?? ((handler: any) => http.createServer(handler) as any);
+  const timeoutMs = deps?.browserCallbackTimeoutMs ?? BROWSER_CALLBACK_TIMEOUT_MS;
 
   // Step 1: OIDC Discovery
   const env = options.env ?? 'prod';
@@ -67,6 +109,16 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
 
   // Step 3: Start local HTTP server on random port
   return new Promise<void>((resolve, reject) => {
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      fn();
+    };
+
     const server = createServerFn((req: http.IncomingMessage, res: http.ServerResponse) => {
       const parsed = url.parse(req.url ?? '', true);
 
@@ -83,7 +135,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML(String(query.error_description || query.error)));
         server.close();
-        reject(new Error(`Authorization failed: ${query.error_description || query.error}`));
+        settle(() => reject(new Error(`Authorization failed: ${query.error_description || query.error}`)));
         return;
       }
 
@@ -92,7 +144,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('State mismatch - possible CSRF attack'));
         server.close();
-        reject(new Error('State mismatch - possible CSRF attack'));
+        settle(() => reject(new Error('State mismatch - possible CSRF attack')));
         return;
       }
 
@@ -101,7 +153,7 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('No authorization code received'));
         server.close();
-        reject(new Error('No authorization code received'));
+        settle(() => reject(new Error('No authorization code received')));
         return;
       }
 
@@ -185,13 +237,13 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
             });
           }
 
-          resolve();
+          settle(() => resolve());
         })
         .catch((err: Error) => {
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.end(ERROR_HTML(err.message));
           server.close();
-          reject(err);
+          settle(() => reject(err));
         });
     });
 
@@ -219,8 +271,20 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
       process.stderr.write(`Opening browser for authentication...\n`);
       process.stderr.write(`If the browser doesn't open, visit: ${authUrl}\n`);
 
-      openBrowser(authUrl).catch(() => {
-        // Browser open failed, URL already printed above
+      // Timeout: no callback → browser flow isn't working, signal fallback
+      timeoutHandle = setTimeout(() => {
+        server.close();
+        settle(() => reject(new BrowserFlowUnavailableError(
+          `no callback received within ${Math.round(timeoutMs / 1000)}s`
+        )));
+      }, timeoutMs);
+
+      // If opening the browser fails at the OS level, signal fallback immediately
+      openBrowser(authUrl).catch((err: Error) => {
+        server.close();
+        settle(() => reject(new BrowserFlowUnavailableError(
+          `failed to launch browser: ${err.message}`
+        )));
       });
     });
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -296,7 +296,20 @@ export async function pollForToken(
       return await response.json() as TokenResponse;
     }
 
-    const errorData = await response.json().catch(() => ({ error: 'unknown' }));
+    // Clone so we can fall back to text() for diagnostic if json() fails
+    // (real Response body can only be read once — see whatwg/fetch)
+    const cloned = (response as any).clone?.() ?? response;
+    let rawBody = '';
+    let errorData: { error?: string; error_description?: string } = {};
+    try {
+      errorData = await response.json();
+    } catch {
+      try {
+        rawBody = await (cloned as any).text?.() ?? '';
+      } catch {
+        // Body unavailable
+      }
+    }
     const error = errorData.error;
 
     if (error === 'authorization_pending') {
@@ -308,8 +321,14 @@ export async function pollForToken(
       throw new Error('Device code expired. Please run login again.');
     } else if (error === 'access_denied') {
       throw new Error('Authorization request was denied by the user.');
-    } else {
+    } else if (error) {
       throw new Error(`Token polling failed: ${error} - ${errorData.error_description ?? ''}`);
+    } else {
+      const snippet = rawBody.slice(0, 200).replace(/\s+/g, ' ').trim();
+      throw new Error(
+        `Token polling failed: server returned HTTP ${response.status} with non-OAuth response. ` +
+        `Body: ${snippet || '(empty)'}`
+      );
     }
   }
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -41,156 +41,7 @@ const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
 h1{color:#ef4444;margin-bottom:0.5rem}p{color:#6b7280}</style></head>
 <body><div class="card"><h1>✗ Authentication Failed</h1><p>${msg}</p></div></body></html>`;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function pollForToken(
-  tokenEndpoint: string,
-  deviceCode: string,
-  clientId: string,
-  interval: number,
-  expiresIn: number,
-): Promise<{access_token: string; refresh_token: string; id_token: string; expires_in: number}> {
-  const deadline = Date.now() + expiresIn * 1000;
-
-  while (Date.now() < deadline) {
-    await sleep(interval * 1000);
-
-    const body = new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-      device_code: deviceCode,
-      client_id: clientId,
-    });
-
-    const response = await globalThis.fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body.toString(),
-    });
-
-    if (response.ok) {
-      return await response.json() as any;
-    }
-
-    const error = await response.json() as any;
-
-    switch (error.error) {
-      case 'authorization_pending':
-        process.stderr.write('.');
-        continue;
-      case 'slow_down':
-        interval += 5;
-        continue;
-      case 'expired_token':
-        throw new Error('인증 시간이 만료되었습니다.');
-      case 'access_denied':
-        throw new Error('인증이 거부되었습니다.');
-      default:
-        throw new Error(error.error_description || error.error);
-    }
-  }
-
-  throw new Error('인증 시간이 만료되었습니다.');
-}
-
-async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}, deps?: LoginDeps): Promise<void> {
-  const credentials = new Credentials();
-
-  // Resolve Stark domain + discover OIDC
-  const env = options.env ?? 'prod';
-  const starkDomain = options.tenantDomain
-    ? resolveStarkDomain(options.tenantDomain)
-    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
-  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
-  const oidc = await discoverOIDC(starkDomain);
-
-  if (!oidc.device_authorization_endpoint) {
-    throw new Error('이 OIDC 프로바이더는 Device Authorization Grant를 지원하지 않습니다.');
-  }
-
-  // Request device code
-  const body = new URLSearchParams({
-    client_id: CLIENT_ID,
-    scope: SCOPES,
-  });
-
-  const deviceResponse = await globalThis.fetch(oidc.device_authorization_endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-  });
-
-  if (!deviceResponse.ok) {
-    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
-  }
-
-  const deviceData = await deviceResponse.json() as any;
-  const { device_code, user_code, verification_uri, expires_in, interval } = deviceData;
-
-  process.stderr.write(`\n아래 URL을 브라우저에서 열고 코드를 입력하세요:\n`);
-  process.stderr.write(`  URL:  ${verification_uri}\n`);
-  process.stderr.write(`  코드: ${user_code}\n\n`);
-  process.stderr.write(`인증 대기 중`);
-
-  // Poll for token
-  const tokenData = await pollForToken(
-    oidc.token_endpoint,
-    device_code,
-    CLIENT_ID,
-    interval ?? 5,
-    expires_in ?? 600,
-  );
-
-  process.stderr.write('\n');
-
-  // Decode ID token
-  let email = 'unknown';
-  let tenantDomain = options.tenantDomain ?? '';
-  let tenantName = tenantDomain;
-  if (tokenData.id_token) {
-    try {
-      const payload = decodeIdTokenPayload(tokenData.id_token);
-      email = payload.email ?? 'unknown';
-      tenantDomain = payload.tenant_domain ?? tenantDomain;
-      tenantName = payload.tenant_name ?? tenantDomain;
-    } catch {
-      // Use defaults
-    }
-  }
-
-  // Save credentials
-  const now = new Date();
-  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
-  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
-
-  const creds: CredentialsData = {
-    tenant_domain: tenantDomain,
-    tenant_name: tenantName,
-    email,
-    access_token: tokenData.access_token,
-    refresh_token: tokenData.refresh_token ?? '',
-    id_token: tokenData.id_token ?? '',
-    access_token_expires_at: accessTokenExpiresAt.toISOString(),
-    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
-    router_url: oidc.router_url,
-  };
-
-  credentials.write(creds);
-
-  process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
-
-  // Auto-setup Claude Code
-  if (!deps?.skipSetup) {
-    process.stderr.write('\nConfiguring Claude Code...\n');
-    setupCommand().catch(() => {
-      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-    });
-  }
-}
-
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
-  // Headless detection
   const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
   if (isHeadless) {
     return deviceCodeLogin(options, deps);
@@ -392,4 +243,175 @@ async function defaultOpenBrowser(url: string): Promise<void> {
       else resolve();
     });
   });
+}
+
+export interface DeviceAuthResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function pollForToken(
+  tokenEndpoint: string,
+  deviceCode: string,
+  interval: number,
+  expiresIn: number,
+  clientId: string,
+  fetchFn: (url: string, init?: any) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>,
+): Promise<TokenResponse> {
+  const deadline = Date.now() + expiresIn * 1000;
+  let currentInterval = interval;
+
+  while (Date.now() < deadline) {
+    await sleep(currentInterval * 1000);
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: clientId,
+    });
+
+    const response = await fetchFn(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (response.ok) {
+      return await response.json() as TokenResponse;
+    }
+
+    const errorData = await response.json().catch(() => ({ error: 'unknown' }));
+    const error = errorData.error;
+
+    if (error === 'authorization_pending') {
+      continue;
+    } else if (error === 'slow_down') {
+      currentInterval += 5;
+      continue;
+    } else if (error === 'expired_token') {
+      throw new Error('Device code expired. Please run login again.');
+    } else if (error === 'access_denied') {
+      throw new Error('Authorization request was denied by the user.');
+    } else {
+      throw new Error(`Token polling failed: ${error} - ${errorData.error_description ?? ''}`);
+    }
+  }
+
+  throw new Error('Device code expired. Please run login again.');
+}
+
+async function deviceCodeLogin(options: LoginOptions, deps?: LoginDeps): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+
+  // Step 1: OIDC Discovery
+  const env = options.env ?? 'prod';
+  const starkDomain = options.tenantDomain
+    ? resolveStarkDomain(options.tenantDomain)
+    : STARK_DOMAINS[env] ?? STARK_DOMAINS.prod;
+  process.stderr.write(`Discovering OIDC configuration for ${starkDomain}...\n`);
+  const oidc = await discoverOIDC(starkDomain, { fetch: fetchFn } as OIDCDeps);
+
+  if (!oidc.device_authorization_endpoint) {
+    throw new Error(
+      'This OIDC provider does not support the Device Authorization Grant. ' +
+      'Remove --device-code flag or use a browser-capable environment.'
+    );
+  }
+
+  // Step 2: Request device code
+  const deviceBody = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+  });
+
+  const deviceResponse = await fetchFn(oidc.device_authorization_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: deviceBody.toString(),
+  });
+
+  if (!deviceResponse.ok) {
+    throw new Error(`Device authorization request failed (HTTP ${deviceResponse.status})`);
+  }
+
+  const deviceData: DeviceAuthResponse = await deviceResponse.json();
+
+  // Step 3: Display verification instructions
+  process.stderr.write('\n');
+  process.stderr.write('To authenticate, visit the following URL in a browser:\n\n');
+  process.stderr.write(`  ${deviceData.verification_uri}\n\n`);
+  process.stderr.write(`Enter the code: ${deviceData.user_code}\n\n`);
+  if (deviceData.verification_uri_complete) {
+    process.stderr.write(`Or open this URL directly:\n  ${deviceData.verification_uri_complete}\n\n`);
+  }
+  process.stderr.write('Waiting for authorization...\n');
+
+  // Step 4: Poll for token
+  const tokenData = await pollForToken(
+    oidc.token_endpoint,
+    deviceData.device_code,
+    deviceData.interval ?? 5,
+    deviceData.expires_in,
+    CLIENT_ID,
+    fetchFn,
+  );
+
+  // Step 5: Decode ID token and save credentials
+  let email = 'unknown';
+  let tenantDomain = options.tenantDomain ?? '';
+  let tenantName = tenantDomain;
+  if (tokenData.id_token) {
+    try {
+      const payload = decodeIdTokenPayload(tokenData.id_token);
+      email = payload.email ?? 'unknown';
+      tenantDomain = payload.tenant_domain ?? tenantDomain;
+      tenantName = payload.tenant_name ?? tenantDomain;
+    } catch {
+      // Use defaults
+    }
+  }
+
+  const now = new Date();
+  const accessTokenExpiresAt = new Date(now.getTime() + (tokenData.expires_in ?? 3600) * 1000);
+  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  const creds: CredentialsData = {
+    tenant_domain: tenantDomain,
+    tenant_name: tenantName,
+    email,
+    access_token: tokenData.access_token,
+    refresh_token: tokenData.refresh_token ?? '',
+    id_token: tokenData.id_token ?? '',
+    access_token_expires_at: accessTokenExpiresAt.toISOString(),
+    refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+    router_url: oidc.router_url,
+  };
+
+  credentials.write(creds);
+  process.stderr.write(`\nLogged in as ${email} (${tenantName})\n`);
+
+  // Auto-setup Claude Code
+  if (!deps?.skipSetup) {
+    process.stderr.write('\nConfiguring Claude Code...\n');
+    setupCommand().catch(() => {
+      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+    });
+  }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -24,6 +24,7 @@ export interface LoginDeps {
     close: (cb?: () => void) => void;
     address: () => { port: number } | null;
   };
+  skipSetup?: boolean;
 }
 
 const SUCCESS_HTML = `<!DOCTYPE html>
@@ -93,7 +94,7 @@ export async function pollForToken(
   throw new Error('인증 시간이 만료되었습니다.');
 }
 
-async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): Promise<void> {
+async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}, deps?: LoginDeps): Promise<void> {
   const credentials = new Credentials();
 
   // Resolve Stark domain + discover OIDC
@@ -180,17 +181,19 @@ async function deviceCodeLogin(options: {tenantDomain?: string; env?: string}): 
   process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
 
   // Auto-setup Claude Code
-  process.stderr.write('\nConfiguring Claude Code...\n');
-  setupCommand().catch(() => {
-    process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-  });
+  if (!deps?.skipSetup) {
+    process.stderr.write('\nConfiguring Claude Code...\n');
+    setupCommand().catch(() => {
+      process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+    });
+  }
 }
 
 export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Promise<void> {
   // Headless detection
   const isHeadless = options.deviceCode || !!process.env.SSH_CLIENT || !!process.env.SSH_TTY || !!process.env.SSH_CONNECTION;
   if (isHeadless) {
-    return deviceCodeLogin(options);
+    return deviceCodeLogin(options, deps);
   }
 
   const credentials = deps?.credentials ?? new Credentials();
@@ -324,10 +327,12 @@ export async function loginCommand(options: LoginOptions, deps?: LoginDeps): Pro
           process.stderr.write(`Logged in as ${email} (${tenantName})\n`);
 
           // Step 12: Auto-setup Claude Code
-          process.stderr.write('\nConfiguring Claude Code...\n');
-          setupCommand().catch(() => {
-            process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
-          });
+          if (!deps?.skipSetup) {
+            process.stderr.write('\nConfiguring Claude Code...\n');
+            setupCommand().catch(() => {
+              process.stderr.write('Warning: Auto-setup failed. Run `monocle setup` manually.\n');
+            });
+          }
 
           resolve();
         })

--- a/src/commands/model-list.ts
+++ b/src/commands/model-list.ts
@@ -1,0 +1,91 @@
+import { Credentials } from '../credentials';
+import { refreshAccessToken, RefreshDeps } from '../refresh';
+
+export interface ModelListDeps {
+  credentials?: Credentials;
+  refreshDeps?: RefreshDeps;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+}
+
+interface ModelInfo {
+  id: string;
+  name?: string;
+  owned_by?: string;
+  context_window?: number;
+}
+
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+export async function modelListCommand(deps?: ModelListDeps): Promise<void> {
+  const credentials = deps?.credentials ?? new Credentials();
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+  const now = deps?.now ?? (() => new Date());
+
+  const creds = credentials.read();
+  if (!creds) {
+    process.stderr.write('Not logged in. Run `monocle login --tenant <domain>` first.\n');
+    process.exit(1);
+  }
+
+  let activeCreds = creds;
+  const expiresAt = new Date(creds.access_token_expires_at).getTime();
+  if (now().getTime() + EXPIRY_BUFFER_MS > expiresAt) {
+    const result = await refreshAccessToken(creds, {
+      credentials,
+      ...deps?.refreshDeps,
+    });
+    if (!result.success || !result.credentials) {
+      process.stderr.write(`Token refresh failed: ${result.error}\n`);
+      process.exit(1);
+    }
+    activeCreds = result.credentials;
+  }
+
+  let routerUrl: string;
+  if (activeCreds.router_url) {
+    routerUrl = activeCreds.router_url;
+  } else {
+    const isLocal =
+      activeCreds.tenant_domain.startsWith('localhost') ||
+      activeCreds.tenant_domain.startsWith('127.0.0.1');
+    routerUrl = `${isLocal ? 'http' : 'https'}://${activeCreds.tenant_domain}`;
+  }
+
+  const response = await fetchFn(`${routerUrl}/v1/models`, {
+    headers: {
+      Authorization: `Bearer ${activeCreds.access_token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as { data: ModelInfo[] };
+  const models = data.data ?? [];
+
+  if (models.length === 0) {
+    process.stderr.write('No models available.\n');
+    return;
+  }
+
+  // Table output
+  const idWidth = Math.max(10, ...models.map((m) => m.id.length));
+  const nameWidth = Math.max(6, ...models.map((m) => (m.name ?? '').length));
+
+  process.stdout.write(
+    `${'MODEL ID'.padEnd(idWidth)}  ${'NAME'.padEnd(nameWidth)}  ${'OWNER'.padEnd(10)}  CONTEXT\n`,
+  );
+  process.stdout.write(`${'─'.repeat(idWidth)}  ${'─'.repeat(nameWidth)}  ${'─'.repeat(10)}  ${'─'.repeat(9)}\n`);
+
+  for (const model of models) {
+    const ctx = model.context_window ? `${(model.context_window / 1000).toFixed(0)}k` : '-';
+    process.stdout.write(
+      `${model.id.padEnd(idWidth)}  ${(model.name ?? '').padEnd(nameWidth)}  ${(model.owned_by ?? '').padEnd(10)}  ${ctx}\n`,
+    );
+  }
+
+  process.stderr.write(`\n${models.length} model(s) available.\n`);
+}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { Credentials } from '../credentials';
+import { c } from '../colors';
 
 export interface SetupDeps {
   credentials?: Credentials;
@@ -67,14 +68,17 @@ export async function setupCommand(deps?: SetupDeps): Promise<void> {
   writeFileSyncFn(settingsPath, JSON.stringify(settings, null, 2));
 
   // Step 6: Success message
-  process.stderr.write('Claude Code configured to use Monocle authentication.\n');
-  process.stderr.write(`  apiKeyHelper: monocle token\n`);
-  process.stderr.write(`  ANTHROPIC_BASE_URL: ${routerUrl}\n`);
+  process.stderr.write(`${c.green('✓')} Claude Code configured to use Monocle authentication\n`);
+  process.stderr.write(`  ${c.dim('apiKeyHelper:')}       monocle token\n`);
+  process.stderr.write(`  ${c.dim('ANTHROPIC_BASE_URL:')} ${routerUrl}\n`);
 
   // Step 7: Warn about conflicting env vars
   const conflicting = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'].filter(k => env[k]);
   if (conflicting.length > 0) {
-    process.stderr.write(`\n⚠ Warning: ${conflicting.join(', ')} environment variable is set.\n`);
-    process.stderr.write('  Use `monocle claude` to launch Claude Code — it clears conflicting env vars automatically.\n');
+    process.stderr.write(`\n${c.yellow('⚠')} ${c.yellow(conflicting.join(', '))} environment variable is set.\n`);
+    process.stderr.write(`  Use ${c.bold('monocle claude')} to launch Claude Code — it clears conflicting env vars automatically.\n`);
   }
+
+  // Step 8: Tip — how to disconnect (red-family: signals undo/remove without alarm)
+  process.stderr.write(`\n${c.red(c.dim('To disconnect Claude Code from Monocle, run:'))} ${c.red(c.bold('monocle unset'))}\n`);
 }

--- a/src/commands/unset.ts
+++ b/src/commands/unset.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { c } from '../colors';
 
 export interface UnsetDeps {
   homedir?: () => string;
@@ -19,7 +20,7 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
   const settingsPath = path.join(homedir(), '.claude', 'settings.json');
 
   if (!existsSyncFn(settingsPath)) {
-    process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
     return;
   }
 
@@ -28,7 +29,7 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
     const content = readFileSyncFn(settingsPath, 'utf-8');
     settings = JSON.parse(content);
   } catch {
-    process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+    process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
     return;
   }
 
@@ -49,5 +50,5 @@ export async function unsetCommand(deps?: UnsetDeps): Promise<void> {
   writeFileSyncFn(settingsPath, JSON.stringify(settings, null, 2));
 
   // Step 5: Success message
-  process.stderr.write('Monocle configuration removed. Claude Code will use Anthropic directly.\n');
+  process.stderr.write(`${c.green('✓')} Monocle configuration removed. ${c.dim('Claude Code will use Anthropic directly.')}\n`);
 }

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -4,6 +4,7 @@ export interface OIDCConfig {
   issuer: string;
   authorization_endpoint: string;
   token_endpoint: string;
+  device_authorization_endpoint?: string;
   router_url?: string;
 }
 
@@ -111,6 +112,7 @@ export async function discoverOIDC(
     issuer: config.issuer,
     authorization_endpoint: config.authorization_endpoint,
     token_endpoint: config.token_endpoint,
+    device_authorization_endpoint: config.device_authorization_endpoint,
     router_url: config.router_url,
   };
 }


### PR DESCRIPTION
## 개요

devel에 누적된 20개 커밋을 main으로 병합한다. 주요 변경:

- 사용자 기능
  - Device Code 로그인 지원 (#16)
  - Model commands (#12/#13)
  - OpenAI SDK 가이드 (#17)
  - Claude isolated launch (#19)
- 배포 인프라
  - OIDC 기반 npm 자동 배포 파이프라인 (#20)
  - dry run job 분리 (#21)

## 다음 단계

이 PR 머지 후:
1. Actions에서 dry run 실행 → Environment 승인 없이 dry-run job만 실행되어야 함
2. 로그에서 OIDC 인증 + \`npm publish --dry-run\` 정상 확인
3. GitHub Release 작성 (v0.5.0, Target: main) → Publish
4. publish job이 Environment 승인 대기 → Approve → npm 실배포

## 검증

- 모든 커밋이 이미 devel 단계에서 CI 통과
- 로컬에서 lint/test/build 확인 완료 (75 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)