### PR TITLE
fix: package.json에 repository 필드 추가 (provenance 검증용)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
   },
   "keywords": ["claude", "monocle", "oidc", "pkce", "cli"],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/warmblood-kr/monocle-cli.git"
+  },
+  "homepage": "https://github.com/warmblood-kr/monocle-cli#readme",
+  "bugs": {
+    "url": "https://github.com/warmblood-kr/monocle-cli/issues"
+  },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "typescript": "^5.3.0",


### PR DESCRIPTION
## 배경

PR #23 머지 후 v0.5.1 publish 재시도. npm 업그레이드로 **E404 → E422**로 에러가 진전되었음 — 즉 OIDC handshake는 성공했으나 **provenance 검증**에서 거부됨.

\`\`\`
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@warmblood%2fmonocle-cli 
- Error verifying sigstore provenance bundle: 
  Failed to validate repository information: 
  package.json: "repository.url" is "", 
  expected to match "https://github.com/warmblood-kr/monocle-cli" from provenance
\`\`\`

## 원인

npm은 \`--provenance\` 배포 시 **provenance attestation의 GitHub URL이 package.json의 \`repository.url\`과 일치하는지** 검증한다. 이는 "선언된 소스 repo"와 "실제 빌드된 repo"가 같은지 확인하는 공급망 보안 단계.

현재 package.json에 \`repository\` 필드가 없어서 검증 실패.

## 변경

package.json에 다음 필드 추가:

- \`repository\`: provenance 검증에 **필수**
- \`homepage\`: npm 페이지에 링크 노출 (부수 효과)
- \`bugs\`: 이슈 트래커 링크 (부수 효과)

## Test plan

- [ ] 머지 후 v0.5.1 release 재생성 불가 (태그 이미 달림) → v0.5.2로 새 release
- [ ] \`gh release create v0.5.2 --target main\` → publish
- [ ] publish job에서 provenance 검증 통과
- [ ] \`npm view @warmblood/monocle-cli version\` → 0.5.2
- [ ] npm 페이지에 repository/homepage 링크 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)