### PR TITLE
feat: monocle claude 기본 모델을 sonnet[1m]로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@monocle-ai/cli",
-  "version": "0.1.0",
+  "name": "@warmblood/monocle-cli",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@monocle-ai/cli",
-      "version": "0.1.0",
+      "name": "@warmblood/monocle-cli",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warmblood/monocle-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CLI authentication tool for Claude Code with Stark OIDC PKCE integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -113,7 +113,7 @@ describe('claudeCommand', () => {
     expect(callArgs.slice(2)).toEqual(['--model', 'opus']);
   });
 
-  it('should default model to sonnet in inline settings', async () => {
+  it('should default model to sonnet[1m] in inline settings', async () => {
     const { spawnFn } = makeMockSpawn();
 
     await claudeCommand([], {
@@ -124,7 +124,7 @@ describe('claudeCommand', () => {
 
     const callArgs = spawnFn.mock.calls[0][1] as string[];
     const parsed = JSON.parse(callArgs[1]);
-    expect(parsed.model).toBe('sonnet');
+    expect(parsed.model).toBe('sonnet[1m]');
   });
 
   it('should let user --model override the default', async () => {

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -30,11 +30,11 @@ export async function claudeCommand(args: string[], deps?: ClaudeDeps): Promise<
 
   // Inline settings scoped to this child only — avoids mutating ~/.claude/settings.json.
   // `apiKeyHelper` keeps tokens fresh across long sessions by re-invoking `monocle token`.
-  // `model` defaults to Sonnet to avoid surprise Opus costs; a user `--model` flag (forwarded
-  // after --settings) still wins, since the CLI flag outranks the settings field.
+  // `model` defaults to the 1M-context Sonnet to avoid surprise Opus costs; a user `--model` flag
+  // (forwarded after --settings) still wins, since the CLI flag outranks the settings field.
   const inlineSettings = JSON.stringify({
     apiKeyHelper: 'monocle token',
-    model: 'sonnet',
+    model: 'sonnet[1m]',
   });
 
   // Build child env — strip conflicting vars, inject base URL.


### PR DESCRIPTION
## 변경 내용

`monocle claude`의 기본 모델을 `sonnet` → `sonnet[1m]`(1M 컨텍스트 Sonnet)로 변경합니다.

- `src/commands/claude.ts`: 인라인 `--settings`의 `model` 값을 `sonnet[1m]`로, 주석 갱신
- `src/__tests__/claude.test.ts`: 테스트 기대값·설명 갱신
- `package.json` / `package-lock.json`: `0.5.0` → `0.5.1`

## 배경

`sonnet[1m]`은 Claude Code가 클라이언트 측에서 full ID로 변환하는 지원 alias이므로, 프록시(Chat Proxy) 측 변경은 불필요합니다. 더 비싼 모델이 아니라 같은 Sonnet의 1M 컨텍스트 변형이라 "Opus 비용 방지"라는 기존 기본값 의도(#31)와도 충돌하지 않습니다.

## 검증

- `npm run test` 통과 (104개)
- `npm run lint`(tsc --noEmit) 통과
- 가짜 `claude` 바이너리로 spawn 인자 확인 → `--settings`에 `model:"sonnet[1m]"` 정상 전달, 사용자 `--model` 오버라이드도 정상 동작

## 참고

- 후속/관련: #31 (기본 모델 Sonnet 도입)
- ⚠️ cmux 터미널 환경에서는 #35(--settings 충돌)로 인해 이 기본값이 현재 무력화됩니다. 일반 터미널에서는 정상 적용되며, #35 수정 시 cmux에서도 살아납니다.