### PR TITLE
docs: README 재구성 및 Claude Code 문서 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,106 +2,117 @@
 
 [한국어](./docs/README.ko.md)
 
-Monocle CLI is a utility to control and use [Monocle AI](https://monocle-ai.com) from your terminal. Log in once, then use that authenticated session for chat, model management, Claude Code integration, and calling Monocle's OpenAI-compatible API from your own apps.
+> Terminal utility to control and use [Monocle AI](https://monocle-ai.com). Log in once, then chat with models, integrate Claude Code, or call Monocle's OpenAI-compatible API from your own apps — all with the same authenticated session.
 
 ## Prerequisites
 
 - **Node.js** 18+ — check with `node -v`
 
-## Setup (takes about 30 seconds)
-
-**Step 1** — Install
+## 🚀 Setup
 
 ```bash
 npm install -g @warmblood/monocle-cli
-```
-
-**Step 2** — Log in
-
-```bash
 monocle login
 ```
 
-A browser opens — sign in with your organization account. Monocle CLI runs the OAuth flow and stores your credentials at `~/.monocle/credentials.json` (file mode 0600), including a short-lived access token and a 30-day refresh token.
+A browser opens — sign in with your organization account.
 
-> **Tip:** To target a specific tenant: `monocle login --tenant your-org.monocle-ai.com`
->
-> **Headless / SSH / CI?** `monocle login` auto-detects these environments and switches to the device code flow. Force it with `--device-code`.
-
-## Check Status
+## ✅ Check status
 
 ```bash
 monocle status
 ```
 
-Shows your tenant, user, access/refresh token validity, and whether Claude Code is globally configured to route through Monocle. This command is read-only — it does not refresh tokens (refresh happens lazily when you run `monocle token` or use an integration).
+Shows your tenant, user, access/refresh token validity, and whether Claude Code is globally configured to route through Monocle. Read-only — it does not refresh tokens.
 
-## Commands
+## 📖 Commands
 
 | Command | Description |
 |---------|-------------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI |
-| `monocle status` | Show login, token validity, and Claude Code configuration status |
+| `monocle login [--tenant <domain>] [--device-code]` | Sign in |
+| `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
-| `monocle model list` | List models available on your tenant |
-| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | Chat with a model — interactive REPL or pipe from stdin |
-| `monocle claude [...args]` | Launch Claude Code scoped **only to this invocation** (args pass through) |
+| `monocle model list` | List available models |
+| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | Chat with a model (REPL or stdin) |
+| `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
 
-## Chat with models (`monocle model`)
+## 💬 Chat with models
 
 List what your tenant has:
 
-```bash
-monocle model list
+```console
+$ monocle model list
+MODEL ID              NAME                  OWNER       CONTEXT
+────────────────────  ────────────────────  ──────────  ─────────
+claude-sonnet-4-6     Claude Sonnet 4.6     anthropic   200k
+claude-opus-4-7       Claude Opus 4.7       anthropic   200k
+gpt-4o                GPT-4o                openai      128k
+
+3 model(s) available.
 ```
 
 Interactive REPL:
 
-```bash
-monocle model chat --model claude-sonnet-4-6
+```console
+$ monocle model chat --model claude-sonnet-4-6
+Monocle Chat (model: claude-sonnet-4-6)
+Router: https://api.monocle-ai.com
+Type your message. Press Ctrl+D to exit.
+---
+> Hello
+Hello! How can I help you today?
+
+> /quit
+Bye.
 ```
 
 One-shot via stdin:
 
-```bash
-echo "Summarize OAuth 2.0 in one sentence." | monocle model chat
+```console
+$ echo "Summarize OAuth 2.0 in one sentence." | monocle model chat
+Using model: claude-sonnet-4-6
+Router: https://api.monocle-ai.com
+OAuth 2.0 is an authorization framework that lets applications access a user's resources on another service without sharing the user's password.
 ```
 
-With a system prompt loaded from a file:
+With a system prompt from a file:
 
 ```bash
 monocle model chat --system-prompt-file ./persona.md --model claude-opus-4-7
 ```
 
-## Claude Code integration
-
-Run Claude Code with Monocle credentials applied **only to this invocation** — no global config changes:
+## 🤖 Claude Code integration
 
 ```bash
 monocle claude
 ```
 
-Plain `claude` in other terminals and IDE integrations is unaffected. If you want every `claude` invocation (including IDE) to route through Monocle, run `monocle setup` once; undo with `monocle unset`.
+Other terminals and IDE integrations running plain `claude` are unaffected. To globally route plain `claude` through Monocle, run `monocle setup` once; undo with `monocle unset`.
 
-See **[Claude Code integration details](./docs/claude-code.md)** for `ANTHROPIC_API_KEY` handling, global setup, and troubleshooting.
+> [!NOTE]
+> See **[Claude Code integration details](./docs/claude-code.md)** for `ANTHROPIC_API_KEY` handling, global setup, and troubleshooting.
 
-## Using Monocle from your own app (OpenAI-compatible SDK)
+## 🔌 Using Monocle from your own app (OpenAI-compatible SDK)
 
-Monocle exposes an OpenAI-compatible Chat Completions API, so any OpenAI client works with two pieces of config:
+Monocle exposes an OpenAI-compatible Chat Completions API, so any OpenAI client works with two env vars. Export them once:
 
-- **Base URL** — `router_url` from your credentials (typically `https://api.monocle-ai.com`)
-- **API key** — output of `monocle token`
+```bash
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)/v1"
+```
 
-Minimal Python example:
+Then from Python:
 
 ```python
-import subprocess
+import os
 from openai import OpenAI
 
-token = subprocess.check_output(["monocle", "token"], text=True).strip()
-client = OpenAI(api_key=token, base_url="https://api.monocle-ai.com/v1")
+client = OpenAI(
+    api_key=os.environ["MONOCLE_API_KEY"],
+    base_url=os.environ["MONOCLE_BASE_URL"],
+)
 
 resp = client.chat.completions.create(
     model="claude-sonnet-4-6",
@@ -110,15 +121,16 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-See **[Using Monocle with the OpenAI SDK](./docs/openai-sdk.md)** for Node.js, `curl`, streaming, token-refresh patterns for long-running apps, and troubleshooting.
+> [!NOTE]
+> See **[Using Monocle with the OpenAI SDK](./docs/openai-sdk.md)** for Node.js, `curl`, streaming, token-refresh patterns for long-running apps, and troubleshooting.
 
-## Troubleshooting
+## 🆘 Troubleshooting
 
 **"Not logged in" error**
 → Run `monocle login` first.
 
 **Token expired**
-→ `monocle token` auto-refreshes when near expiry. If it's been more than 30 days since your last login (refresh token TTL), run `monocle login` again.
+→ `monocle token` auto-refreshes when near expiry. If it's been more than 30 days since your last login, run `monocle login` again.
 
 For Claude Code and OpenAI SDK specific issues, see the linked guides above.
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,15 @@
 
 [한국어](./docs/README.ko.md)
 
-Monocle CLI connects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to [Monocle AI](https://monocle-ai.com).
-
-Log in once and you're done — no API key management, no manual config file editing.
+Monocle CLI is a utility to control and use [Monocle AI](https://monocle-ai.com) from your terminal. Log in once, then use that authenticated session for chat, model management, Claude Code integration, and calling Monocle's OpenAI-compatible API from your own apps.
 
 ## Prerequisites
 
 - **Node.js** 18+ — check with `node -v`
-- **Claude Code** — [install here](https://docs.anthropic.com/en/docs/claude-code/getting-started) if you haven't already
 
 ## Setup (takes about 30 seconds)
 
-**Step 1** — Install Monocle CLI
+**Step 1** — Install
 
 ```bash
 npm install -g @warmblood/monocle-cli
@@ -25,29 +22,11 @@ npm install -g @warmblood/monocle-cli
 monocle login
 ```
 
-A browser window will open — sign in with your organization account.
+A browser opens — sign in with your organization account. Monocle CLI runs the OAuth flow and stores your credentials at `~/.monocle/credentials.json` (file mode 0600), including a short-lived access token and a 30-day refresh token.
 
-**Step 3** — Launch Claude Code through Monocle
-
-```bash
-monocle claude
-```
-
-`monocle claude` runs Claude Code with Monocle credentials scoped **only to
-that invocation**. Your global Claude Code configuration is not touched —
-plain `claude` in other terminals or IDE integrations stays unaffected.
-
-> **Tip:** Want plain `claude` (including IDE integrations and other
-> terminals) to also route through Monocle globally? Run `monocle setup`
-> once. Undo with `monocle unset`.
+> **Tip:** To target a specific tenant: `monocle login --tenant your-org.monocle-ai.com`
 >
-> **Tip:** To specify a tenant explicitly, use `monocle login --tenant your-org.monocle-ai.com`
->
-> **Tip:** If you have `ANTHROPIC_API_KEY` set in your environment, `monocle claude` will automatically clear it to avoid conflicts.
->
-> **Headless / SSH / CI?** `monocle login` auto-detects these environments and switches to
-> the device code flow — a URL and short code you enter on another machine. If auto-detection
-> misses your environment, force it with `monocle login --device-code`.
+> **Headless / SSH / CI?** `monocle login` auto-detects these environments and switches to the device code flow. Force it with `--device-code`.
 
 ## Check Status
 
@@ -55,18 +34,83 @@ plain `claude` in other terminals or IDE integrations stays unaffected.
 monocle status
 ```
 
-All green (**Valid** and **Configured**) means you're good to go!
+Shows your tenant, user, access/refresh token validity, and whether Claude Code is globally configured to route through Monocle. This command is read-only — it does not refresh tokens (refresh happens lazily when you run `monocle token` or use an integration).
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | Sign in — browser by default, device code on headless/SSH/CI |
-| `monocle claude` | Launch Claude Code with Monocle scoped **only to this invocation** (no global changes) |
-| `monocle setup` | Opt in to global routing — makes plain `claude` (other terminals, IDE integrations) also use Monocle |
-| `monocle status` | Show login and configuration status |
-| `monocle token` | Print current access token (used internally by Claude Code) |
-| `monocle unset` | Remove Monocle configuration from Claude Code |
+| `monocle status` | Show login, token validity, and Claude Code configuration status |
+| `monocle token` | Print current access token (auto-refreshed when near expiry) |
+| `monocle model list` | List models available on your tenant |
+| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | Chat with a model — interactive REPL or pipe from stdin |
+| `monocle claude [...args]` | Launch Claude Code scoped **only to this invocation** (args pass through) |
+| `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
+| `monocle unset` | Remove the global `claude` routing |
+
+## Chat with models (`monocle model`)
+
+List what your tenant has:
+
+```bash
+monocle model list
+```
+
+Interactive REPL:
+
+```bash
+monocle model chat --model claude-sonnet-4-6
+```
+
+One-shot via stdin:
+
+```bash
+echo "Summarize OAuth 2.0 in one sentence." | monocle model chat
+```
+
+With a system prompt loaded from a file:
+
+```bash
+monocle model chat --system-prompt-file ./persona.md --model claude-opus-4-7
+```
+
+## Claude Code integration
+
+Run Claude Code with Monocle credentials applied **only to this invocation** — no global config changes:
+
+```bash
+monocle claude
+```
+
+Plain `claude` in other terminals and IDE integrations is unaffected. If you want every `claude` invocation (including IDE) to route through Monocle, run `monocle setup` once; undo with `monocle unset`.
+
+See **[Claude Code integration details](./docs/claude-code.md)** for `ANTHROPIC_API_KEY` handling, global setup, and troubleshooting.
+
+## Using Monocle from your own app (OpenAI-compatible SDK)
+
+Monocle exposes an OpenAI-compatible Chat Completions API, so any OpenAI client works with two pieces of config:
+
+- **Base URL** — `router_url` from your credentials (typically `https://api.monocle-ai.com`)
+- **API key** — output of `monocle token`
+
+Minimal Python example:
+
+```python
+import subprocess
+from openai import OpenAI
+
+token = subprocess.check_output(["monocle", "token"], text=True).strip()
+client = OpenAI(api_key=token, base_url="https://api.monocle-ai.com/v1")
+
+resp = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(resp.choices[0].message.content)
+```
+
+See **[Using Monocle with the OpenAI SDK](./docs/openai-sdk.md)** for Node.js, `curl`, streaming, token-refresh patterns for long-running apps, and troubleshooting.
 
 ## Troubleshooting
 
@@ -74,22 +118,9 @@ All green (**Valid** and **Configured**) means you're good to go!
 → Run `monocle login` first.
 
 **Token expired**
-→ Tokens are refreshed automatically. If it's been more than 30 days since your last login, run `monocle login` again.
+→ `monocle token` auto-refreshes when near expiry. If it's been more than 30 days since your last login (refresh token TTL), run `monocle login` again.
 
-**Claude Code is ignoring Monocle**
-→ An `ANTHROPIC_API_KEY` environment variable takes precedence over Monocle. Use `monocle claude` to launch Claude Code — it clears the conflict automatically.
-
-**Plain `claude` doesn't use Monocle**
-→ By design. `monocle claude` is isolated to its own invocation. Run `monocle setup` if you want plain `claude` to also route through Monocle.
-
-**Want to start fresh?**
-→ Run `monocle unset` to remove global routing, then re-run `monocle setup` if needed.
-
-## Using Monocle from your own app
-
-Want to call Monocle's OpenAI-compatible API from your own code (Python,
-Node.js, `curl`)? See **Using Monocle with the OpenAI SDK**
-— [English](./docs/openai-sdk.md) · [한국어](./docs/openai-sdk.ko.md).
+For Claude Code and OpenAI SDK specific issues, see the linked guides above.
 
 ## Help
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -2,71 +2,79 @@
 
 [English](../README.md)
 
-Monocle CLI는 터미널에서 [Monocle AI](https://monocle-ai.com)를 제어하고 사용하는 유틸리티예요. 한 번 로그인하면 그 세션으로 채팅, 모델 조회, Claude Code 연동, 직접 만든 앱에서 Monocle의 OpenAI 호환 API 호출까지 이어서 쓸 수 있어요.
+> 터미널에서 [Monocle AI](https://monocle-ai.com)를 제어하고 사용하는 유틸리티예요. 한 번 로그인하면 그 세션으로 모델과 채팅하고, Claude Code를 연동하고, 직접 만든 앱에서 Monocle의 OpenAI 호환 API를 호출할 수 있어요.
 
 ## 시작하기 전에
 
 - **Node.js** 18 이상 — `node -v`로 확인해 주세요
 
-## 설정 (30초면 충분해요)
-
-**Step 1** — 설치
+## 🚀 설정
 
 ```bash
 npm install -g @warmblood/monocle-cli
-```
-
-**Step 2** — 로그인
-
-```bash
 monocle login
 ```
 
-브라우저가 열리면 회사 계정으로 로그인해 주세요. OAuth 흐름이 끝나면 Monocle CLI가 자격 증명을 `~/.monocle/credentials.json`(권한 0600)에 저장해요 — 짧은 수명의 액세스 토큰과 30일짜리 리프레시 토큰이 함께 들어가요.
+브라우저가 열리면 회사 계정으로 로그인해 주세요.
 
-> **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`.
->
-> **헤드리스 / SSH / CI 환경이신가요?** `monocle login`이 자동 감지해서 device code 방식으로 전환해요. 수동으로 강제하려면 `--device-code`.
-
-## 상태 확인
+## ✅ 상태 확인
 
 ```bash
 monocle status
 ```
 
-테넌트, 사용자, 액세스/리프레시 토큰 유효성, Claude Code 전역 연동 여부를 보여줘요. 이 명령은 읽기 전용이에요 — 토큰 갱신은 하지 않아요 (갱신은 `monocle token` 호출이나 연동 사용 시에 자동으로 일어나요).
+테넌트, 사용자, 액세스/리프레시 토큰 유효성, Claude Code 전역 연동 여부를 보여줘요. 읽기 전용이라 토큰 갱신은 하지 않아요.
 
-## 전체 명령어
+## 📖 전체 명령어
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code |
-| `monocle status` | 로그인, 토큰 유효성, Claude Code 구성 상태 확인 |
+| `monocle login [--tenant <domain>] [--device-code]` | 로그인 |
+| `monocle status` | 로그인, 토큰, Claude Code 구성 상태 확인 |
 | `monocle token` | 현재 액세스 토큰 출력 (만료 임박 시 자동 갱신) |
-| `monocle model list` | 테넌트에서 사용 가능한 모델 목록 |
-| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | 모델과 채팅 — 인터랙티브 REPL 또는 stdin 파이프 |
-| `monocle claude [...args]` | Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행 (인자 그대로 전달) |
+| `monocle model list` | 사용 가능한 모델 목록 |
+| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | 모델과 채팅 (REPL 또는 stdin) |
+| `monocle claude [...args]` | Claude Code를 Monocle에 연결해서 실행 (인자 그대로 전달) |
 | `monocle setup` | 일반 `claude`도 전역으로 Monocle을 거치게 설정 (opt-in) |
 | `monocle unset` | 전역 `claude` 라우팅 제거 |
 
-## 모델과 채팅하기 (`monocle model`)
+## 💬 모델과 채팅하기
 
 사용 가능한 모델 보기:
 
-```bash
-monocle model list
+```console
+$ monocle model list
+MODEL ID              NAME                  OWNER       CONTEXT
+────────────────────  ────────────────────  ──────────  ─────────
+claude-sonnet-4-6     Claude Sonnet 4.6     anthropic   200k
+claude-opus-4-7       Claude Opus 4.7       anthropic   200k
+gpt-4o                GPT-4o                openai      128k
+
+3 model(s) available.
 ```
 
 인터랙티브 REPL:
 
-```bash
-monocle model chat --model claude-sonnet-4-6
+```console
+$ monocle model chat --model claude-sonnet-4-6
+Monocle Chat (model: claude-sonnet-4-6)
+Router: https://api.monocle-ai.com
+Type your message. Press Ctrl+D to exit.
+---
+> 안녕하세요
+안녕하세요! 무엇을 도와드릴까요?
+
+> /quit
+Bye.
 ```
 
 stdin 파이프로 one-shot:
 
-```bash
-echo "OAuth 2.0을 한 문장으로 요약해줘." | monocle model chat
+```console
+$ echo "OAuth 2.0을 한 문장으로 요약해줘." | monocle model chat
+Using model: claude-sonnet-4-6
+Router: https://api.monocle-ai.com
+OAuth 2.0은 사용자가 비밀번호를 공유하지 않고도 애플리케이션이 다른 서비스의 자원에 접근할 수 있게 해주는 인증 프레임워크예요.
 ```
 
 파일에서 시스템 프롬프트를 불러와서:
@@ -75,33 +83,36 @@ echo "OAuth 2.0을 한 문장으로 요약해줘." | monocle model chat
 monocle model chat --system-prompt-file ./persona.md --model claude-opus-4-7
 ```
 
-## Claude Code 연동
-
-Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행:
+## 🤖 Claude Code 연동
 
 ```bash
 monocle claude
 ```
 
-다른 터미널이나 IDE 연동의 일반 `claude`는 영향받지 않아요. 일반 `claude`(IDE 포함)도 전역으로 Monocle을 거치게 하려면 `monocle setup`을 한 번 실행하세요. 해제는 `monocle unset`.
+다른 터미널이나 IDE 연동에서 실행되는 일반 `claude`는 영향받지 않아요. 일반 `claude`도 전역으로 Monocle을 거치게 하려면 `monocle setup`을 한 번 실행하세요. 해제는 `monocle unset`.
 
-자세한 내용은 **[Claude Code 연동 상세](./claude-code.ko.md)** — `ANTHROPIC_API_KEY` 처리, 전역 설정, 문제 해결을 참고해 주세요.
+> [!NOTE]
+> 자세한 내용은 **[Claude Code 연동 상세](./claude-code.ko.md)** — `ANTHROPIC_API_KEY` 처리, 전역 설정, 문제 해결을 참고해 주세요.
 
-## 직접 만든 앱에서 쓰기 (OpenAI 호환 SDK)
+## 🔌 직접 만든 앱에서 쓰기 (OpenAI 호환 SDK)
 
-Monocle은 OpenAI 호환 Chat Completions API를 제공해요. 두 가지만 설정하면 어떤 OpenAI 클라이언트로도 호출할 수 있어요:
+Monocle은 OpenAI 호환 Chat Completions API를 제공해요. 환경 변수 두 개만 설정하면 어떤 OpenAI 클라이언트로도 호출할 수 있어요. 한 번 export 해두세요:
 
-- **Base URL** — 자격 증명의 `router_url` (보통 `https://api.monocle-ai.com`)
-- **API key** — `monocle token` 출력값
+```bash
+export MONOCLE_API_KEY="$(monocle token)"
+export MONOCLE_BASE_URL="$(jq -r .router_url ~/.monocle/credentials.json)/v1"
+```
 
-최소 Python 예시:
+그리고 Python에서:
 
 ```python
-import subprocess
+import os
 from openai import OpenAI
 
-token = subprocess.check_output(["monocle", "token"], text=True).strip()
-client = OpenAI(api_key=token, base_url="https://api.monocle-ai.com/v1")
+client = OpenAI(
+    api_key=os.environ["MONOCLE_API_KEY"],
+    base_url=os.environ["MONOCLE_BASE_URL"],
+)
 
 resp = client.chat.completions.create(
     model="claude-sonnet-4-6",
@@ -110,15 +121,16 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-Node.js, `curl`, 스트리밍, 장시간 실행 앱에서의 토큰 갱신 패턴, 문제 해결은 **[OpenAI SDK로 Monocle 사용하기](./openai-sdk.ko.md)** 참고.
+> [!NOTE]
+> Node.js, `curl`, 스트리밍, 장시간 실행 앱에서의 토큰 갱신 패턴, 문제 해결은 **[OpenAI SDK로 Monocle 사용하기](./openai-sdk.ko.md)** 참고.
 
-## 문제가 생겼나요?
+## 🆘 문제가 생겼나요?
 
 **"Not logged in" 오류가 나와요**
 → `monocle login`을 먼저 실행해 주세요.
 
 **토큰이 만료됐대요**
-→ `monocle token`이 만료 임박 시 자동으로 갱신해요. 마지막 로그인 후 30일(리프레시 토큰 TTL)이 지났다면 `monocle login`을 다시 실행해 주세요.
+→ `monocle token`이 만료 임박 시 자동으로 갱신해요. 마지막 로그인 후 30일이 지났다면 `monocle login`을 다시 실행해 주세요.
 
 Claude Code나 OpenAI SDK 관련 문제는 위의 연결된 가이드를 참고해 주세요.
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -2,18 +2,15 @@
 
 [English](../README.md)
 
-Monocle CLI를 사용하면 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)를 [Monocle AI](https://monocle-ai.com)에 연동해 사용할 수 있어요.
-
-한 번만 로그인하고 설정하면 끝! API 키 관리도, 설정 파일 직접 수정도 필요 없어요.
+Monocle CLI는 터미널에서 [Monocle AI](https://monocle-ai.com)를 제어하고 사용하는 유틸리티예요. 한 번 로그인하면 그 세션으로 채팅, 모델 조회, Claude Code 연동, 직접 만든 앱에서 Monocle의 OpenAI 호환 API 호출까지 이어서 쓸 수 있어요.
 
 ## 시작하기 전에
 
 - **Node.js** 18 이상 — `node -v`로 확인해 주세요
-- **Claude Code** — 아직 없다면 [여기서 설치](https://docs.anthropic.com/en/docs/claude-code/getting-started)해 주세요
 
 ## 설정 (30초면 충분해요)
 
-**Step 1** — Monocle CLI 설치
+**Step 1** — 설치
 
 ```bash
 npm install -g @warmblood/monocle-cli
@@ -25,27 +22,11 @@ npm install -g @warmblood/monocle-cli
 monocle login
 ```
 
-브라우저가 열리면 평소 사용하시는 회사 계정으로 로그인해 주세요.
+브라우저가 열리면 회사 계정으로 로그인해 주세요. OAuth 흐름이 끝나면 Monocle CLI가 자격 증명을 `~/.monocle/credentials.json`(권한 0600)에 저장해요 — 짧은 수명의 액세스 토큰과 30일짜리 리프레시 토큰이 함께 들어가요.
 
-**Step 3** — Monocle 경유로 Claude Code 실행
-
-```bash
-monocle claude
-```
-
-`monocle claude`는 Monocle 설정을 **이 실행에만** 적용한 상태로 Claude
-Code를 띄워요. 전역 Claude Code 설정은 전혀 건드리지 않아서, 다른 터미널이나
-IDE 연동의 `claude`는 그대로예요.
-
-> **Tip:** 다른 터미널이나 IDE 연동의 일반 `claude`도 Monocle을 거치게
-> 하고 싶다면 `monocle setup`을 한 번 실행하시면 돼요. 해제할 땐
-> `monocle unset`.
+> **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`.
 >
-> **Tip:** 특정 테넌트를 지정하려면 `monocle login --tenant your-org.monocle-ai.com`으로 실행하세요.
->
-> **Tip:** `ANTHROPIC_API_KEY` 같은 환경 변수가 설정되어 있어도 `monocle claude`가 자동으로 정리해 줘요.
->
-> **헤드리스 / SSH / CI 환경이신가요?** `monocle login`이 자동으로 감지해서 device code 방식으로 전환합니다 — 다른 기기의 브라우저에서 URL을 열고 짧은 코드를 입력하는 방식이에요. 자동 감지가 안 되는 환경이면 `monocle login --device-code`로 강제할 수 있어요.
+> **헤드리스 / SSH / CI 환경이신가요?** `monocle login`이 자동 감지해서 device code 방식으로 전환해요. 수동으로 강제하려면 `--device-code`.
 
 ## 상태 확인
 
@@ -53,18 +34,83 @@ IDE 연동의 `claude`는 그대로예요.
 monocle status
 ```
 
-모두 **Valid**이고 **Configured**로 표시되면 정상이에요!
+테넌트, 사용자, 액세스/리프레시 토큰 유효성, Claude Code 전역 연동 여부를 보여줘요. 이 명령은 읽기 전용이에요 — 토큰 갱신은 하지 않아요 (갱신은 `monocle token` 호출이나 연동 사용 시에 자동으로 일어나요).
 
 ## 전체 명령어
 
 | 명령어 | 설명 |
 |--------|------|
-| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code 방식 |
-| `monocle claude` | Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행 (전역 설정 변경 없음) |
-| `monocle setup` | 전역 라우팅 opt-in — 다른 터미널/IDE 연동의 일반 `claude`도 Monocle을 거치게 설정 |
-| `monocle status` | 로그인/설정 상태 확인 |
-| `monocle token` | 현재 액세스 토큰 출력 (Claude Code가 내부적으로 사용) |
-| `monocle unset` | Claude Code에서 Monocle 설정 제거 |
+| `monocle login [--tenant <domain>] [--env <env>] [--device-code]` | 로그인 — 기본은 브라우저, 헤드리스/SSH/CI에서는 device code |
+| `monocle status` | 로그인, 토큰 유효성, Claude Code 구성 상태 확인 |
+| `monocle token` | 현재 액세스 토큰 출력 (만료 임박 시 자동 갱신) |
+| `monocle model list` | 테넌트에서 사용 가능한 모델 목록 |
+| `monocle model chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | 모델과 채팅 — 인터랙티브 REPL 또는 stdin 파이프 |
+| `monocle claude [...args]` | Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행 (인자 그대로 전달) |
+| `monocle setup` | 일반 `claude`도 전역으로 Monocle을 거치게 설정 (opt-in) |
+| `monocle unset` | 전역 `claude` 라우팅 제거 |
+
+## 모델과 채팅하기 (`monocle model`)
+
+사용 가능한 모델 보기:
+
+```bash
+monocle model list
+```
+
+인터랙티브 REPL:
+
+```bash
+monocle model chat --model claude-sonnet-4-6
+```
+
+stdin 파이프로 one-shot:
+
+```bash
+echo "OAuth 2.0을 한 문장으로 요약해줘." | monocle model chat
+```
+
+파일에서 시스템 프롬프트를 불러와서:
+
+```bash
+monocle model chat --system-prompt-file ./persona.md --model claude-opus-4-7
+```
+
+## Claude Code 연동
+
+Monocle 설정을 **이 실행에만** 적용해서 Claude Code 실행:
+
+```bash
+monocle claude
+```
+
+다른 터미널이나 IDE 연동의 일반 `claude`는 영향받지 않아요. 일반 `claude`(IDE 포함)도 전역으로 Monocle을 거치게 하려면 `monocle setup`을 한 번 실행하세요. 해제는 `monocle unset`.
+
+자세한 내용은 **[Claude Code 연동 상세](./claude-code.ko.md)** — `ANTHROPIC_API_KEY` 처리, 전역 설정, 문제 해결을 참고해 주세요.
+
+## 직접 만든 앱에서 쓰기 (OpenAI 호환 SDK)
+
+Monocle은 OpenAI 호환 Chat Completions API를 제공해요. 두 가지만 설정하면 어떤 OpenAI 클라이언트로도 호출할 수 있어요:
+
+- **Base URL** — 자격 증명의 `router_url` (보통 `https://api.monocle-ai.com`)
+- **API key** — `monocle token` 출력값
+
+최소 Python 예시:
+
+```python
+import subprocess
+from openai import OpenAI
+
+token = subprocess.check_output(["monocle", "token"], text=True).strip()
+client = OpenAI(api_key=token, base_url="https://api.monocle-ai.com/v1")
+
+resp = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "안녕"}],
+)
+print(resp.choices[0].message.content)
+```
+
+Node.js, `curl`, 스트리밍, 장시간 실행 앱에서의 토큰 갱신 패턴, 문제 해결은 **[OpenAI SDK로 Monocle 사용하기](./openai-sdk.ko.md)** 참고.
 
 ## 문제가 생겼나요?
 
@@ -72,22 +118,9 @@ monocle status
 → `monocle login`을 먼저 실행해 주세요.
 
 **토큰이 만료됐대요**
-→ 토큰은 자동으로 갱신돼요. 마지막 로그인 후 30일이 지났다면 `monocle login`을 다시 실행해 주세요.
+→ `monocle token`이 만료 임박 시 자동으로 갱신해요. 마지막 로그인 후 30일(리프레시 토큰 TTL)이 지났다면 `monocle login`을 다시 실행해 주세요.
 
-**Claude Code가 Monocle을 무시해요**
-→ 환경 변수에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Monocle보다 우선 적용돼요. `monocle claude`로 실행하면 자동으로 해결됩니다.
-
-**일반 `claude`가 Monocle을 안 쓰네요**
-→ 의도된 동작이에요. `monocle claude`는 자기 실행에만 Monocle을 적용해요. 일반 `claude`도 Monocle로 향하게 하려면 `monocle setup`을 한 번 실행해 주세요.
-
-**처음부터 다시 하고 싶어요**
-→ `monocle unset`으로 전역 라우팅을 제거하시고, 필요하면 `monocle setup`을 다시 실행하시면 돼요.
-
-## 직접 만든 앱에서 Monocle 쓰기
-
-Python, Node.js, `curl` 같은 도구로 Monocle의 OpenAI 호환 API를 호출하고
-싶으신가요? **OpenAI SDK로 Monocle 사용하기** 가이드를 참고해 주세요
-— [한국어](./openai-sdk.ko.md) · [English](./openai-sdk.md).
+Claude Code나 OpenAI SDK 관련 문제는 위의 연결된 가이드를 참고해 주세요.
 
 ## 도움이 필요하신가요?
 

--- a/docs/claude-code.ko.md
+++ b/docs/claude-code.ko.md
@@ -1,0 +1,62 @@
+# Claude Code 연동
+
+[English](./claude-code.md)
+
+Monocle CLI로 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)를 Anthropic API 대신 Monocle 테넌트에 연결해서 쓸 수 있어요. 두 가지 모드가 있습니다 — **이 실행에만 적용**(기본, 권장)과 **전역 opt-in**.
+
+## 시작하기 전에
+
+- `monocle login`이 먼저 완료되어 있어야 해요 ([메인 README](../README.md#설정-30초면-충분해요) 참고)
+- **Claude Code** 설치 — [여기서 설치](https://docs.anthropic.com/en/docs/claude-code/getting-started)
+
+## 이 실행에만 적용: `monocle claude`
+
+```bash
+monocle claude
+```
+
+Monocle 설정을 **이 실행에만** 적용한 상태로 Claude Code를 띄워요 (실행 단위 `--settings` 오버라이드). 전역 Claude Code 설정은 건드리지 않아서, 다른 터미널이나 IDE 연동의 `claude`는 그대로예요.
+
+추가 인자는 Claude Code로 그대로 전달돼요:
+
+```bash
+monocle claude --help
+monocle claude -c      # 가장 최근 세션 재개
+```
+
+### `ANTHROPIC_API_KEY` 처리
+
+환경에 `ANTHROPIC_API_KEY`가 설정되어 있으면 Claude Code는 이를 Monocle보다 우선해요. `monocle claude`는 자식 프로세스 환경에서 이 변수를 자동으로 제거해서 Monocle 자격 증명이 사용되도록 해줘요 — 수동으로 `unset` 할 필요 없어요.
+
+## 전역 opt-in: `monocle setup`
+
+다른 터미널이나 IDE 연동의 일반 `claude`도 전부 Monocle을 거치게 하려면:
+
+```bash
+monocle setup
+```
+
+`~/.claude/settings.json`에 `apiKeyHelper: "monocle token"`을 적어 넣어요. 이후 Claude Code는 요청마다 `monocle token`을 호출해서 최신 액세스 토큰을 가져가요.
+
+해제할 땐:
+
+```bash
+monocle unset
+```
+
+상태 확인:
+
+```bash
+monocle status   # "Claude Code: Configured"
+```
+
+## 문제가 생겼나요?
+
+**Claude Code가 Monocle을 무시해요**
+→ 환경 변수에 `ANTHROPIC_API_KEY`가 있으면 Monocle보다 우선 적용돼요. `monocle claude`로 실행하면 자동으로 제거해 주거나, 쉘에서 직접 `unset ANTHROPIC_API_KEY` 해주세요.
+
+**일반 `claude`가 Monocle을 안 써요**
+→ 의도된 동작이에요. `monocle claude`는 자기 실행에만 Monocle을 적용해요. IDE 연동이나 다른 터미널의 일반 `claude`도 Monocle로 가게 하려면 `monocle setup`을 한 번 실행해 주세요.
+
+**처음부터 다시 하고 싶어요**
+→ `monocle unset`으로 전역 라우팅 제거 후, 필요하면 `monocle setup`을 다시 실행하세요.

--- a/docs/claude-code.ko.md
+++ b/docs/claude-code.ko.md
@@ -6,7 +6,7 @@ Monocle CLI로 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)를 
 
 ## 시작하기 전에
 
-- `monocle login`이 먼저 완료되어 있어야 해요 ([메인 README](../README.md#설정-30초면-충분해요) 참고)
+- `monocle login`이 먼저 완료되어 있어야 해요 ([메인 README](../README.md#-설정) 참고)
 - **Claude Code** 설치 — [여기서 설치](https://docs.anthropic.com/en/docs/claude-code/getting-started)
 
 ## 이 실행에만 적용: `monocle claude`

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -6,7 +6,7 @@ Monocle CLI lets you run [Claude Code](https://docs.anthropic.com/en/docs/claude
 
 ## Prerequisites
 
-- `monocle login` has completed successfully (see the [main README](../README.md#setup-takes-about-30-seconds))
+- `monocle login` has completed successfully (see the [main README](../README.md#-setup))
 - **Claude Code** installed — [install here](https://docs.anthropic.com/en/docs/claude-code/getting-started)
 
 ## Invocation-scoped: `monocle claude`

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,62 @@
+# Claude Code integration
+
+[한국어](./claude-code.ko.md)
+
+Monocle CLI lets you run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) against your Monocle tenant instead of directly against the Anthropic API. Two modes are available: **invocation-scoped** (default, recommended) and **global opt-in**.
+
+## Prerequisites
+
+- `monocle login` has completed successfully (see the [main README](../README.md#setup-takes-about-30-seconds))
+- **Claude Code** installed — [install here](https://docs.anthropic.com/en/docs/claude-code/getting-started)
+
+## Invocation-scoped: `monocle claude`
+
+```bash
+monocle claude
+```
+
+Launches Claude Code with Monocle credentials scoped **only to this invocation** via a per-invocation `--settings` override. Your global Claude Code configuration is untouched — plain `claude` in other terminals and IDE integrations stays on whatever it was pointing at.
+
+Extra arguments are passed through to Claude Code:
+
+```bash
+monocle claude --help
+monocle claude -c      # resume most recent session
+```
+
+### `ANTHROPIC_API_KEY` handling
+
+If `ANTHROPIC_API_KEY` is set in your environment, Claude Code prefers it over Monocle. `monocle claude` clears this variable in the child process environment automatically so Monocle credentials win — no manual `unset` needed.
+
+## Global opt-in: `monocle setup`
+
+To route plain `claude` (including IDE integrations and every other terminal) through Monocle globally:
+
+```bash
+monocle setup
+```
+
+This writes `apiKeyHelper: "monocle token"` into `~/.claude/settings.json`. Claude Code then calls `monocle token` to fetch a fresh access token per request.
+
+Undo at any time:
+
+```bash
+monocle unset
+```
+
+Verify state:
+
+```bash
+monocle status   # look for "Claude Code: Configured"
+```
+
+## Troubleshooting
+
+**Claude Code ignores Monocle**
+→ An `ANTHROPIC_API_KEY` in your environment takes precedence. Use `monocle claude` (which clears it automatically) or `unset ANTHROPIC_API_KEY` in your shell.
+
+**Plain `claude` doesn't use Monocle**
+→ By design. `monocle claude` is invocation-scoped. Run `monocle setup` if you want plain `claude` (IDE integrations, other terminals) to also route through Monocle.
+
+**Want to start fresh**
+→ `monocle unset` removes global routing. Re-run `monocle setup` if needed.


### PR DESCRIPTION
## 요약
- README를 Claude Code 커넥터가 아닌 **Monocle AI용 터미널 유틸리티** 관점으로 재구성 (#25 종결, #26 리뷰 반영)
- Claude Code 관련 상세 내용을 `docs/claude-code.md` / `docs/claude-code.ko.md`로 분리
- `monocle model list` / `monocle model chat` 명령, OpenAI 호환 SDK 사용 예시, 이모지 섹션 마커와 GitHub `[!NOTE]` 콜아웃 등 스타일 개선

## 포함 커밋
- c06b62c docs: reposition README around terminal-first Monocle control (Closes #25)
- ad44f0e docs: tighten README copy and add modern styling (#26 리뷰 반영)
- 372815b Merge pull request #26

## 테스트 플랜
- [ ] GitHub에서 렌더링된 README/docs 링크·앵커가 정상 작동하는지 확인
- [ ] `docs/claude-code.md`의 Setup 앵커가 메인 README 변경된 헤딩과 일치하는지 확인
- [ ] 한국어/영어 문서 쌍의 정보 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)