### PR TITLE
ci: Trusted Publishing을 위한 npm 최신 업그레이드

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm (Trusted Publishing requires 11.5.1+)
+        run: npm install -g npm@latest
+
       - name: Install
         run: npm ci
 
@@ -60,6 +63,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm (Trusted Publishing requires 11.5.1+)
+        run: npm install -g npm@latest
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
## 배경

v0.5.0 첫 실배포(#22 머지 후 release publish) 시 \`npm publish\`가 다음 에러로 반복 실패함:

\`\`\`
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@warmblood%2fmonocle-cli - Not found
npm error 404  '@warmblood/monocle-cli@0.5.0' is not in this registry.
\`\`\`

## 진단 과정에서 확인된 것

1. OIDC token 정상 발급 (Sigstore certificate의 SAN에 repo/workflow/environment claim 모두 올바르게 포함)
2. Sigstore transparency log에 provenance statement까지 성공적으로 기록
3. npm Trusted Publisher 설정 정상 (repo/workflow/environment 매칭)
4. Environment 필드 비우고 시도해도 동일 실패
5. TP 삭제 후 재등록해도 동일 실패

즉 OIDC, TP, Environment matching 모두 건강한 상태였음. 그런데도 registry PUT이 404로 거부됨.

## 근본 원인

[npm/cli#8730](https://github.com/npm/cli/issues/8730), [#8976](https://github.com/npm/cli/issues/8976), [#9088](https://github.com/npm/cli/issues/9088) 및 커뮤니티 토론에서 보고된 동일 증상의 근본 원인은 **npm CLI 버전이 오래된 것**이었다.

- Trusted Publishing의 OIDC handshake protocol은 **npm 11.5.1 이상**에서 지원
- \`actions/setup-node@v4\` + \`node-version: '20'\`은 **npm 10.x**를 번들
- npm 10에서는 새 handshake가 실패하고 구버전으로 fallback → registry가 익명 요청으로 취급 → PUT 거부 → 404
- npm CLI가 이 실패를 의미 있는 에러로 번역하지 않아 generic 404만 노출됨 (npm 팀이 에러 메시지 개선 이슈 오픈 중)

## 변경

\`dry-run\`과 \`publish\` 두 job에 각각 다음 step 추가:

\`\`\`yaml
- name: Upgrade npm (Trusted Publishing requires 11.5.1+)
  run: npm install -g npm@latest
\`\`\`

### 설계 선택

**Node 버전을 올리는 대신 npm만 업그레이드**한 이유:
- Node 20 LTS는 2028년까지 지원 — 프로젝트 Node 호환성 범위와 맞음
- TP는 node가 아닌 **npm CLI의 기능**이므로 필요한 계층만 업그레이드
- 번들 수명 주기에 의존하지 않고 명시적으로 최신 npm 사용

## Test plan

- [ ] PR 머지 후 Release v0.5.0의 실패한 publish job을 \`gh run rerun --failed\`로 재시도
- [ ] 이번엔 npm 11+가 설치된 상태에서 OIDC handshake 성공해야 함
- [ ] npm registry에 0.5.0 버전이 올라간 것 확인: \`npm view @warmblood/monocle-cli version\`
- [ ] \`npx @warmblood/monocle-cli@0.5.0 --version\` → 0.5.0 출력 확인
- [ ] \`npx @warmblood/monocle-cli@0.5.0 login --device-code\` 플로우 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)