### PR TITLE
에이전트 모드 (Path B): 네이티브 Rust 헤드리스 에이전트 + ACP 착수

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,22 @@ cargo fmt               # 포매팅
 - 내부 리팩토링이나 구현 개선은 README 반영 불필요
 - 새 명령어, 옵션 변경, 설정 흐름 변경 등 사용자에게 보이는 변화만 반영 대상
 
+## 에이전트 모드 (WIP — Path B)
+
+`monocle`를 **헤드리스 에이전트**로 확장 중. **코딩 에이전트가 아니라**, monocle
+**Craft**(및 데스크탑)가 구동하는 **모델‑무관 서버‑에이전트 백엔드** — Craft의
+Sonnet 종속 비용을 Craft 코어 변경 없이 완화(= 모델 자유도 G1)하는 게 목적.
+
+- **설계(SDD/에픽):** warmblood-kr/monocle#158 · **구현 상태:** warmblood-kr/monocle-cli#44
+- **코드:** `src/agent/`(`providers`=LLM 추상화/G1, `tools`=read/write/edit +
+  크로스플랫폼 shell, `runner`=agent-core 루프) + `src/commands/agent.rs`
+  (`monocle agent <prompt>`, experimental). 모든 HTTP는 `src/net.rs` 파사드.
+- **작업 브랜치:** `feature/agent-mode-providers` (base `rust-rewrite`/PR #43).
+  push/PR은 승인 게이트 — 로컬 커밋만.
+- **시퀀스(§9):** Phase 0(얼개)✅ → **Phase 1 스트리밍(동기 SSE)+멀티턴**(다음) →
+  Phase 2 세션/스티어링 → Phase 3 **ACP 표면 + 권한**(G4) → Phase 4 정교화.
+- pi(earendil-works/pi, MIT)를 설계 참고로만(코드 차용 X); ACP = Zed Agent Client Protocol.
+
 ## 지식 관리 — wb-para 스킬 적극 사용
 
 이 저장소는 모노클 AI 코드베이스입니다. 작업 중 나오는 결정·통찰·운영 지식은 `warmble-jumble` vault에 축적해야 팀이 재활용할 수 있으므로, wb-para sub-skill을 능동적으로 호출하세요.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,37 @@
 version = 4
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499b7ff5c6c842e43fb188f6da7c99a258ae89a9df8c896d6e9784da9b4b23e7"
+dependencies = [
+ "agent-client-protocol-schema",
+ "anyhow",
+ "async-broadcast",
+ "async-trait",
+ "derive_more",
+ "futures",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bc1fef9c32f03bce2ab44af35b6f483bfd169bf55cc59beeb2e3b1a00ae4d1"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +93,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -207,6 +267,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +298,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -240,6 +324,29 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -276,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +402,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -313,6 +447,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,10 +478,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -352,8 +523,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -777,6 +950,8 @@ dependencies = [
 name = "monocle-cli"
 version = "0.5.0"
 dependencies = [
+ "agent-client-protocol",
+ "async-trait",
  "base64",
  "chrono",
  "clap",
@@ -789,6 +964,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "tiny_http",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -849,6 +1026,12 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "pathdiff"
@@ -1031,6 +1214,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1293,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1152,6 +1364,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1418,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1257,6 +1511,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1376,7 +1651,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1386,6 +1673,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1476,6 +1777,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +250,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -748,6 +780,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "ctrlc",
  "open",
  "rand 0.8.6",
  "reqwest",
@@ -759,6 +792,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +811,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 tiny_http = "0.12"
 open = "5"
+ctrlc = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 tiny_http = "0.12"
 open = "5"
 ctrlc = "3"
+# ACP server-agent surface (Phase 3). async stays confined to src/acp.rs; the
+# core loop is sync. Pin 0.9 (trait-based `impl Agent`); 1.0 is a builder rewrite.
+agent-client-protocol = "0.9"
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt", "io-std", "macros", "sync"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,3 +5,5 @@
 //! tools, permission/sandboxing, session, and ACP surface come later.
 
 pub mod providers;
+pub mod runner;
+pub mod tools;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod providers;
 pub mod runner;
+pub mod session;
 pub mod tools;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,0 +1,7 @@
+//! Agent subsystem (Path B — native Rust headless agent loop).
+//!
+//! Design: warmblood-kr/monocle#158 (SDD) · impl: warmblood-kr/monocle-cli#44.
+//! This is the §9 step-1 spike: the `providers` abstraction only. The agent loop,
+//! tools, permission/sandboxing, session, and ACP surface come later.
+
+pub mod providers;

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -21,14 +21,14 @@ use crate::origin::origin_header;
 
 /// One chat message (OpenAI-compatible). `content` is optional because an
 /// assistant message that only makes tool calls carries no text.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_calls: Vec<ToolCall>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
 }
 

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -6,10 +6,11 @@
 //! (OpenAI-compatible `/v1/chat/completions`), so monocle-model-router /
 //! monocle-auto can select any model and the agent stays vendor-agnostic.
 //!
-//! Spike scope (monocle-cli#44, step 1): one non-streaming turn. No tool calls,
-//! no streaming, no loop yet.
+//! The OpenAI Chat Completions wire format (incl. tool-calling shapes) is an
+//! implementation detail of this provider; the loop sees only the normalized
+//! types here (SDD §4a — wire format is a seam, not exposed upward).
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::auth::AuthSession;
@@ -18,47 +19,122 @@ use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::origin_header;
 
-/// One chat message. Serializes to the OpenAI-compatible `{role, content}` shape.
+/// One chat message (OpenAI-compatible). `content` is optional because an
+/// assistant message that only makes tool calls carries no text.
 #[derive(Debug, Clone, Serialize)]
 pub struct Message {
     pub role: String,
-    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 impl Message {
-    pub fn user(content: impl Into<String>) -> Self {
+    fn base(role: &str, content: Option<String>) -> Self {
         Self {
-            role: "user".to_string(),
-            content: content.into(),
+            role: role.to_string(),
+            content,
+            tool_calls: Vec::new(),
+            tool_call_id: None,
         }
+    }
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::base("user", Some(content.into()))
     }
     pub fn system(content: impl Into<String>) -> Self {
-        Self {
-            role: "system".to_string(),
-            content: content.into(),
-        }
+        Self::base("system", Some(content.into()))
     }
     pub fn assistant(content: impl Into<String>) -> Self {
+        Self::base("assistant", Some(content.into()))
+    }
+    /// The assistant turn that issued tool calls — replayed into the conversation
+    /// before the matching tool results so the API can correlate them.
+    pub fn assistant_with_tool_calls(
+        content: impl Into<String>,
+        tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        let mut m = Self::base("assistant", Some(content.into()));
+        m.tool_calls = tool_calls;
+        m
+    }
+    /// A tool result, keyed to the originating tool call.
+    pub fn tool(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        let mut m = Self::base("tool", Some(content.into()));
+        m.tool_call_id = Some(tool_call_id.into());
+        m
+    }
+}
+
+/// A tool call requested by the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type", default = "function_kind")]
+    pub kind: String,
+    pub function: FunctionCall,
+}
+
+fn function_kind() -> String {
+    "function".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    pub name: String,
+    /// JSON-encoded arguments (a string, per the OpenAI wire format).
+    pub arguments: String,
+}
+
+/// A tool definition advertised to the model.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolDef {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: ToolFunction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolFunction {
+    pub name: String,
+    pub description: String,
+    pub parameters: Value,
+}
+
+impl ToolDef {
+    pub fn function(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: Value,
+    ) -> Self {
         Self {
-            role: "assistant".to_string(),
-            content: content.into(),
+            kind: "function".to_string(),
+            function: ToolFunction {
+                name: name.into(),
+                description: description.into(),
+                parameters,
+            },
         }
     }
 }
 
 /// A vendor-agnostic chat request. `model` is just an id the router understands —
 /// the loop does not know or care which vendor it maps to.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ChatRequest {
     pub model: String,
     pub messages: Vec<Message>,
     pub max_tokens: Option<i64>,
+    pub tools: Vec<ToolDef>,
 }
 
 /// The assistant's reply for one turn.
 #[derive(Debug, Clone)]
 pub struct ChatResponse {
     pub content: String,
+    pub tool_calls: Vec<ToolCall>,
     /// The model the backend actually served (echoed by the API when present).
     pub model: Option<String>,
     pub finish_reason: Option<String>,
@@ -103,6 +179,9 @@ impl LlmProvider for MonocleProvider {
         if let Some(max_tokens) = req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
+        if !req.tools.is_empty() {
+            body["tools"] = json!(req.tools);
+        }
 
         let resp = self.client.post_json(
             &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
@@ -119,16 +198,18 @@ impl LlmProvider for MonocleProvider {
         }
 
         let data: Value = resp.json()?;
-        let choice = &data["choices"][0];
-        let content = choice["message"]["content"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
+        let message = &data["choices"][0]["message"];
+        let content = message["content"].as_str().unwrap_or_default().to_string();
+        let tool_calls: Vec<ToolCall> =
+            serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
         let model = data["model"].as_str().map(String::from);
-        let finish_reason = choice["finish_reason"].as_str().map(String::from);
+        let finish_reason = data["choices"][0]["finish_reason"]
+            .as_str()
+            .map(String::from);
 
         Ok(ChatResponse {
             content,
+            tool_calls,
             model,
             finish_reason,
         })

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -17,7 +17,7 @@ use crate::auth::AuthSession;
 use crate::endpoints;
 use crate::error::{AppError, Result};
 use crate::net::Client;
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 /// One chat message (OpenAI-compatible). `content` is optional because an
 /// assistant message that only makes tool calls carries no text.
@@ -237,7 +237,7 @@ impl LlmProvider for MonocleProvider {
         let bearer = format!("Bearer {}", self.token);
         let resp = self.client.post_json(
             &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
-            &[("Authorization", &bearer), origin_header()],
+            &auth_headers(&bearer),
             &self.build_body(req, false),
         )?;
         if !resp.ok() {
@@ -259,7 +259,7 @@ impl LlmProvider for MonocleProvider {
         let bearer = format!("Bearer {}", self.token);
         let mut stream = self.client.post_json_stream(
             &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
-            &[("Authorization", &bearer), origin_header()],
+            &auth_headers(&bearer),
             &self.build_body(req, true),
         )?;
 

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -140,10 +140,52 @@ pub struct ChatResponse {
     pub finish_reason: Option<String>,
 }
 
+/// Parse an OpenAI-compatible (non-streaming) chat completion body.
+fn parse_response_value(data: &Value) -> ChatResponse {
+    let message = &data["choices"][0]["message"];
+    let content = message["content"].as_str().unwrap_or_default().to_string();
+    let tool_calls: Vec<ToolCall> =
+        serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    let model = data["model"].as_str().map(String::from);
+    let finish_reason = data["choices"][0]["finish_reason"]
+        .as_str()
+        .map(String::from);
+    ChatResponse {
+        content,
+        tool_calls,
+        model,
+        finish_reason,
+    }
+}
+
+/// Accumulates a streamed tool call across SSE deltas (id/name arrive first,
+/// arguments come in fragments).
+#[derive(Default)]
+struct ToolCallAcc {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
 /// The seam the agent loop is built on. Any backend (monocle-routed today, a
 /// direct provider tomorrow) implements this; the loop never names a vendor.
 pub trait LlmProvider {
     fn chat(&self, req: &ChatRequest) -> Result<ChatResponse>;
+
+    /// Streaming variant: emits assistant text deltas via `on_delta` as they
+    /// arrive, returning the assembled final response. Default delegates to
+    /// `chat` and emits the whole content once (fine for tests / non-streaming).
+    fn chat_stream(
+        &self,
+        req: &ChatRequest,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<ChatResponse> {
+        let resp = self.chat(req)?;
+        if !resp.content.is_empty() {
+            on_delta(&resp.content);
+        }
+        Ok(resp)
+    }
 }
 
 /// `LlmProvider` backed by monocle routing (chat-proxy, OpenAI-compatible).
@@ -166,15 +208,12 @@ impl MonocleProvider {
     pub fn from_session(session: AuthSession) -> Self {
         Self::new(session.token, session.router_url)
     }
-}
 
-impl LlmProvider for MonocleProvider {
-    fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
-        let bearer = format!("Bearer {}", self.token);
+    fn build_body(&self, req: &ChatRequest, stream: bool) -> Value {
         let mut body = json!({
             "model": req.model,
             "messages": req.messages,
-            "stream": false,
+            "stream": stream,
         });
         if let Some(max_tokens) = req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
@@ -182,13 +221,18 @@ impl LlmProvider for MonocleProvider {
         if !req.tools.is_empty() {
             body["tools"] = json!(req.tools);
         }
+        body
+    }
+}
 
+impl LlmProvider for MonocleProvider {
+    fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
+        let bearer = format!("Bearer {}", self.token);
         let resp = self.client.post_json(
             &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
             &[("Authorization", &bearer), origin_header()],
-            &body,
+            &self.build_body(req, false),
         )?;
-
         if !resp.ok() {
             return Err(AppError::new(format!(
                 "API error {}: {}",
@@ -196,16 +240,106 @@ impl LlmProvider for MonocleProvider {
                 resp.text()
             )));
         }
-
         let data: Value = resp.json()?;
-        let message = &data["choices"][0]["message"];
-        let content = message["content"].as_str().unwrap_or_default().to_string();
-        let tool_calls: Vec<ToolCall> =
-            serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
-        let model = data["model"].as_str().map(String::from);
-        let finish_reason = data["choices"][0]["finish_reason"]
-            .as_str()
-            .map(String::from);
+        Ok(parse_response_value(&data))
+    }
+
+    fn chat_stream(
+        &self,
+        req: &ChatRequest,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<ChatResponse> {
+        let bearer = format!("Bearer {}", self.token);
+        let mut stream = self.client.post_json_stream(
+            &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
+            &[("Authorization", &bearer), origin_header()],
+            &self.build_body(req, true),
+        )?;
+
+        if !stream.ok() {
+            let status = stream.status;
+            let body = stream.read_all();
+            return Err(AppError::new(format!("API error {status}: {body}")));
+        }
+
+        // Non-SSE response (or a stub): buffer and parse as one completion.
+        if !stream.is_event_stream() {
+            let data: Value = serde_json::from_str(&stream.read_all())?;
+            let resp = parse_response_value(&data);
+            if !resp.content.is_empty() {
+                on_delta(&resp.content);
+            }
+            return Ok(resp);
+        }
+
+        // SSE: assemble content + tool calls from `data:` deltas.
+        let mut content = String::new();
+        let mut finish_reason: Option<String> = None;
+        let mut model: Option<String> = None;
+        let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
+
+        while let Some(raw) = stream.next_line()? {
+            let data = match raw.trim_end().strip_prefix("data:") {
+                Some(d) => d.trim_start().to_string(),
+                None => continue,
+            };
+            if data == "[DONE]" {
+                break;
+            }
+            let v: Value = match serde_json::from_str(&data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if model.is_none() {
+                model = v["model"].as_str().map(String::from);
+            }
+            let choice = &v["choices"][0];
+            if let Some(fr) = choice["finish_reason"].as_str() {
+                finish_reason = Some(fr.to_string());
+            }
+            let delta = &choice["delta"];
+            if let Some(c) = delta["content"].as_str() {
+                if !c.is_empty() {
+                    content.push_str(c);
+                    on_delta(c);
+                }
+            }
+            if let Some(tcs) = delta["tool_calls"].as_array() {
+                for tc in tcs {
+                    let idx = tc["index"].as_u64().unwrap_or(0) as usize;
+                    while tool_acc.len() <= idx {
+                        tool_acc.push(ToolCallAcc::default());
+                    }
+                    let acc = &mut tool_acc[idx];
+                    if let Some(id) = tc["id"].as_str() {
+                        if !id.is_empty() {
+                            acc.id = id.to_string();
+                        }
+                    }
+                    if let Some(name) = tc["function"]["name"].as_str() {
+                        if !name.is_empty() {
+                            acc.name = name.to_string();
+                        }
+                    }
+                    if let Some(args) = tc["function"]["arguments"].as_str() {
+                        acc.arguments.push_str(args);
+                    }
+                }
+            }
+        }
+
+        let tool_calls = tool_acc
+            .into_iter()
+            .filter(|a| !a.name.is_empty())
+            .map(|a| ToolCall {
+                id: a.id,
+                kind: "function".to_string(),
+                function: FunctionCall {
+                    name: a.name,
+                    arguments: a.arguments,
+                },
+            })
+            .collect();
 
         Ok(ChatResponse {
             content,

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -140,8 +140,15 @@ pub struct ChatResponse {
     pub finish_reason: Option<String>,
 }
 
-/// Parse an OpenAI-compatible (non-streaming) chat completion body.
-fn parse_response_value(data: &Value) -> ChatResponse {
+/// Parse an OpenAI-compatible (non-streaming) chat completion body. Errors on a
+/// body with no `choices` (e.g. an error-shaped response) rather than silently
+/// returning an empty assistant turn that the loop would treat as a final answer.
+fn parse_response_value(data: &Value) -> Result<ChatResponse> {
+    if data.get("choices").and_then(|c| c.get(0)).is_none() {
+        return Err(AppError::new(format!(
+            "unexpected chat response (no choices): {data}"
+        )));
+    }
     let message = &data["choices"][0]["message"];
     let content = message["content"].as_str().unwrap_or_default().to_string();
     let tool_calls: Vec<ToolCall> =
@@ -150,12 +157,12 @@ fn parse_response_value(data: &Value) -> ChatResponse {
     let finish_reason = data["choices"][0]["finish_reason"]
         .as_str()
         .map(String::from);
-    ChatResponse {
+    Ok(ChatResponse {
         content,
         tool_calls,
         model,
         finish_reason,
-    }
+    })
 }
 
 /// Accumulates a streamed tool call across SSE deltas (id/name arrive first,
@@ -241,7 +248,7 @@ impl LlmProvider for MonocleProvider {
             )));
         }
         let data: Value = resp.json()?;
-        Ok(parse_response_value(&data))
+        parse_response_value(&data)
     }
 
     fn chat_stream(
@@ -265,7 +272,7 @@ impl LlmProvider for MonocleProvider {
         // Non-SSE response (or a stub): buffer and parse as one completion.
         if !stream.is_event_stream() {
             let data: Value = serde_json::from_str(&stream.read_all())?;
-            let resp = parse_response_value(&data);
+            let resp = parse_response_value(&data)?;
             if !resp.content.is_empty() {
                 on_delta(&resp.content);
             }

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -1,0 +1,136 @@
+//! LLM provider abstraction — the **model-choice-freedom (G1)** seam.
+//!
+//! The agent loop depends on the `LlmProvider` trait, never on a specific vendor.
+//! Swapping the model id (or the provider impl) changes the backing model without
+//! touching the loop. `MonocleProvider` routes through monocle's chat-proxy
+//! (OpenAI-compatible `/v1/chat/completions`), so monocle-model-router /
+//! monocle-auto can select any model and the agent stays vendor-agnostic.
+//!
+//! Spike scope (monocle-cli#44, step 1): one non-streaming turn. No tool calls,
+//! no streaming, no loop yet.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::auth::AuthSession;
+use crate::endpoints;
+use crate::error::{AppError, Result};
+use crate::net::Client;
+use crate::origin::origin_header;
+
+/// One chat message. Serializes to the OpenAI-compatible `{role, content}` shape.
+#[derive(Debug, Clone, Serialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+impl Message {
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: content.into(),
+        }
+    }
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".to_string(),
+            content: content.into(),
+        }
+    }
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: content.into(),
+        }
+    }
+}
+
+/// A vendor-agnostic chat request. `model` is just an id the router understands —
+/// the loop does not know or care which vendor it maps to.
+#[derive(Debug, Clone)]
+pub struct ChatRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    pub max_tokens: Option<i64>,
+}
+
+/// The assistant's reply for one turn.
+#[derive(Debug, Clone)]
+pub struct ChatResponse {
+    pub content: String,
+    /// The model the backend actually served (echoed by the API when present).
+    pub model: Option<String>,
+    pub finish_reason: Option<String>,
+}
+
+/// The seam the agent loop is built on. Any backend (monocle-routed today, a
+/// direct provider tomorrow) implements this; the loop never names a vendor.
+pub trait LlmProvider {
+    fn chat(&self, req: &ChatRequest) -> Result<ChatResponse>;
+}
+
+/// `LlmProvider` backed by monocle routing (chat-proxy, OpenAI-compatible).
+pub struct MonocleProvider {
+    client: Client,
+    token: String,
+    router_url: String,
+}
+
+impl MonocleProvider {
+    pub fn new(token: impl Into<String>, router_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            token: token.into(),
+            router_url: router_url.into(),
+        }
+    }
+
+    /// Build from a resolved auth session (token + router URL).
+    pub fn from_session(session: AuthSession) -> Self {
+        Self::new(session.token, session.router_url)
+    }
+}
+
+impl LlmProvider for MonocleProvider {
+    fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
+        let bearer = format!("Bearer {}", self.token);
+        let mut body = json!({
+            "model": req.model,
+            "messages": req.messages,
+            "stream": false,
+        });
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+
+        let resp = self.client.post_json(
+            &format!("{}{}", self.router_url, endpoints::CHAT_COMPLETIONS),
+            &[("Authorization", &bearer), origin_header()],
+            &body,
+        )?;
+
+        if !resp.ok() {
+            return Err(AppError::new(format!(
+                "API error {}: {}",
+                resp.status,
+                resp.text()
+            )));
+        }
+
+        let data: Value = resp.json()?;
+        let choice = &data["choices"][0];
+        let content = choice["message"]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let model = data["model"].as_str().map(String::from);
+        let finish_reason = choice["finish_reason"].as_str().map(String::from);
+
+        Ok(ChatResponse {
+            content,
+            model,
+            finish_reason,
+        })
+    }
+}

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -27,7 +27,8 @@ impl Approver for AllowAll {
 
 /// Observes loop steps (for printing / logging). Default = no-op ([`Silent`]).
 pub trait Observer {
-    fn on_text(&mut self, _text: &str) {}
+    /// A chunk of assistant text as it streams in.
+    fn on_text_delta(&mut self, _delta: &str) {}
     fn on_tool_call(&mut self, _name: &str, _args: &Value) {}
     fn on_tool_result(&mut self, _name: &str, _outcome: &ToolOutcome) {}
 }
@@ -85,21 +86,24 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         let mut last_text = String::new();
 
         for _step in 0..self.config.max_steps {
-            let resp = self.provider.chat(&ChatRequest {
+            let req = ChatRequest {
                 model: self.config.model.clone(),
                 messages: messages.clone(),
                 max_tokens: self.config.max_tokens,
                 tools: defs.clone(),
-            })?;
+            };
+            // Stream assistant text to the observer as it arrives.
+            let resp = self
+                .provider
+                .chat_stream(&req, &mut |delta| observer.on_text_delta(delta))?;
 
-            // No tool calls → this is the final answer (returned, not observed, so
-            // the caller can route it to stdout exactly once).
+            // No tool calls → this is the final answer (already streamed to the
+            // observer; also returned for programmatic / multi-turn callers).
             if resp.tool_calls.is_empty() {
                 return Ok(resp.content);
             }
 
             if !resp.content.is_empty() {
-                observer.on_text(&resp.content);
                 last_text = resp.content.clone();
             }
             // Replay the assistant's tool-call turn before the matching results.
@@ -148,6 +152,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             "[agent stopped after {} steps without finishing]",
             self.config.max_steps
         );
+        observer.on_text_delta(&format!("\n{notice}\n"));
         Ok(if last_text.is_empty() {
             notice
         } else {

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -125,7 +125,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                             call.function.name
                         ));
                         observer.on_tool_result(&call.function.name, &outcome);
-                        conversation.push(Message::tool(call.id.clone(), outcome.content.clone()));
+                        conversation.push(Message::tool(call.id.clone(), outcome.llm.clone()));
                         continue;
                     }
                 };
@@ -144,7 +144,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 };
 
                 observer.on_tool_result(&call.function.name, &outcome);
-                conversation.push(Message::tool(call.id.clone(), outcome.content.clone()));
+                conversation.push(Message::tool(call.id.clone(), outcome.llm.clone()));
             }
         }
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -1,0 +1,136 @@
+//! The agent-core loop: prompt → LLM (with tools) → execute tool calls → feed
+//! results back → repeat until the model answers with no tool calls.
+//!
+//! Side-effecting tools are gated by an `Approver` (SDD G4 — the permission seam;
+//! a real scoped-approval / sandboxing policy plugs in here later). An `Observer`
+//! surfaces the loop's steps (the CLI prints them; tests stay silent).
+
+use serde_json::{json, Value};
+
+use crate::agent::providers::{ChatRequest, LlmProvider, Message};
+use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::error::{AppError, Result};
+
+/// Decides whether a *side-effecting* tool call may run. Read-only tools are not
+/// gated. (Default policies: [`AllowAll`].)
+pub trait Approver {
+    fn approve(&mut self, tool_name: &str, args: &Value) -> bool;
+}
+
+/// Approve everything — for tests and explicit local "yolo" runs.
+pub struct AllowAll;
+impl Approver for AllowAll {
+    fn approve(&mut self, _tool_name: &str, _args: &Value) -> bool {
+        true
+    }
+}
+
+/// Observes loop steps (for printing / logging). Default = no-op ([`Silent`]).
+pub trait Observer {
+    fn on_text(&mut self, _text: &str) {}
+    fn on_tool_call(&mut self, _name: &str, _args: &Value) {}
+    fn on_tool_result(&mut self, _name: &str, _outcome: &ToolOutcome) {}
+}
+
+pub struct Silent;
+impl Observer for Silent {}
+
+pub struct AgentConfig {
+    pub model: String,
+    pub max_steps: usize,
+    pub max_tokens: Option<i64>,
+}
+
+impl AgentConfig {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            max_steps: 20,
+            max_tokens: None,
+        }
+    }
+}
+
+pub struct Agent<'a, P: LlmProvider> {
+    provider: &'a P,
+    tools: &'a ToolRegistry,
+    ctx: ToolContext,
+    config: AgentConfig,
+}
+
+impl<'a, P: LlmProvider> Agent<'a, P> {
+    pub fn new(
+        provider: &'a P,
+        tools: &'a ToolRegistry,
+        ctx: ToolContext,
+        config: AgentConfig,
+    ) -> Self {
+        Self {
+            provider,
+            tools,
+            ctx,
+            config,
+        }
+    }
+
+    /// Run the loop to completion, returning the model's final text answer.
+    /// `messages` is the seed conversation (e.g. a system prompt + the user task).
+    pub fn run(
+        &self,
+        mut messages: Vec<Message>,
+        approver: &mut dyn Approver,
+        observer: &mut dyn Observer,
+    ) -> Result<String> {
+        let defs = self.tools.defs();
+
+        for _step in 0..self.config.max_steps {
+            let resp = self.provider.chat(&ChatRequest {
+                model: self.config.model.clone(),
+                messages: messages.clone(),
+                max_tokens: self.config.max_tokens,
+                tools: defs.clone(),
+            })?;
+
+            // No tool calls → this is the final answer (returned, not observed, so
+            // the caller can route it to stdout exactly once).
+            if resp.tool_calls.is_empty() {
+                return Ok(resp.content);
+            }
+
+            if !resp.content.is_empty() {
+                observer.on_text(&resp.content);
+            }
+            // Replay the assistant's tool-call turn before the matching results.
+            messages.push(Message::assistant_with_tool_calls(
+                resp.content.clone(),
+                resp.tool_calls.clone(),
+            ));
+
+            for call in &resp.tool_calls {
+                let args: Value =
+                    serde_json::from_str(&call.function.arguments).unwrap_or_else(|_| json!({}));
+                observer.on_tool_call(&call.function.name, &args);
+
+                let side_effecting = self
+                    .tools
+                    .get(&call.function.name)
+                    .map(|t| t.is_side_effecting())
+                    .unwrap_or(true);
+
+                let outcome = if side_effecting && !approver.approve(&call.function.name, &args) {
+                    ToolOutcome::error(format!("tool call `{}` denied", call.function.name))
+                } else {
+                    self.tools.run(&self.ctx, &call.function.name, &args)
+                };
+
+                observer.on_tool_result(&call.function.name, &outcome);
+                messages.push(Message::tool(call.id.clone(), outcome.content.clone()));
+            }
+        }
+
+        Err(AppError::new(format!(
+            "agent did not finish within {} steps",
+            self.config.max_steps
+        )))
+    }
+}

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -55,6 +55,9 @@ pub trait Observer {
     fn on_text_delta(&mut self, _delta: &str) {}
     fn on_tool_call(&mut self, _name: &str, _args: &Value) {}
     fn on_tool_result(&mut self, _name: &str, _outcome: &ToolOutcome) {}
+    /// A meta/control notice (stopped, cancelled) — NOT model answer text, so the
+    /// CLI keeps it off the stdout answer channel.
+    fn on_notice(&mut self, _msg: &str) {}
 }
 
 pub struct Silent;
@@ -115,7 +118,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             // Cancellation is checked at each step boundary (graceful stop).
             if cancel.is_cancelled() {
                 let notice = "[agent cancelled]".to_string();
-                observer.on_text_delta(&format!("\n{notice}\n"));
+                observer.on_notice(&notice);
                 return Ok(if last_text.is_empty() {
                     notice
                 } else {
@@ -189,7 +192,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             "[agent stopped after {} steps without finishing]",
             self.config.max_steps
         );
-        observer.on_text_delta(&format!("\n{notice}\n"));
+        observer.on_notice(&notice);
         Ok(if last_text.is_empty() {
             notice
         } else {

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -74,11 +74,12 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         }
     }
 
-    /// Run the loop to completion, returning the model's final text answer.
-    /// `messages` is the seed conversation (e.g. a system prompt + the user task).
+    /// Run the loop to completion, appending this turn's assistant/tool messages
+    /// to `conversation` (so callers can continue a multi-turn session) and
+    /// returning the model's final text answer.
     pub fn run(
         &self,
-        mut messages: Vec<Message>,
+        conversation: &mut Vec<Message>,
         approver: &mut dyn Approver,
         observer: &mut dyn Observer,
     ) -> Result<String> {
@@ -88,7 +89,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         for _step in 0..self.config.max_steps {
             let req = ChatRequest {
                 model: self.config.model.clone(),
-                messages: messages.clone(),
+                messages: conversation.clone(),
                 max_tokens: self.config.max_tokens,
                 tools: defs.clone(),
             };
@@ -100,6 +101,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             // No tool calls → this is the final answer (already streamed to the
             // observer; also returned for programmatic / multi-turn callers).
             if resp.tool_calls.is_empty() {
+                conversation.push(Message::assistant(resp.content.clone()));
                 return Ok(resp.content);
             }
 
@@ -107,7 +109,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 last_text = resp.content.clone();
             }
             // Replay the assistant's tool-call turn before the matching results.
-            messages.push(Message::assistant_with_tool_calls(
+            conversation.push(Message::assistant_with_tool_calls(
                 resp.content.clone(),
                 resp.tool_calls.clone(),
             ));
@@ -123,7 +125,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                             call.function.name
                         ));
                         observer.on_tool_result(&call.function.name, &outcome);
-                        messages.push(Message::tool(call.id.clone(), outcome.content.clone()));
+                        conversation.push(Message::tool(call.id.clone(), outcome.content.clone()));
                         continue;
                     }
                 };
@@ -142,7 +144,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 };
 
                 observer.on_tool_result(&call.function.name, &outcome);
-                messages.push(Message::tool(call.id.clone(), outcome.content.clone()));
+                conversation.push(Message::tool(call.id.clone(), outcome.content.clone()));
             }
         }
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -5,11 +5,35 @@
 //! a real scoped-approval / sandboxing policy plugs in here later). An `Observer`
 //! surfaces the loop's steps (the CLI prints them; tests stay silent).
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use serde_json::Value;
 
 use crate::agent::providers::{ChatRequest, LlmProvider, Message};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::error::Result;
+
+/// A cheap, clonable cancellation flag shared between the loop and whoever can
+/// stop it (a Ctrl-C handler, an ACP `session/cancel`, a test). Checked at each
+/// step boundary — the loop stops gracefully. Pure and trivially testable.
+#[derive(Clone, Default)]
+pub struct Cancel(Arc<AtomicBool>);
+
+impl Cancel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+    pub fn reset(&self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
 
 /// Decides whether a *side-effecting* tool call may run. Read-only tools are not
 /// gated. (Default policies: [`AllowAll`].)
@@ -82,11 +106,22 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         conversation: &mut Vec<Message>,
         approver: &mut dyn Approver,
         observer: &mut dyn Observer,
+        cancel: &Cancel,
     ) -> Result<String> {
         let defs = self.tools.defs();
         let mut last_text = String::new();
 
         for _step in 0..self.config.max_steps {
+            // Cancellation is checked at each step boundary (graceful stop).
+            if cancel.is_cancelled() {
+                let notice = "[agent cancelled]".to_string();
+                observer.on_text_delta(&format!("\n{notice}\n"));
+                return Ok(if last_text.is_empty() {
+                    notice
+                } else {
+                    format!("{last_text}\n\n{notice}")
+                });
+            }
             let req = ChatRequest {
                 model: self.config.model.clone(),
                 messages: conversation.clone(),

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -5,11 +5,11 @@
 //! a real scoped-approval / sandboxing policy plugs in here later). An `Observer`
 //! surfaces the loop's steps (the CLI prints them; tests stay silent).
 
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::agent::providers::{ChatRequest, LlmProvider, Message};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
-use crate::error::{AppError, Result};
+use crate::error::Result;
 
 /// Decides whether a *side-effecting* tool call may run. Read-only tools are not
 /// gated. (Default policies: [`AllowAll`].)
@@ -82,6 +82,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         observer: &mut dyn Observer,
     ) -> Result<String> {
         let defs = self.tools.defs();
+        let mut last_text = String::new();
 
         for _step in 0..self.config.max_steps {
             let resp = self.provider.chat(&ChatRequest {
@@ -99,6 +100,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
 
             if !resp.content.is_empty() {
                 observer.on_text(&resp.content);
+                last_text = resp.content.clone();
             }
             // Replay the assistant's tool-call turn before the matching results.
             messages.push(Message::assistant_with_tool_calls(
@@ -107,8 +109,20 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             ));
 
             for call in &resp.tool_calls {
-                let args: Value =
-                    serde_json::from_str(&call.function.arguments).unwrap_or_else(|_| json!({}));
+                // Surface malformed arguments back to the model (as a tool error)
+                // instead of silently running the tool with `{}` — let it self-correct.
+                let args: Value = match serde_json::from_str(&call.function.arguments) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let outcome = ToolOutcome::error(format!(
+                            "invalid arguments for `{}` (not valid JSON): {e}",
+                            call.function.name
+                        ));
+                        observer.on_tool_result(&call.function.name, &outcome);
+                        messages.push(Message::tool(call.id.clone(), outcome.content.clone()));
+                        continue;
+                    }
+                };
                 observer.on_tool_call(&call.function.name, &args);
 
                 let side_effecting = self
@@ -128,9 +142,16 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             }
         }
 
-        Err(AppError::new(format!(
-            "agent did not finish within {} steps",
+        // Step budget exhausted: don't throw away work — return the best text so
+        // far with a clear notice (graceful stop, not a hard error).
+        let notice = format!(
+            "[agent stopped after {} steps without finishing]",
             self.config.max_steps
-        )))
+        );
+        Ok(if last_text.is_empty() {
+            notice
+        } else {
+            format!("{last_text}\n\n{notice}")
+        })
     }
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -31,15 +31,28 @@ impl SessionStore {
             return Ok(Vec::new());
         }
         let text = std::fs::read_to_string(&self.path)?;
-        let mut messages = Vec::new();
-        for (i, line) in text.lines().enumerate() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
+        let lines: Vec<&str> = text
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .collect();
+        let mut messages = Vec::with_capacity(lines.len());
+        for (i, line) in lines.iter().enumerate() {
+            match serde_json::from_str::<Message>(line) {
+                Ok(message) => messages.push(message),
+                Err(e) => {
+                    // Tolerate a truncated/corrupt FINAL line (e.g. the process was
+                    // killed mid-write); a corrupt earlier line is real corruption.
+                    if i + 1 == lines.len() {
+                        eprintln!("Warning: dropping incomplete final session line: {e}");
+                        break;
+                    }
+                    return Err(AppError::new(format!(
+                        "corrupt session line {}: {e}",
+                        i + 1
+                    )));
+                }
             }
-            let message: Message = serde_json::from_str(line)
-                .map_err(|e| AppError::new(format!("corrupt session line {}: {e}", i + 1)))?;
-            messages.push(message);
         }
         Ok(messages)
     }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -1,0 +1,73 @@
+//! Session persistence — append-only JSONL of the conversation, replayed on
+//! resume (SDD §9 Phase 2). Path-injectable and pure so it is trivially tested
+//! against a tempdir; no globals.
+//!
+//! One `Message` per line. Resume = read every line back into the conversation;
+//! continue = append only the new messages. Append-only keeps the file cheap to
+//! grow and mirrors the in-memory append-only conversation (prompt-cache friendly).
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::agent::providers::Message;
+use crate::error::{AppError, Result};
+
+pub struct SessionStore {
+    path: PathBuf,
+}
+
+impl SessionStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Replay the persisted conversation (empty if the file does not exist yet).
+    pub fn load(&self) -> Result<Vec<Message>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let text = std::fs::read_to_string(&self.path)?;
+        let mut messages = Vec::new();
+        for (i, line) in text.lines().enumerate() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let message: Message = serde_json::from_str(line)
+                .map_err(|e| AppError::new(format!("corrupt session line {}: {e}", i + 1)))?;
+            messages.push(message);
+        }
+        Ok(messages)
+    }
+
+    /// Append messages (one JSON object per line). Creates the file/dir as needed.
+    pub fn append(&self, messages: &[Message]) -> Result<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        for message in messages {
+            let line = serde_json::to_string(message)?;
+            writeln!(file, "{line}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Default file for a named session under the user's monocle dir:
+/// `<home>/.monocle/agent/<name>.jsonl`.
+pub fn session_path(home: &Path, name: &str) -> PathBuf {
+    home.join(".monocle")
+        .join("agent")
+        .join(format!("{name}.jsonl"))
+}

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -37,25 +37,39 @@ impl ToolContext {
     }
 }
 
-/// The result of running a tool. `is_error` lets the loop/model see failures
-/// without aborting the whole turn.
+/// The result of running a tool, split into two channels (SDD §9a):
+/// `llm` is fed back into the conversation (re-sent every turn → keep bounded);
+/// `ui` is the human/client-facing rendering (falls back to `llm`).
+/// `is_error` lets the loop/model see failures without aborting the whole turn.
 pub struct ToolOutcome {
-    pub content: String,
+    pub llm: String,
+    pub ui: Option<String>,
     pub is_error: bool,
 }
 
 impl ToolOutcome {
-    pub fn ok(content: impl Into<String>) -> Self {
+    pub fn ok(llm: impl Into<String>) -> Self {
         Self {
-            content: content.into(),
+            llm: llm.into(),
+            ui: None,
             is_error: false,
         }
     }
-    pub fn error(content: impl Into<String>) -> Self {
+    pub fn error(llm: impl Into<String>) -> Self {
         Self {
-            content: content.into(),
+            llm: llm.into(),
+            ui: None,
             is_error: true,
         }
+    }
+    /// Attach an explicit human/UI-facing rendering.
+    pub fn with_ui(mut self, ui: impl Into<String>) -> Self {
+        self.ui = Some(ui.into());
+        self
+    }
+    /// The human-facing text (explicit `ui`, else the `llm` channel).
+    pub fn ui_text(&self) -> &str {
+        self.ui.as_deref().unwrap_or(&self.llm)
     }
 }
 
@@ -81,6 +95,25 @@ fn str_arg<'a>(args: &'a Value, key: &str) -> std::result::Result<&'a str, ToolO
     args[key]
         .as_str()
         .ok_or_else(|| ToolOutcome::error(format!("missing or non-string argument: {key}")))
+}
+
+/// Cap on `bash`/`powershell` output fed to the model (re-sent every turn, §9a).
+const MAX_SHELL_CHARS: usize = 20_000;
+
+/// Truncate the middle of long output, keeping head + tail (errors often trail).
+fn cap_output(s: &str, max: usize) -> String {
+    let total = s.chars().count();
+    if total <= max {
+        return s.to_string();
+    }
+    let head_n = max * 3 / 5;
+    let tail_n = max - head_n;
+    let head: String = s.chars().take(head_n).collect();
+    let tail: String = s.chars().skip(total - tail_n).collect();
+    format!(
+        "{head}\n[... {} characters omitted ...]\n{tail}",
+        total - head_n - tail_n
+    )
 }
 
 // ── read_file ──────────────────────────────────────────────────────────────
@@ -112,14 +145,18 @@ impl Tool for ReadFile {
             // Cap large reads so one file can't blow the model's context window.
             Ok(content) => {
                 let total = content.chars().count();
-                if total > MAX_READ_CHARS {
+                let (llm, truncated) = if total > MAX_READ_CHARS {
                     let head: String = content.chars().take(MAX_READ_CHARS).collect();
-                    ToolOutcome::ok(format!(
-                        "{head}\n\n[truncated: showing first {MAX_READ_CHARS} of {total} characters]"
-                    ))
+                    (
+                        format!(
+                            "{head}\n\n[truncated: showing first {MAX_READ_CHARS} of {total} characters]"
+                        ),
+                        ", truncated",
+                    )
                 } else {
-                    ToolOutcome::ok(content)
-                }
+                    (content, "")
+                };
+                ToolOutcome::ok(llm).with_ui(format!("read {path} — {total} chars{truncated}"))
             }
             Err(e) => ToolOutcome::error(format!("read_file failed for {path}: {e}")),
         }
@@ -286,19 +323,24 @@ impl Tool for Shell {
                 let code = out.status.code().unwrap_or(-1);
                 let stdout = String::from_utf8_lossy(&out.stdout);
                 let stderr = String::from_utf8_lossy(&out.stderr);
-                let mut content = String::new();
+                let mut combined = String::new();
                 if !stdout.is_empty() {
-                    content.push_str(&stdout);
+                    combined.push_str(&stdout);
                 }
                 if !stderr.is_empty() {
-                    if !content.is_empty() && !content.ends_with('\n') {
-                        content.push('\n');
+                    if !combined.is_empty() && !combined.ends_with('\n') {
+                        combined.push('\n');
                     }
-                    content.push_str(&stderr);
+                    combined.push_str(&stderr);
                 }
-                content.push_str(&format!("\n[exit code: {code}]"));
+                // Cap the LLM-facing output (re-sent every turn — §9a).
+                let llm = format!(
+                    "{}\n[exit code: {code}]",
+                    cap_output(&combined, MAX_SHELL_CHARS)
+                );
                 ToolOutcome {
-                    content,
+                    llm,
+                    ui: Some(format!("exit {code}")),
                     is_error: !out.status.success(),
                 }
             }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -1,0 +1,339 @@
+//! Tools the agent can call — early-Claude-Code-style: filesystem (read/write/
+//! edit) plus a cross-platform shell (`bash` on macOS/Linux, `powershell` on
+//! Windows). The shell tool's NAME and description are platform-specific so the
+//! model writes syntax for the right shell.
+//!
+//! Safety/sandboxing (SDD G4) is the loop's responsibility via the `Approver`
+//! seam (see `loop`); tools here just execute. Paths resolve relative to the
+//! tool context's working directory.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::{json, Value};
+
+use crate::agent::providers::ToolDef;
+
+/// Execution context shared by all tools (the working directory the agent acts in).
+pub struct ToolContext {
+    pub workdir: PathBuf,
+}
+
+impl ToolContext {
+    pub fn new(workdir: impl Into<PathBuf>) -> Self {
+        Self {
+            workdir: workdir.into(),
+        }
+    }
+
+    /// Resolve a (possibly relative) path against the working directory.
+    fn resolve(&self, p: &str) -> PathBuf {
+        let path = PathBuf::from(p);
+        if path.is_absolute() {
+            path
+        } else {
+            self.workdir.join(path)
+        }
+    }
+}
+
+/// The result of running a tool. `is_error` lets the loop/model see failures
+/// without aborting the whole turn.
+pub struct ToolOutcome {
+    pub content: String,
+    pub is_error: bool,
+}
+
+impl ToolOutcome {
+    pub fn ok(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: false,
+        }
+    }
+    pub fn error(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: true,
+        }
+    }
+}
+
+pub trait Tool {
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
+    /// JSON Schema for the tool's arguments.
+    fn parameters(&self) -> Value;
+    fn run(&self, ctx: &ToolContext, args: &Value) -> ToolOutcome;
+
+    /// Whether the tool mutates state / has side effects (gates approval).
+    /// Read-only tools override this to `false`.
+    fn is_side_effecting(&self) -> bool {
+        true
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef::function(self.name(), self.description(), self.parameters())
+    }
+}
+
+fn str_arg<'a>(args: &'a Value, key: &str) -> std::result::Result<&'a str, ToolOutcome> {
+    args[key]
+        .as_str()
+        .ok_or_else(|| ToolOutcome::error(format!("missing or non-string argument: {key}")))
+}
+
+// ── read_file ──────────────────────────────────────────────────────────────
+
+pub struct ReadFile;
+impl Tool for ReadFile {
+    fn name(&self) -> &str {
+        "read_file"
+    }
+    fn description(&self) -> &str {
+        "Read a UTF-8 text file and return its contents. `path` may be absolute or relative to the working directory."
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": { "path": { "type": "string", "description": "File path to read" } },
+            "required": ["path"]
+        })
+    }
+    fn is_side_effecting(&self) -> bool {
+        false
+    }
+    fn run(&self, ctx: &ToolContext, args: &Value) -> ToolOutcome {
+        let path = match str_arg(args, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        match std::fs::read_to_string(ctx.resolve(path)) {
+            Ok(content) => ToolOutcome::ok(content),
+            Err(e) => ToolOutcome::error(format!("read_file failed for {path}: {e}")),
+        }
+    }
+}
+
+// ── write_file ─────────────────────────────────────────────────────────────
+
+pub struct WriteFile;
+impl Tool for WriteFile {
+    fn name(&self) -> &str {
+        "write_file"
+    }
+    fn description(&self) -> &str {
+        "Write (creating or overwriting) a UTF-8 text file. Creates parent directories as needed."
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "File path to write" },
+                "content": { "type": "string", "description": "Full file contents" }
+            },
+            "required": ["path", "content"]
+        })
+    }
+    fn run(&self, ctx: &ToolContext, args: &Value) -> ToolOutcome {
+        let path = match str_arg(args, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let content = match str_arg(args, "content") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+        let full = ctx.resolve(path);
+        if let Some(parent) = full.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return ToolOutcome::error(format!(
+                    "write_file failed to create {}: {e}",
+                    parent.display()
+                ));
+            }
+        }
+        match std::fs::write(&full, content) {
+            Ok(()) => ToolOutcome::ok(format!("Wrote {} bytes to {path}", content.len())),
+            Err(e) => ToolOutcome::error(format!("write_file failed for {path}: {e}")),
+        }
+    }
+}
+
+// ── edit_file ──────────────────────────────────────────────────────────────
+
+pub struct EditFile;
+impl Tool for EditFile {
+    fn name(&self) -> &str {
+        "edit_file"
+    }
+    fn description(&self) -> &str {
+        "Replace an exact substring in a text file. `old_string` must occur exactly once (include enough surrounding context to make it unique)."
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "File path to edit" },
+                "old_string": { "type": "string", "description": "Exact text to replace (must be unique in the file)" },
+                "new_string": { "type": "string", "description": "Replacement text" }
+            },
+            "required": ["path", "old_string", "new_string"]
+        })
+    }
+    fn run(&self, ctx: &ToolContext, args: &Value) -> ToolOutcome {
+        let path = match str_arg(args, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let old = match str_arg(args, "old_string") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let new = match str_arg(args, "new_string") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let full = ctx.resolve(path);
+        let original = match std::fs::read_to_string(&full) {
+            Ok(c) => c,
+            Err(e) => return ToolOutcome::error(format!("edit_file failed to read {path}: {e}")),
+        };
+        let count = original.matches(old).count();
+        if count == 0 {
+            return ToolOutcome::error(format!("edit_file: `old_string` not found in {path}"));
+        }
+        if count > 1 {
+            return ToolOutcome::error(format!(
+                "edit_file: `old_string` occurs {count} times in {path}; add surrounding context to make it unique"
+            ));
+        }
+        let updated = original.replacen(old, new, 1);
+        match std::fs::write(&full, updated) {
+            Ok(()) => ToolOutcome::ok(format!("Edited {path}")),
+            Err(e) => ToolOutcome::error(format!("edit_file failed to write {path}: {e}")),
+        }
+    }
+}
+
+// ── shell (bash on unix / powershell on windows) ────────────────────────────
+
+pub struct Shell;
+impl Tool for Shell {
+    fn name(&self) -> &str {
+        #[cfg(windows)]
+        {
+            "powershell"
+        }
+        #[cfg(not(windows))]
+        {
+            "bash"
+        }
+    }
+    fn description(&self) -> &str {
+        #[cfg(windows)]
+        {
+            "Run a PowerShell command on Windows in the working directory. Returns combined stdout/stderr and the exit code."
+        }
+        #[cfg(not(windows))]
+        {
+            "Run a bash command on macOS/Linux in the working directory. Returns combined stdout/stderr and the exit code."
+        }
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": { "command": { "type": "string", "description": "The shell command to run" } },
+            "required": ["command"]
+        })
+    }
+    fn run(&self, ctx: &ToolContext, args: &Value) -> ToolOutcome {
+        let command = match str_arg(args, "command") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+
+        #[cfg(windows)]
+        let mut cmd = {
+            let mut c = Command::new("powershell");
+            c.args(["-NoProfile", "-NonInteractive", "-Command", command]);
+            c
+        };
+        #[cfg(not(windows))]
+        let mut cmd = {
+            let mut c = Command::new("bash");
+            c.arg("-c").arg(command);
+            c
+        };
+        cmd.current_dir(&ctx.workdir);
+
+        match cmd.output() {
+            Ok(out) => {
+                let code = out.status.code().unwrap_or(-1);
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let mut content = String::new();
+                if !stdout.is_empty() {
+                    content.push_str(&stdout);
+                }
+                if !stderr.is_empty() {
+                    if !content.is_empty() && !content.ends_with('\n') {
+                        content.push('\n');
+                    }
+                    content.push_str(&stderr);
+                }
+                content.push_str(&format!("\n[exit code: {code}]"));
+                ToolOutcome {
+                    content,
+                    is_error: !out.status.success(),
+                }
+            }
+            Err(e) => ToolOutcome::error(format!("failed to run shell: {e}")),
+        }
+    }
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct ToolRegistry {
+    tools: Vec<Box<dyn Tool>>,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The default early-Claude-Code-style toolset: read/write/edit + shell.
+    pub fn with_defaults() -> Self {
+        let mut r = Self::new();
+        r.add(Box::new(ReadFile));
+        r.add(Box::new(WriteFile));
+        r.add(Box::new(EditFile));
+        r.add(Box::new(Shell));
+        r
+    }
+
+    pub fn add(&mut self, tool: Box<dyn Tool>) {
+        self.tools.push(tool);
+    }
+
+    pub fn defs(&self) -> Vec<ToolDef> {
+        self.tools.iter().map(|t| t.def()).collect()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&dyn Tool> {
+        self.tools
+            .iter()
+            .find(|t| t.name() == name)
+            .map(|b| b.as_ref())
+    }
+
+    pub fn run(&self, ctx: &ToolContext, name: &str, args: &Value) -> ToolOutcome {
+        match self.get(name) {
+            Some(tool) => tool.run(ctx, args),
+            None => ToolOutcome::error(format!("unknown tool: {name}")),
+        }
+    }
+}

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -109,11 +109,25 @@ impl Tool for ReadFile {
             Err(e) => return e,
         };
         match std::fs::read_to_string(ctx.resolve(path)) {
-            Ok(content) => ToolOutcome::ok(content),
+            // Cap large reads so one file can't blow the model's context window.
+            Ok(content) => {
+                let total = content.chars().count();
+                if total > MAX_READ_CHARS {
+                    let head: String = content.chars().take(MAX_READ_CHARS).collect();
+                    ToolOutcome::ok(format!(
+                        "{head}\n\n[truncated: showing first {MAX_READ_CHARS} of {total} characters]"
+                    ))
+                } else {
+                    ToolOutcome::ok(content)
+                }
+            }
             Err(e) => ToolOutcome::error(format!("read_file failed for {path}: {e}")),
         }
     }
 }
+
+/// Cap on `read_file` output (characters) to protect the context window.
+const MAX_READ_CHARS: usize = 50_000;
 
 // ── write_file ─────────────────────────────────────────────────────────────
 

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
-use crate::agent::providers::{LlmProvider, Message, MonocleProvider};
+use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent, AgentConfig, AllowAll, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
@@ -62,19 +62,69 @@ impl Observer for CliObserver {
     }
 }
 
-pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -> Result<()> {
-    let auth = get_access_token(client, creds);
-    let provider = MonocleProvider::from_session(auth);
-    let tools = ToolRegistry::with_defaults();
+/// Per-session driver. Rebuilds the provider each turn so a fresh (auto-refreshed)
+/// token is used — a long-lived interactive session never sends a stale bearer.
+struct Repl<'a> {
+    client: &'a Client,
+    creds: &'a Credentials,
+    tools: ToolRegistry,
+    workdir: PathBuf,
+    model: String,
+    max_steps: usize,
+    cancel: Cancel,
+    session: Option<SessionStore>,
+    convo: Vec<Message>,
+    persisted: usize,
+}
 
+impl Repl<'_> {
+    fn run_turn(&mut self, user: String) -> Result<()> {
+        // Fresh token each turn (get_access_token refreshes if near expiry).
+        let auth = get_access_token(self.client, self.creds);
+        let provider = MonocleProvider::from_session(auth);
+        let mut config = AgentConfig::new(self.model.as_str());
+        config.max_steps = self.max_steps;
+        let agent = Agent::new(
+            &provider,
+            &self.tools,
+            ToolContext::new(self.workdir.clone()),
+            config,
+        );
+
+        // Clear any cancel from an idle Ctrl-C press before starting this turn.
+        self.cancel.reset();
+        let mark = self.convo.len();
+        self.convo.push(Message::user(user));
+        if let Err(e) = agent.run(
+            &mut self.convo,
+            &mut AllowAll,
+            &mut CliObserver,
+            &self.cancel,
+        ) {
+            // Roll back this failed turn's (partial) messages so a retry — and the
+            // persisted session — stay well-formed.
+            self.convo.truncate(mark);
+            return Err(e);
+        }
+
+        let mut out = std::io::stdout();
+        out.write_all(b"\n")?;
+        out.flush()?;
+
+        // Persist this turn's new messages (append-only).
+        if let Some(store) = &self.session {
+            store.append(&self.convo[self.persisted..])?;
+            self.persisted = self.convo.len();
+        }
+        Ok(())
+    }
+}
+
+pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -> Result<()> {
     let workdir = opts
         .workdir
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-
-    let mut config = AgentConfig::new(opts.model);
-    config.max_steps = opts.max_steps;
-    let agent = Agent::new(&provider, &tools, ToolContext::new(workdir.clone()), config);
 
     eprintln!(
         "{} {}",
@@ -98,7 +148,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         .session
         .as_ref()
         .map(|name| SessionStore::new(session_path(&home_dir(), name)));
-    let (mut convo, mut persisted) = match &session {
+    let (convo, persisted) = match &session {
         Some(store) => {
             let loaded = store.load()?;
             if loaded.is_empty() {
@@ -115,11 +165,24 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         None => (vec![Message::system(SYSTEM_PROMPT)], 0),
     };
 
+    let mut repl = Repl {
+        client,
+        creds,
+        tools: ToolRegistry::with_defaults(),
+        workdir,
+        model: opts.model,
+        max_steps: opts.max_steps,
+        cancel,
+        session,
+        convo,
+        persisted,
+    };
+
     let interactive = std::io::stdin().is_terminal();
 
     // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
     if let Some(p) = opts.prompt {
-        run_turn(&agent, &mut convo, p, &cancel, &session, &mut persisted)?;
+        repl.run_turn(p)?;
     } else if !interactive {
         let mut input = String::new();
         std::io::stdin().read_to_string(&mut input)?;
@@ -127,14 +190,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("No input provided.");
             std::process::exit(1);
         }
-        run_turn(
-            &agent,
-            &mut convo,
-            input.trim().to_string(),
-            &cancel,
-            &session,
-            &mut persisted,
-        )?;
+        repl.run_turn(input.trim().to_string())?;
     }
 
     // Piped / one-shot: done. Interactive: keep taking follow-ups in the session.
@@ -164,48 +220,9 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             break;
         }
         // A transient per-turn error must not tear down the interactive session.
-        if let Err(e) = run_turn(
-            &agent,
-            &mut convo,
-            msg.to_string(),
-            &cancel,
-            &session,
-            &mut persisted,
-        ) {
+        if let Err(e) = repl.run_turn(msg.to_string()) {
             eprintln!("{} {e}", c::red("Error:"));
         }
-    }
-    Ok(())
-}
-
-/// Run one user turn to completion: append the message, stream the agent's
-/// answer to stdout (via the observer), and terminate the streamed line.
-#[allow(clippy::too_many_arguments)]
-fn run_turn<P: LlmProvider>(
-    agent: &Agent<'_, P>,
-    convo: &mut Vec<Message>,
-    user: String,
-    cancel: &Cancel,
-    session: &Option<SessionStore>,
-    persisted: &mut usize,
-) -> Result<()> {
-    // Clear any cancel from an idle Ctrl-C press before starting this turn.
-    cancel.reset();
-    let mark = convo.len();
-    convo.push(Message::user(user));
-    if let Err(e) = agent.run(convo, &mut AllowAll, &mut CliObserver, cancel) {
-        // Roll back this failed turn's (partial) messages so a retry — and the
-        // persisted session — stay well-formed.
-        convo.truncate(mark);
-        return Err(e);
-    }
-    let mut out = std::io::stdout();
-    out.write_all(b"\n")?;
-    out.flush()?;
-    // Persist this turn's new messages (append-only).
-    if let Some(store) = session {
-        store.append(&convo[*persisted..])?;
-        *persisted = convo.len();
     }
     Ok(())
 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -51,7 +51,7 @@ impl Observer for CliObserver {
         } else {
             c::green("✓")
         };
-        eprintln!("  {} {}", tag, c::dim(&one_line(&outcome.content, 200)));
+        eprintln!("  {} {}", tag, c::dim(&one_line(outcome.ui_text(), 200)));
     }
 }
 

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -11,12 +11,14 @@ use serde_json::Value;
 
 use crate::agent::providers::{LlmProvider, Message, MonocleProvider};
 use crate::agent::runner::{Agent, AgentConfig, AllowAll, Cancel, Observer};
+use crate::agent::session::{session_path, SessionStore};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
+use crate::util::home_dir;
 
 const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
 (read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
@@ -27,6 +29,7 @@ pub struct AgentOptions {
     pub workdir: Option<String>,
     pub model: String,
     pub max_steps: usize,
+    pub session: Option<String>,
 }
 
 struct CliObserver;
@@ -86,12 +89,33 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         move || c.cancel()
     });
 
+    // Optional named session: resume by replaying the persisted conversation.
+    let session: Option<SessionStore> = opts
+        .session
+        .as_ref()
+        .map(|name| SessionStore::new(session_path(&home_dir(), name)));
+    let (mut convo, mut persisted) = match &session {
+        Some(store) => {
+            let loaded = store.load()?;
+            if loaded.is_empty() {
+                (vec![Message::system(SYSTEM_PROMPT)], 0)
+            } else {
+                eprintln!(
+                    "{}",
+                    c::dim(&format!("resumed session ({} messages)", loaded.len()))
+                );
+                let n = loaded.len();
+                (loaded, n)
+            }
+        }
+        None => (vec![Message::system(SYSTEM_PROMPT)], 0),
+    };
+
     let interactive = std::io::stdin().is_terminal();
-    let mut convo = vec![Message::system(SYSTEM_PROMPT)];
 
     // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
     if let Some(p) = opts.prompt {
-        run_turn(&agent, &mut convo, p, &cancel)?;
+        run_turn(&agent, &mut convo, p, &cancel, &session, &mut persisted)?;
     } else if !interactive {
         let mut input = String::new();
         std::io::stdin().read_to_string(&mut input)?;
@@ -99,7 +123,14 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("No input provided.");
             std::process::exit(1);
         }
-        run_turn(&agent, &mut convo, input.trim().to_string(), &cancel)?;
+        run_turn(
+            &agent,
+            &mut convo,
+            input.trim().to_string(),
+            &cancel,
+            &session,
+            &mut persisted,
+        )?;
     }
 
     // Piped / one-shot: done. Interactive: keep taking follow-ups in the session.
@@ -128,18 +159,28 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("Bye.");
             break;
         }
-        run_turn(&agent, &mut convo, msg.to_string(), &cancel)?;
+        run_turn(
+            &agent,
+            &mut convo,
+            msg.to_string(),
+            &cancel,
+            &session,
+            &mut persisted,
+        )?;
     }
     Ok(())
 }
 
 /// Run one user turn to completion: append the message, stream the agent's
 /// answer to stdout (via the observer), and terminate the streamed line.
+#[allow(clippy::too_many_arguments)]
 fn run_turn<P: LlmProvider>(
     agent: &Agent<'_, P>,
     convo: &mut Vec<Message>,
     user: String,
     cancel: &Cancel,
+    session: &Option<SessionStore>,
+    persisted: &mut usize,
 ) -> Result<()> {
     // Clear any cancel from an idle Ctrl-C press before starting this turn.
     cancel.reset();
@@ -148,6 +189,11 @@ fn run_turn<P: LlmProvider>(
     let mut out = std::io::stdout();
     out.write_all(b"\n")?;
     out.flush()?;
+    // Persist this turn's new messages (append-only).
+    if let Some(store) = session {
+        store.append(&convo[*persisted..])?;
+        *persisted = convo.len();
+    }
     Ok(())
 }
 

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -31,14 +31,15 @@ pub struct AgentOptions {
 
 struct CliObserver;
 impl Observer for CliObserver {
-    fn on_text(&mut self, text: &str) {
-        if !text.trim().is_empty() {
-            eprintln!("{}", c::dim(text));
-        }
+    fn on_text_delta(&mut self, delta: &str) {
+        // Stream assistant text to stdout as it arrives (tool progress goes to stderr).
+        let mut out = std::io::stdout();
+        let _ = out.write_all(delta.as_bytes());
+        let _ = out.flush();
     }
     fn on_tool_call(&mut self, name: &str, args: &Value) {
         eprintln!(
-            "{} {} {}",
+            "\n{} {} {}",
             c::cyan("⏵"),
             c::bold(name),
             c::dim(&one_line(&args.to_string(), 120))
@@ -78,15 +79,17 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         c::yellow("⚠ experimental: tools auto-approved (read/write/edit + shell). Run only in a directory you trust.")
     );
 
-    let answer = agent.run(
+    // Assistant text (including the final answer) is streamed to stdout by the
+    // observer as it arrives; we don't reprint the returned value.
+    agent.run(
         vec![Message::system(SYSTEM_PROMPT), Message::user(opts.prompt)],
         &mut AllowAll,
         &mut CliObserver,
     )?;
 
     let mut out = std::io::stdout();
-    out.write_all(answer.as_bytes())?;
     out.write_all(b"\n")?;
+    out.flush()?;
     Ok(())
 }
 

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -4,12 +4,12 @@
 //! edit + cross-platform shell) into the agent-core loop, prints progress to
 //! stderr, and the final answer to stdout.
 
-use std::io::Write;
+use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
 
 use serde_json::Value;
 
-use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::providers::{LlmProvider, Message, MonocleProvider};
 use crate::agent::runner::{Agent, AgentConfig, AllowAll, Observer};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::auth::get_access_token;
@@ -18,12 +18,12 @@ use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
 
-const SYSTEM_PROMPT: &str = "You are Monocle's headless coding agent. Use the provided tools \
+const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
 (read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
 working directory. Take minimal, verified steps. When finished, give a brief summary.";
 
 pub struct AgentOptions {
-    pub prompt: String,
+    pub prompt: Option<String>,
     pub workdir: Option<String>,
     pub model: String,
     pub max_steps: usize,
@@ -79,14 +79,62 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         c::yellow("⚠ experimental: tools auto-approved (read/write/edit + shell). Run only in a directory you trust.")
     );
 
-    // Assistant text (including the final answer) is streamed to stdout by the
-    // observer as it arrives; we don't reprint the returned value.
-    agent.run(
-        vec![Message::system(SYSTEM_PROMPT), Message::user(opts.prompt)],
-        &mut AllowAll,
-        &mut CliObserver,
-    )?;
+    let interactive = std::io::stdin().is_terminal();
+    let mut convo = vec![Message::system(SYSTEM_PROMPT)];
 
+    // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
+    if let Some(p) = opts.prompt {
+        run_turn(&agent, &mut convo, p)?;
+    } else if !interactive {
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input)?;
+        if input.trim().is_empty() {
+            eprintln!("No input provided.");
+            std::process::exit(1);
+        }
+        run_turn(&agent, &mut convo, input.trim().to_string())?;
+    }
+
+    // Piped / one-shot: done. Interactive: keep taking follow-ups in the session.
+    if !interactive {
+        return Ok(());
+    }
+
+    eprintln!(
+        "{}",
+        c::dim("Interactive — type a follow-up; Ctrl-D or /exit to quit.")
+    );
+    let stdin = std::io::stdin();
+    loop {
+        eprint!("\n{} ", c::cyan("»"));
+        let _ = std::io::stderr().flush();
+        let mut line = String::new();
+        if stdin.read_line(&mut line)? == 0 {
+            eprintln!("\nBye.");
+            break;
+        }
+        let msg = line.trim();
+        if msg.is_empty() {
+            continue;
+        }
+        if msg == "/exit" || msg == "/quit" {
+            eprintln!("Bye.");
+            break;
+        }
+        run_turn(&agent, &mut convo, msg.to_string())?;
+    }
+    Ok(())
+}
+
+/// Run one user turn to completion: append the message, stream the agent's
+/// answer to stdout (via the observer), and terminate the streamed line.
+fn run_turn<P: LlmProvider>(
+    agent: &Agent<'_, P>,
+    convo: &mut Vec<Message>,
+    user: String,
+) -> Result<()> {
+    convo.push(Message::user(user));
+    agent.run(convo, &mut AllowAll, &mut CliObserver)?;
     let mut out = std::io::stdout();
     out.write_all(b"\n")?;
     out.flush()?;

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::providers::{LlmProvider, Message, MonocleProvider};
-use crate::agent::runner::{Agent, AgentConfig, AllowAll, Observer};
+use crate::agent::runner::{Agent, AgentConfig, AllowAll, Cancel, Observer};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::auth::get_access_token;
 use crate::colors as c;
@@ -79,12 +79,19 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         c::yellow("⚠ experimental: tools auto-approved (read/write/edit + shell). Run only in a directory you trust.")
     );
 
+    // Ctrl-C cancels the *current turn* (not the process); Ctrl-D / /exit quits.
+    let cancel = Cancel::new();
+    let _ = ctrlc::set_handler({
+        let c = cancel.clone();
+        move || c.cancel()
+    });
+
     let interactive = std::io::stdin().is_terminal();
     let mut convo = vec![Message::system(SYSTEM_PROMPT)];
 
     // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
     if let Some(p) = opts.prompt {
-        run_turn(&agent, &mut convo, p)?;
+        run_turn(&agent, &mut convo, p, &cancel)?;
     } else if !interactive {
         let mut input = String::new();
         std::io::stdin().read_to_string(&mut input)?;
@@ -92,7 +99,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("No input provided.");
             std::process::exit(1);
         }
-        run_turn(&agent, &mut convo, input.trim().to_string())?;
+        run_turn(&agent, &mut convo, input.trim().to_string(), &cancel)?;
     }
 
     // Piped / one-shot: done. Interactive: keep taking follow-ups in the session.
@@ -102,7 +109,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
 
     eprintln!(
         "{}",
-        c::dim("Interactive — type a follow-up; Ctrl-D or /exit to quit.")
+        c::dim("Interactive — Ctrl-C aborts the turn; Ctrl-D or /exit to quit.")
     );
     let stdin = std::io::stdin();
     loop {
@@ -121,7 +128,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("Bye.");
             break;
         }
-        run_turn(&agent, &mut convo, msg.to_string())?;
+        run_turn(&agent, &mut convo, msg.to_string(), &cancel)?;
     }
     Ok(())
 }
@@ -132,9 +139,12 @@ fn run_turn<P: LlmProvider>(
     agent: &Agent<'_, P>,
     convo: &mut Vec<Message>,
     user: String,
+    cancel: &Cancel,
 ) -> Result<()> {
+    // Clear any cancel from an idle Ctrl-C press before starting this turn.
+    cancel.reset();
     convo.push(Message::user(user));
-    agent.run(convo, &mut AllowAll, &mut CliObserver)?;
+    agent.run(convo, &mut AllowAll, &mut CliObserver, cancel)?;
     let mut out = std::io::stdout();
     out.write_all(b"\n")?;
     out.flush()?;

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -56,11 +56,15 @@ impl Observer for CliObserver {
         };
         eprintln!("  {} {}", tag, c::dim(&one_line(outcome.ui_text(), 200)));
     }
+    fn on_notice(&mut self, msg: &str) {
+        // Control notices go to stderr — stdout stays the clean answer channel.
+        eprintln!("\n{}", c::dim(msg));
+    }
 }
 
 pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -> Result<()> {
-    let session = get_access_token(client, creds);
-    let provider = MonocleProvider::from_session(session);
+    let auth = get_access_token(client, creds);
+    let provider = MonocleProvider::from_session(auth);
     let tools = ToolRegistry::with_defaults();
 
     let workdir = opts
@@ -159,14 +163,17 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
             eprintln!("Bye.");
             break;
         }
-        run_turn(
+        // A transient per-turn error must not tear down the interactive session.
+        if let Err(e) = run_turn(
             &agent,
             &mut convo,
             msg.to_string(),
             &cancel,
             &session,
             &mut persisted,
-        )?;
+        ) {
+            eprintln!("{} {e}", c::red("Error:"));
+        }
     }
     Ok(())
 }
@@ -184,8 +191,14 @@ fn run_turn<P: LlmProvider>(
 ) -> Result<()> {
     // Clear any cancel from an idle Ctrl-C press before starting this turn.
     cancel.reset();
+    let mark = convo.len();
     convo.push(Message::user(user));
-    agent.run(convo, &mut AllowAll, &mut CliObserver, cancel)?;
+    if let Err(e) = agent.run(convo, &mut AllowAll, &mut CliObserver, cancel) {
+        // Roll back this failed turn's (partial) messages so a retry — and the
+        // persisted session — stay well-formed.
+        convo.truncate(mark);
+        return Err(e);
+    }
     let mut out = std::io::stdout();
     out.write_all(b"\n")?;
     out.flush()?;

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,0 +1,102 @@
+//! `monocle agent` — experimental headless agent loop (Path B, monocle-cli#44).
+//!
+//! Wires the real provider (monocle routing) + the default toolset (read/write/
+//! edit + cross-platform shell) into the agent-core loop, prints progress to
+//! stderr, and the final answer to stdout.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::runner::{Agent, AgentConfig, AllowAll, Observer};
+use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::auth::get_access_token;
+use crate::colors as c;
+use crate::credentials::Credentials;
+use crate::error::Result;
+use crate::net::Client;
+
+const SYSTEM_PROMPT: &str = "You are Monocle's headless coding agent. Use the provided tools \
+(read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
+working directory. Take minimal, verified steps. When finished, give a brief summary.";
+
+pub struct AgentOptions {
+    pub prompt: String,
+    pub workdir: Option<String>,
+    pub model: String,
+    pub max_steps: usize,
+}
+
+struct CliObserver;
+impl Observer for CliObserver {
+    fn on_text(&mut self, text: &str) {
+        if !text.trim().is_empty() {
+            eprintln!("{}", c::dim(text));
+        }
+    }
+    fn on_tool_call(&mut self, name: &str, args: &Value) {
+        eprintln!(
+            "{} {} {}",
+            c::cyan("⏵"),
+            c::bold(name),
+            c::dim(&one_line(&args.to_string(), 120))
+        );
+    }
+    fn on_tool_result(&mut self, _name: &str, outcome: &ToolOutcome) {
+        let tag = if outcome.is_error {
+            c::red("✗")
+        } else {
+            c::green("✓")
+        };
+        eprintln!("  {} {}", tag, c::dim(&one_line(&outcome.content, 200)));
+    }
+}
+
+pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -> Result<()> {
+    let session = get_access_token(client, creds);
+    let provider = MonocleProvider::from_session(session);
+    let tools = ToolRegistry::with_defaults();
+
+    let workdir = opts
+        .workdir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+    let mut config = AgentConfig::new(opts.model);
+    config.max_steps = opts.max_steps;
+    let agent = Agent::new(&provider, &tools, ToolContext::new(workdir.clone()), config);
+
+    eprintln!(
+        "{} {}",
+        c::dim("agent · workdir"),
+        c::dim(&workdir.display().to_string())
+    );
+    eprintln!(
+        "{}",
+        c::yellow("⚠ experimental: tools auto-approved (read/write/edit + shell). Run only in a directory you trust.")
+    );
+
+    let answer = agent.run(
+        vec![Message::system(SYSTEM_PROMPT), Message::user(opts.prompt)],
+        &mut AllowAll,
+        &mut CliObserver,
+    )?;
+
+    let mut out = std::io::stdout();
+    out.write_all(answer.as_bytes())?;
+    out.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Collapse whitespace and truncate, for compact one-line progress output.
+fn one_line(s: &str, max: usize) -> String {
+    let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > max {
+        let head: String = collapsed.chars().take(max).collect();
+        format!("{head}…")
+    } else {
+        collapsed
+    }
+}

--- a/src/commands/audio_speech.rs
+++ b/src/commands/audio_speech.rs
@@ -9,7 +9,7 @@ use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::{AppError, Result};
 use crate::net::Client;
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 const DEFAULT_MODEL: &str = "gpt-4o-mini-tts";
 const DEFAULT_VOICE: &str = "alloy";
@@ -63,7 +63,7 @@ pub fn audio_speech_command(
     let bearer = format!("Bearer {}", session.token);
     let resp = client.post_json(
         &format!("{}{}", session.router_url, endpoints::AUDIO_SPEECH),
-        &[("Authorization", &bearer), origin_header()],
+        &auth_headers(&bearer),
         &payload,
     )?;
 

--- a/src/commands/audio_transcribe.rs
+++ b/src/commands/audio_transcribe.rs
@@ -6,7 +6,7 @@ use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
 use crate::net::{Client, FilePart};
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 #[derive(Default)]
 pub struct AudioTranscribeOptions {
@@ -53,7 +53,7 @@ pub fn audio_transcribe_command(
     let bearer = format!("Bearer {}", session.token);
     let resp = client.post_multipart(
         &format!("{}{}", session.router_url, endpoints::AUDIO_TRANSCRIPTIONS),
-        &[("Authorization", &bearer), origin_header()],
+        &auth_headers(&bearer),
         FilePart {
             field: "file".to_string(),
             filename: input.filename,

--- a/src/commands/audio_transcribe_azure.rs
+++ b/src/commands/audio_transcribe_azure.rs
@@ -8,7 +8,7 @@ use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::{AppError, Result};
 use crate::net::{Client, FilePart};
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 #[derive(Default)]
 pub struct AudioTranscribeAzureOptions {
@@ -87,7 +87,7 @@ pub fn audio_transcribe_azure_command(
     let bearer = format!("Bearer {}", session.token);
     let resp = client.post_multipart(
         &format!("{}{}", session.router_url, endpoints::AZURE_SPEECH_TO_TEXT),
-        &[("Authorization", &bearer), origin_header()],
+        &auth_headers(&bearer),
         FilePart {
             field: "audio".to_string(),
             filename: input.filename,

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,14 +1,14 @@
 use std::io::{IsTerminal, Write};
 
-use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::Value;
 
+use crate::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
 use crate::auth::get_access_token;
 use crate::credentials::Credentials;
 use crate::endpoints;
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::net::Client;
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS: i64 = 4096;
@@ -20,63 +20,27 @@ pub struct ChatOptions {
     pub max_tokens: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct ChatChoiceMsg {
-    content: Option<String>,
-}
-#[derive(Deserialize)]
-struct ChatChoice {
-    message: Option<ChatChoiceMsg>,
-}
-#[derive(Deserialize)]
-struct ChatResponse {
-    #[serde(default)]
-    choices: Vec<ChatChoice>,
-}
-
+/// One non-streaming chat turn via the shared provider (chat-proxy routing).
 fn call_chat(
-    client: &Client,
-    router_url: &str,
-    token: &str,
+    provider: &MonocleProvider,
     model: &str,
     system_prompt: Option<&str>,
     user_message: &str,
     max_tokens: i64,
 ) -> Result<String> {
-    let mut messages: Vec<Value> = Vec::new();
+    let mut messages = Vec::new();
     if let Some(sp) = system_prompt {
-        messages.push(json!({ "role": "system", "content": sp }));
+        messages.push(Message::system(sp));
     }
-    messages.push(json!({ "role": "user", "content": user_message }));
+    messages.push(Message::user(user_message));
 
-    let bearer = format!("Bearer {token}");
-    let resp = client.post_json(
-        &format!("{router_url}{}", endpoints::CHAT_COMPLETIONS),
-        &[("Authorization", &bearer), origin_header()],
-        &json!({
-            "model": model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "stream": false,
-        }),
-    )?;
-
-    if !resp.ok() {
-        return Err(AppError::new(format!(
-            "API error {}: {}",
-            resp.status,
-            resp.text()
-        )));
-    }
-
-    let data: ChatResponse = resp.json()?;
-    Ok(data
-        .choices
-        .into_iter()
-        .next()
-        .and_then(|c| c.message)
-        .and_then(|m| m.content)
-        .unwrap_or_default())
+    let resp = provider.chat(&ChatRequest {
+        model: model.to_string(),
+        messages,
+        max_tokens: Some(max_tokens),
+        ..Default::default()
+    })?;
+    Ok(resp.content)
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
@@ -110,7 +74,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     // Validate the model ID against the available models (non-fatal on failure).
     if let Ok(resp) = client.get(
         &format!("{router_url}{}", endpoints::MODELS),
-        &[("Authorization", &bearer), origin_header()],
+        &auth_headers(&bearer),
     ) {
         if resp.ok() {
             if let Ok(data) = resp.json::<Value>() {
@@ -135,6 +99,8 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         }
     }
 
+    let provider = MonocleProvider::new(token, router_url.clone());
+
     // Non-interactive: stdin is piped.
     if !std::io::stdin().is_terminal() {
         let mut input = String::new();
@@ -146,9 +112,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
         let result = call_chat(
-            client,
-            &router_url,
-            &token,
+            &provider,
             &model,
             system_prompt.as_deref(),
             input.trim(),
@@ -192,9 +156,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
 
         eprintln!();
         match call_chat(
-            client,
-            &router_url,
-            &token,
+            &provider,
             &model,
             system_prompt.as_deref(),
             trimmed,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod audio_speech;
 pub mod audio_speech_azure;
 pub mod audio_transcribe;

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -7,7 +7,7 @@ use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::{AppError, Result};
 use crate::net::Client;
-use crate::origin::origin_header;
+use crate::origin::auth_headers;
 
 #[derive(Deserialize)]
 struct ModelInfo {
@@ -39,7 +39,7 @@ pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
 
     let resp = client.get(
         &format!("{}{}", session.router_url, endpoints::MODELS),
-        &[("Authorization", &bearer), origin_header()],
+        &auth_headers(&bearer),
     )?;
 
     if !resp.ok() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Library surface for the `monocle` CLI. The binary (`src/main.rs`) is a thin
 //! clap front-end over these modules; tests import them directly.
 
+pub mod agent;
 pub mod audio_io;
 pub mod auth;
 pub mod colors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,8 @@ enum Commands {
     Chat(ChatArgs),
     /// [Experimental] Headless agent loop with tools (read/write/edit + shell)
     Agent {
-        /// The task/prompt for the agent
-        prompt: String,
+        /// The task/prompt (optional; omit to type it interactively, or pipe via stdin)
+        prompt: Option<String>,
         /// Working directory the agent acts in (default: current directory)
         #[arg(long)]
         workdir: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand};
 
+use monocle_cli::commands::agent::{agent_command, AgentOptions};
 use monocle_cli::commands::audio_speech::{audio_speech_command, AudioSpeechOptions};
 use monocle_cli::commands::audio_speech_azure::{
     audio_speech_azure_command, AudioSpeechAzureOptions,
@@ -64,6 +65,20 @@ enum Commands {
     Models,
     /// Chat with LLM via Monocle router (interactive REPL or pipe from stdin)
     Chat(ChatArgs),
+    /// [Experimental] Headless agent loop with tools (read/write/edit + shell)
+    Agent {
+        /// The task/prompt for the agent
+        prompt: String,
+        /// Working directory the agent acts in (default: current directory)
+        #[arg(long)]
+        workdir: Option<String>,
+        /// Model id to use (routed via Monocle)
+        #[arg(long, default_value = "claude-sonnet-4-6")]
+        model: String,
+        /// Maximum loop steps before giving up
+        #[arg(long = "max-steps", default_value = "20")]
+        max_steps: usize,
+    },
     /// Call audio (STT / TTS) endpoints directly for debugging
     Audio {
         #[command(subcommand)]
@@ -228,6 +243,21 @@ fn main() {
         }
         Commands::Models => model_list_command(&client, &creds),
         Commands::Chat(args) => chat_command(&client, &creds, args.into()),
+        Commands::Agent {
+            prompt,
+            workdir,
+            model,
+            max_steps,
+        } => agent_command(
+            &client,
+            &creds,
+            AgentOptions {
+                prompt,
+                workdir,
+                model,
+                max_steps,
+            },
+        ),
         Commands::Audio { command } => run_audio(&client, &creds, command),
         Commands::Model { command } => {
             match command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,9 @@ enum Commands {
         /// Maximum loop steps before giving up
         #[arg(long = "max-steps", default_value = "20")]
         max_steps: usize,
+        /// Named session to persist/resume (~/.monocle/agent/<name>.jsonl)
+        #[arg(long)]
+        session: Option<String>,
     },
     /// Call audio (STT / TTS) endpoints directly for debugging
     Audio {
@@ -248,6 +251,7 @@ fn main() {
             workdir,
             model,
             max_steps,
+            session,
         } => agent_command(
             &client,
             &creds,
@@ -256,6 +260,7 @@ fn main() {
                 workdir,
                 model,
                 max_steps,
+                session,
             },
         ),
         Commands::Audio { command } => run_audio(&client, &creds, command),

--- a/src/net.rs
+++ b/src/net.rs
@@ -7,6 +7,8 @@
 //! signatures — so "go async later" never colors the call tree. Keep `reqwest`
 //! types from leaking past this boundary.
 
+use std::io::{BufRead, BufReader, Read};
+
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
@@ -136,6 +138,33 @@ impl Client {
         }
         send(req)
     }
+
+    /// POST `application/json` and return a streaming line reader over the (SSE)
+    /// response body — no buffering. For `stream: true` chat completions.
+    pub fn post_json_stream(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: &Value,
+    ) -> Result<EventStream> {
+        let mut req = self.inner.post(url).json(body);
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        Ok(EventStream {
+            status,
+            content_type,
+            reader: BufReader::new(resp),
+        })
+    }
 }
 
 fn send(req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
@@ -148,4 +177,41 @@ fn send(req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
         status_text,
         body,
     })
+}
+
+/// A streaming HTTP response — a blocking line reader over the body. Keeps the
+/// `reqwest` type private so streaming stays behind the net boundary; the caller
+/// parses SSE (`data:` lines) itself.
+pub struct EventStream {
+    pub status: u16,
+    pub content_type: String,
+    reader: BufReader<reqwest::blocking::Response>,
+}
+
+impl EventStream {
+    pub fn ok(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// Whether the body is a Server-Sent Events stream.
+    pub fn is_event_stream(&self) -> bool {
+        self.content_type.contains("event-stream")
+    }
+
+    /// Next line (including the trailing newline), or `None` at end of stream.
+    pub fn next_line(&mut self) -> Result<Option<String>> {
+        let mut line = String::new();
+        let n = self
+            .reader
+            .read_line(&mut line)
+            .map_err(|e| AppError(e.to_string()))?;
+        Ok(if n == 0 { None } else { Some(line) })
+    }
+
+    /// Drain the remaining body to a string (error bodies / non-SSE responses).
+    pub fn read_all(&mut self) -> String {
+        let mut s = String::new();
+        let _ = self.reader.read_to_string(&mut s);
+        s
+    }
 }

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -11,3 +11,10 @@ pub const ORIGIN_HEADER_NAME: &str = "x-monocle-origin";
 pub fn origin_header() -> (&'static str, &'static str) {
     (ORIGIN_HEADER_NAME, MONOCLE_ORIGIN)
 }
+
+/// The standard headers for an authenticated chat-proxy call: bearer auth + the
+/// origin attribution header. `bearer` must be the full `Bearer <token>` value.
+/// One place owns this contract so a new header is added once, not at every site.
+pub fn auth_headers(bearer: &str) -> [(&str, &str); 2] {
+    [("Authorization", bearer), origin_header()]
+}

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -168,7 +168,12 @@ fn conversation_persists_across_turns() {
     let provider = MonocleProvider::new("tok", s.router_url());
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let agent = Agent::new(&provider, &tools, ToolContext::new(dir.path()), AgentConfig::new("any"));
+    let agent = Agent::new(
+        &provider,
+        &tools,
+        ToolContext::new(dir.path()),
+        AgentConfig::new("any"),
+    );
 
     let mut convo = vec![Message::system("s"), Message::user("first")];
     let a1 = agent.run(&mut convo, &mut AllowAll, &mut Silent).unwrap();

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -59,7 +59,7 @@ fn loop_executes_tool_then_returns_final_answer() {
 
     let answer = agent
         .run(
-            vec![
+            &mut vec![
                 Message::system("be helpful"),
                 Message::user("write out.txt"),
             ],
@@ -98,7 +98,7 @@ fn denied_side_effecting_tool_is_not_executed() {
 
     let answer = agent
         .run(
-            vec![Message::user("write out.txt")],
+            &mut vec![Message::user("write out.txt")],
             &mut DenyAll,
             &mut Silent,
         )
@@ -139,12 +139,48 @@ fn loop_stops_at_max_steps() {
     // Graceful stop: returns a notice (not a hard error) so partial work isn't lost.
     let answer = agent
         .run(
-            vec![Message::user("loop forever")],
+            &mut vec![Message::user("loop forever")],
             &mut AllowAll,
             &mut Silent,
         )
         .unwrap();
     assert!(answer.contains("stopped after 3 steps"), "got: {answer}");
+}
+
+#[test]
+fn conversation_persists_across_turns() {
+    // No-tool stub whose answer reports how many `user` messages it saw — proof
+    // the conversation carries forward between `run` calls (multi-turn).
+    let s = stub(|_a, _m, url, body| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
+        let users = req["messages"]
+            .as_array()
+            .map(|ms| ms.iter().filter(|m| m["role"] == "user").count())
+            .unwrap_or(0);
+        (
+            200,
+            json!({"choices":[{"message":{"role":"assistant","content":format!("seen {users}")},"finish_reason":"stop"}]}).to_string(),
+        )
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = Agent::new(&provider, &tools, ToolContext::new(dir.path()), AgentConfig::new("any"));
+
+    let mut convo = vec![Message::system("s"), Message::user("first")];
+    let a1 = agent.run(&mut convo, &mut AllowAll, &mut Silent).unwrap();
+    assert_eq!(a1, "seen 1");
+
+    // `run` appended the assistant answer; a follow-up turn sees both users.
+    convo.push(Message::user("second"));
+    let a2 = agent.run(&mut convo, &mut AllowAll, &mut Silent).unwrap();
+    assert_eq!(a2, "seen 2");
+
+    // system, user, assistant, user, assistant
+    assert_eq!(convo.len(), 5);
 }
 
 #[test]
@@ -179,7 +215,11 @@ fn malformed_tool_args_are_reported_to_model_not_swallowed() {
     );
 
     let answer = agent
-        .run(vec![Message::user("do it")], &mut AllowAll, &mut Silent)
+        .run(
+            &mut vec![Message::user("do it")],
+            &mut AllowAll,
+            &mut Silent,
+        )
         .unwrap();
     assert_eq!(answer, "recovered");
 }

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1,51 +1,50 @@
 mod common;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use serde_json::{json, Value};
 
-use common::stub;
-use monocle_cli::agent::providers::{Message, MonocleProvider};
-use monocle_cli::agent::runner::{Agent, AgentConfig, AllowAll, Approver, Observer, Silent};
+use common::{
+    has_tool_result, text_response, tool_call_response, tool_call_response_raw, FakeProvider,
+};
+use monocle_cli::agent::providers::Message;
+use monocle_cli::agent::runner::{
+    Agent, AgentConfig, AllowAll, Approver, Cancel, Observer, Silent,
+};
 use monocle_cli::agent::tools::{ToolContext, ToolRegistry};
 
-/// Stateful stub LLM: first turn requests a `write_file` tool call; once it sees
-/// a tool-result message in the conversation, it returns a final answer.
-fn write_then_finish_stub() -> common::Stub {
-    stub(|_addr, _method, url, body| {
-        if !url.starts_with("/v1/chat/completions") {
-            return (404, String::new());
-        }
-        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
-        let seen_tool_result = req["messages"]
-            .as_array()
-            .map(|ms| ms.iter().any(|m| m["role"] == "tool"))
-            .unwrap_or(false);
+// These tests exercise the loop IN ISOLATION via a scripted `FakeProvider` — no
+// HTTP, no wire format. The wire (Chat Completions / SSE) is covered separately
+// by `agent_providers` / `agent_streaming`.
 
-        let resp = if seen_tool_result {
-            json!({"choices":[{"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]})
-        } else {
-            let args = serde_json::to_string(&json!({"path":"out.txt","content":"hi"})).unwrap();
-            json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
-                {"id":"call_1","type":"function","function":{"name":"write_file","arguments": args}}
-            ]},"finish_reason":"tool_calls"}]})
-        };
-        (200, resp.to_string())
-    })
+fn agent<'a>(
+    provider: &'a FakeProvider,
+    tools: &'a ToolRegistry,
+    dir: &std::path::Path,
+    max_steps: usize,
+) -> Agent<'a, FakeProvider> {
+    let mut config = AgentConfig::new("any");
+    config.max_steps = max_steps;
+    Agent::new(provider, tools, ToolContext::new(dir), config)
 }
 
 #[test]
 fn loop_executes_tool_then_returns_final_answer() {
-    let s = write_then_finish_stub();
-    let provider = MonocleProvider::new("tok", s.router_url());
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("done")
+        } else {
+            tool_call_response(
+                "call_1",
+                "write_file",
+                json!({"path":"out.txt","content":"hi"}),
+            )
+        }
+    });
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let agent = Agent::new(
-        &provider,
-        &tools,
-        ToolContext::new(dir.path()),
-        AgentConfig::new("any"),
-    );
+    let agent = agent(&provider, &tools, dir.path(), 20);
 
-    // Observer records which tools were called.
     #[derive(Default)]
     struct Rec {
         calls: Vec<String>,
@@ -57,15 +56,12 @@ fn loop_executes_tool_then_returns_final_answer() {
     }
     let mut rec = Rec::default();
 
+    let mut convo = vec![
+        Message::system("be helpful"),
+        Message::user("write out.txt"),
+    ];
     let answer = agent
-        .run(
-            &mut vec![
-                Message::system("be helpful"),
-                Message::user("write out.txt"),
-            ],
-            &mut AllowAll,
-            &mut rec,
-        )
+        .run(&mut convo, &mut AllowAll, &mut rec, &Cancel::new())
         .unwrap();
 
     assert_eq!(answer, "done");
@@ -78,16 +74,16 @@ fn loop_executes_tool_then_returns_final_answer() {
 
 #[test]
 fn denied_side_effecting_tool_is_not_executed() {
-    let s = write_then_finish_stub();
-    let provider = MonocleProvider::new("tok", s.router_url());
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("done")
+        } else {
+            tool_call_response("c", "write_file", json!({"path":"out.txt","content":"hi"}))
+        }
+    });
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let agent = Agent::new(
-        &provider,
-        &tools,
-        ToolContext::new(dir.path()),
-        AgentConfig::new("any"),
-    );
+    let agent = agent(&provider, &tools, dir.path(), 20);
 
     struct DenyAll;
     impl Approver for DenyAll {
@@ -101,11 +97,10 @@ fn denied_side_effecting_tool_is_not_executed() {
             &mut vec![Message::user("write out.txt")],
             &mut DenyAll,
             &mut Silent,
+            &Cancel::new(),
         )
         .unwrap();
 
-    // The model still finishes (it sees the denial as a tool result), but nothing
-    // was written.
     assert_eq!(answer, "done");
     assert!(
         !dir.path().join("out.txt").exists(),
@@ -115,33 +110,19 @@ fn denied_side_effecting_tool_is_not_executed() {
 
 #[test]
 fn loop_stops_at_max_steps() {
-    // Stub that ALWAYS asks for another (read-only) tool call → never finishes.
-    let s = stub(|_a, _m, url, _b| {
-        if !url.starts_with("/v1/chat/completions") {
-            return (404, String::new());
-        }
-        let args = serde_json::to_string(&json!({"path":"whatever"})).unwrap();
-        (
-            200,
-            json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
-                {"id":"c","type":"function","function":{"name":"read_file","arguments": args}}
-            ]},"finish_reason":"tool_calls"}]})
-            .to_string(),
-        )
-    });
-    let provider = MonocleProvider::new("tok", s.router_url());
+    // Always asks for another (read-only) tool call → never finishes.
+    let provider =
+        FakeProvider::new(|_| tool_call_response("c", "read_file", json!({"path":"whatever"})));
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let mut config = AgentConfig::new("any");
-    config.max_steps = 3;
-    let agent = Agent::new(&provider, &tools, ToolContext::new(dir.path()), config);
+    let agent = agent(&provider, &tools, dir.path(), 3);
 
-    // Graceful stop: returns a notice (not a hard error) so partial work isn't lost.
     let answer = agent
         .run(
             &mut vec![Message::user("loop forever")],
             &mut AllowAll,
             &mut Silent,
+            &Cancel::new(),
         )
         .unwrap();
     assert!(answer.contains("stopped after 3 steps"), "got: {answer}");
@@ -149,39 +130,26 @@ fn loop_stops_at_max_steps() {
 
 #[test]
 fn conversation_persists_across_turns() {
-    // No-tool stub whose answer reports how many `user` messages it saw — proof
-    // the conversation carries forward between `run` calls (multi-turn).
-    let s = stub(|_a, _m, url, body| {
-        if !url.starts_with("/v1/chat/completions") {
-            return (404, String::new());
-        }
-        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
-        let users = req["messages"]
-            .as_array()
-            .map(|ms| ms.iter().filter(|m| m["role"] == "user").count())
-            .unwrap_or(0);
-        (
-            200,
-            json!({"choices":[{"message":{"role":"assistant","content":format!("seen {users}")},"finish_reason":"stop"}]}).to_string(),
-        )
+    // Answer reports how many `user` messages it saw — proof the conversation
+    // carries forward between `run` calls (multi-turn).
+    let provider = FakeProvider::new(|req| {
+        let users = req.messages.iter().filter(|m| m.role == "user").count();
+        text_response(&format!("seen {users}"))
     });
-    let provider = MonocleProvider::new("tok", s.router_url());
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let agent = Agent::new(
-        &provider,
-        &tools,
-        ToolContext::new(dir.path()),
-        AgentConfig::new("any"),
-    );
+    let agent = agent(&provider, &tools, dir.path(), 20);
 
     let mut convo = vec![Message::system("s"), Message::user("first")];
-    let a1 = agent.run(&mut convo, &mut AllowAll, &mut Silent).unwrap();
+    let a1 = agent
+        .run(&mut convo, &mut AllowAll, &mut Silent, &Cancel::new())
+        .unwrap();
     assert_eq!(a1, "seen 1");
 
-    // `run` appended the assistant answer; a follow-up turn sees both users.
     convo.push(Message::user("second"));
-    let a2 = agent.run(&mut convo, &mut AllowAll, &mut Silent).unwrap();
+    let a2 = agent
+        .run(&mut convo, &mut AllowAll, &mut Silent, &Cancel::new())
+        .unwrap();
     assert_eq!(a2, "seen 2");
 
     // system, user, assistant, user, assistant
@@ -190,41 +158,52 @@ fn conversation_persists_across_turns() {
 
 #[test]
 fn malformed_tool_args_are_reported_to_model_not_swallowed() {
-    // First turn: a tool call whose `arguments` is not valid JSON. Once the model
-    // sees the error tool-result, it recovers with a final answer.
-    let s = stub(|_a, _m, url, body| {
-        if !url.starts_with("/v1/chat/completions") {
-            return (404, String::new());
-        }
-        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
-        let seen_tool = req["messages"]
-            .as_array()
-            .map(|ms| ms.iter().any(|m| m["role"] == "tool"))
-            .unwrap_or(false);
-        if seen_tool {
-            (200, json!({"choices":[{"message":{"role":"assistant","content":"recovered"},"finish_reason":"stop"}]}).to_string())
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("recovered")
         } else {
-            (200, json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
-                {"id":"c","type":"function","function":{"name":"write_file","arguments":"{not json"}}
-            ]},"finish_reason":"tool_calls"}]}).to_string())
+            tool_call_response_raw("c", "write_file", "{not json")
         }
     });
-    let provider = MonocleProvider::new("tok", s.router_url());
     let tools = ToolRegistry::with_defaults();
     let dir = tempfile::tempdir().unwrap();
-    let agent = Agent::new(
-        &provider,
-        &tools,
-        ToolContext::new(dir.path()),
-        AgentConfig::new("any"),
-    );
+    let agent = agent(&provider, &tools, dir.path(), 20);
 
     let answer = agent
         .run(
             &mut vec![Message::user("do it")],
             &mut AllowAll,
             &mut Silent,
+            &Cancel::new(),
         )
         .unwrap();
     assert_eq!(answer, "recovered");
+}
+
+#[test]
+fn loop_can_be_cancelled_mid_run() {
+    // The fake cancels after its first response; the loop must stop at the next
+    // step boundary rather than looping forever.
+    let cancel = Cancel::new();
+    let trigger = cancel.clone();
+    let calls = AtomicUsize::new(0);
+    let provider = FakeProvider::new(move |_| {
+        if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            trigger.cancel();
+        }
+        tool_call_response("c", "read_file", json!({"path":"x"}))
+    });
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = agent(&provider, &tools, dir.path(), 100);
+
+    let answer = agent
+        .run(
+            &mut vec![Message::user("go")],
+            &mut AllowAll,
+            &mut Silent,
+            &cancel,
+        )
+        .unwrap();
+    assert!(answer.contains("cancelled"), "got: {answer}");
 }

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -136,13 +136,50 @@ fn loop_stops_at_max_steps() {
     config.max_steps = 3;
     let agent = Agent::new(&provider, &tools, ToolContext::new(dir.path()), config);
 
-    let err = agent
+    // Graceful stop: returns a notice (not a hard error) so partial work isn't lost.
+    let answer = agent
         .run(
             vec![Message::user("loop forever")],
             &mut AllowAll,
             &mut Silent,
         )
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("did not finish within 3 steps"), "got: {err}");
+        .unwrap();
+    assert!(answer.contains("stopped after 3 steps"), "got: {answer}");
+}
+
+#[test]
+fn malformed_tool_args_are_reported_to_model_not_swallowed() {
+    // First turn: a tool call whose `arguments` is not valid JSON. Once the model
+    // sees the error tool-result, it recovers with a final answer.
+    let s = stub(|_a, _m, url, body| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
+        let seen_tool = req["messages"]
+            .as_array()
+            .map(|ms| ms.iter().any(|m| m["role"] == "tool"))
+            .unwrap_or(false);
+        if seen_tool {
+            (200, json!({"choices":[{"message":{"role":"assistant","content":"recovered"},"finish_reason":"stop"}]}).to_string())
+        } else {
+            (200, json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
+                {"id":"c","type":"function","function":{"name":"write_file","arguments":"{not json"}}
+            ]},"finish_reason":"tool_calls"}]}).to_string())
+        }
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = Agent::new(
+        &provider,
+        &tools,
+        ToolContext::new(dir.path()),
+        AgentConfig::new("any"),
+    );
+
+    let answer = agent
+        .run(vec![Message::user("do it")], &mut AllowAll, &mut Silent)
+        .unwrap();
+    assert_eq!(answer, "recovered");
 }

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1,0 +1,148 @@
+mod common;
+
+use serde_json::{json, Value};
+
+use common::stub;
+use monocle_cli::agent::providers::{Message, MonocleProvider};
+use monocle_cli::agent::runner::{Agent, AgentConfig, AllowAll, Approver, Observer, Silent};
+use monocle_cli::agent::tools::{ToolContext, ToolRegistry};
+
+/// Stateful stub LLM: first turn requests a `write_file` tool call; once it sees
+/// a tool-result message in the conversation, it returns a final answer.
+fn write_then_finish_stub() -> common::Stub {
+    stub(|_addr, _method, url, body| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let req: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
+        let seen_tool_result = req["messages"]
+            .as_array()
+            .map(|ms| ms.iter().any(|m| m["role"] == "tool"))
+            .unwrap_or(false);
+
+        let resp = if seen_tool_result {
+            json!({"choices":[{"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]})
+        } else {
+            let args = serde_json::to_string(&json!({"path":"out.txt","content":"hi"})).unwrap();
+            json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
+                {"id":"call_1","type":"function","function":{"name":"write_file","arguments": args}}
+            ]},"finish_reason":"tool_calls"}]})
+        };
+        (200, resp.to_string())
+    })
+}
+
+#[test]
+fn loop_executes_tool_then_returns_final_answer() {
+    let s = write_then_finish_stub();
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = Agent::new(
+        &provider,
+        &tools,
+        ToolContext::new(dir.path()),
+        AgentConfig::new("any"),
+    );
+
+    // Observer records which tools were called.
+    #[derive(Default)]
+    struct Rec {
+        calls: Vec<String>,
+    }
+    impl Observer for Rec {
+        fn on_tool_call(&mut self, name: &str, _args: &Value) {
+            self.calls.push(name.to_string());
+        }
+    }
+    let mut rec = Rec::default();
+
+    let answer = agent
+        .run(
+            vec![
+                Message::system("be helpful"),
+                Message::user("write out.txt"),
+            ],
+            &mut AllowAll,
+            &mut rec,
+        )
+        .unwrap();
+
+    assert_eq!(answer, "done");
+    assert_eq!(rec.calls, vec!["write_file"]);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn denied_side_effecting_tool_is_not_executed() {
+    let s = write_then_finish_stub();
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = Agent::new(
+        &provider,
+        &tools,
+        ToolContext::new(dir.path()),
+        AgentConfig::new("any"),
+    );
+
+    struct DenyAll;
+    impl Approver for DenyAll {
+        fn approve(&mut self, _name: &str, _args: &Value) -> bool {
+            false
+        }
+    }
+
+    let answer = agent
+        .run(
+            vec![Message::user("write out.txt")],
+            &mut DenyAll,
+            &mut Silent,
+        )
+        .unwrap();
+
+    // The model still finishes (it sees the denial as a tool result), but nothing
+    // was written.
+    assert_eq!(answer, "done");
+    assert!(
+        !dir.path().join("out.txt").exists(),
+        "denied write must not touch disk"
+    );
+}
+
+#[test]
+fn loop_stops_at_max_steps() {
+    // Stub that ALWAYS asks for another (read-only) tool call → never finishes.
+    let s = stub(|_a, _m, url, _b| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let args = serde_json::to_string(&json!({"path":"whatever"})).unwrap();
+        (
+            200,
+            json!({"choices":[{"message":{"role":"assistant","content":"","tool_calls":[
+                {"id":"c","type":"function","function":{"name":"read_file","arguments": args}}
+            ]},"finish_reason":"tool_calls"}]})
+            .to_string(),
+        )
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = AgentConfig::new("any");
+    config.max_steps = 3;
+    let agent = Agent::new(&provider, &tools, ToolContext::new(dir.path()), config);
+
+    let err = agent
+        .run(
+            vec![Message::user("loop forever")],
+            &mut AllowAll,
+            &mut Silent,
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("did not finish within 3 steps"), "got: {err}");
+}

--- a/tests/agent_providers.rs
+++ b/tests/agent_providers.rs
@@ -36,6 +36,7 @@ fn non_streaming_turn_returns_assistant_content() {
             model: "claude-sonnet-4-6".into(),
             messages: vec![Message::system("be terse"), Message::user("hi")],
             max_tokens: Some(64),
+            ..Default::default()
         })
         .unwrap();
 
@@ -57,6 +58,7 @@ fn same_provider_swaps_model_vendor_agnostically() {
                 model: model.into(),
                 messages: vec![Message::user("hi")],
                 max_tokens: None,
+                ..Default::default()
             })
             .unwrap();
         assert_eq!(resp.content, format!("echo:{model}"));
@@ -74,6 +76,7 @@ fn non_200_is_an_error() {
             model: "any".into(),
             messages: vec![Message::user("hi")],
             max_tokens: None,
+            ..Default::default()
         })
         .unwrap_err()
         .to_string();

--- a/tests/agent_providers.rs
+++ b/tests/agent_providers.rs
@@ -82,3 +82,26 @@ fn non_200_is_an_error() {
         .to_string();
     assert!(err.contains("API error 500"), "got: {err}");
 }
+
+#[test]
+fn chat_errors_when_response_has_no_choices() {
+    // A 200 with an error-shaped body (no `choices`) must surface as an error,
+    // not a silent empty assistant turn.
+    let s = stub(|_a, _m, url, _b| {
+        if url.starts_with("/v1/chat/completions") {
+            (200, r#"{"error":{"message":"boom"}}"#.to_string())
+        } else {
+            (404, String::new())
+        }
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let err = provider
+        .chat(&ChatRequest {
+            model: "m".into(),
+            messages: vec![Message::user("hi")],
+            ..Default::default()
+        })
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no choices"), "got: {err}");
+}

--- a/tests/agent_providers.rs
+++ b/tests/agent_providers.rs
@@ -1,0 +1,81 @@
+mod common;
+
+use common::stub;
+use serde_json::Value;
+
+use monocle_cli::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
+
+/// Stub that echoes back the requested model id, so tests can prove the provider
+/// (a) passed the model through and (b) parsed the OpenAI-compatible response.
+fn echo_model_stub() -> common::Stub {
+    stub(|_addr, _method, url, body| {
+        if url.starts_with("/v1/chat/completions") {
+            let model = serde_json::from_str::<Value>(body)
+                .ok()
+                .and_then(|v| v["model"].as_str().map(String::from))
+                .unwrap_or_default();
+            (
+                200,
+                format!(
+                    r#"{{"model":"{model}","choices":[{{"message":{{"role":"assistant","content":"echo:{model}"}},"finish_reason":"stop"}}]}}"#
+                ),
+            )
+        } else {
+            (404, String::new())
+        }
+    })
+}
+
+#[test]
+fn non_streaming_turn_returns_assistant_content() {
+    let s = echo_model_stub();
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    let resp = provider
+        .chat(&ChatRequest {
+            model: "claude-sonnet-4-6".into(),
+            messages: vec![Message::system("be terse"), Message::user("hi")],
+            max_tokens: Some(64),
+        })
+        .unwrap();
+
+    assert_eq!(resp.content, "echo:claude-sonnet-4-6");
+    assert_eq!(resp.model.as_deref(), Some("claude-sonnet-4-6"));
+    assert_eq!(resp.finish_reason.as_deref(), Some("stop"));
+}
+
+/// G1 — model-choice freedom: the SAME provider/loop routes to different models
+/// (different vendors) just by changing the model id. Vendor-agnostic.
+#[test]
+fn same_provider_swaps_model_vendor_agnostically() {
+    let s = echo_model_stub();
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    for model in ["claude-sonnet-4-6", "gpt-4o", "gemini-2.5-pro"] {
+        let resp = provider
+            .chat(&ChatRequest {
+                model: model.into(),
+                messages: vec![Message::user("hi")],
+                max_tokens: None,
+            })
+            .unwrap();
+        assert_eq!(resp.content, format!("echo:{model}"));
+        assert_eq!(resp.model.as_deref(), Some(model));
+    }
+}
+
+#[test]
+fn non_200_is_an_error() {
+    let s = stub(|_a, _m, _u, _b| (500, "boom".to_string()));
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    let err = provider
+        .chat(&ChatRequest {
+            model: "any".into(),
+            messages: vec![Message::user("hi")],
+            max_tokens: None,
+        })
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("API error 500"), "got: {err}");
+}

--- a/tests/agent_session.rs
+++ b/tests/agent_session.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use monocle_cli::agent::providers::{FunctionCall, Message, ToolCall};
+use monocle_cli::agent::session::{session_path, SessionStore};
+
+#[test]
+fn load_missing_is_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SessionStore::new(dir.path().join("s.jsonl"));
+    assert!(store.load().unwrap().is_empty());
+}
+
+#[test]
+fn append_then_load_round_trips_including_tool_messages() {
+    let dir = tempfile::tempdir().unwrap();
+    // Nested path also exercises parent-dir creation.
+    let store = SessionStore::new(dir.path().join("nested/s.jsonl"));
+
+    let msgs = vec![
+        Message::system("sys"),
+        Message::user("hi"),
+        Message::assistant_with_tool_calls(
+            "",
+            vec![ToolCall {
+                id: "c1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "read_file".into(),
+                    arguments: "{\"path\":\"a\"}".into(),
+                },
+            }],
+        ),
+        Message::tool("c1", "file contents"),
+        Message::assistant("done"),
+    ];
+    store.append(&msgs).unwrap();
+
+    let loaded = store.load().unwrap();
+    assert_eq!(loaded.len(), 5);
+    assert_eq!(loaded[0].role, "system");
+    assert_eq!(loaded[2].tool_calls[0].function.name, "read_file");
+    assert_eq!(loaded[2].tool_calls[0].id, "c1");
+    assert_eq!(loaded[3].role, "tool");
+    assert_eq!(loaded[3].tool_call_id.as_deref(), Some("c1"));
+    assert_eq!(loaded[4].content.as_deref(), Some("done"));
+}
+
+#[test]
+fn append_accumulates() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SessionStore::new(dir.path().join("s.jsonl"));
+    store.append(&[Message::user("one")]).unwrap();
+    store.append(&[Message::user("two")]).unwrap();
+    let loaded = store.load().unwrap();
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[1].content.as_deref(), Some("two"));
+}
+
+#[test]
+fn session_path_is_under_monocle_agent() {
+    let p = session_path(Path::new("/home/x"), "work");
+    assert!(p.ends_with(".monocle/agent/work.jsonl"), "{}", p.display());
+}

--- a/tests/agent_session.rs
+++ b/tests/agent_session.rs
@@ -57,6 +57,41 @@ fn append_accumulates() {
 }
 
 #[test]
+fn load_tolerates_truncated_final_line() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s.jsonl");
+    let store = SessionStore::new(&path);
+    store
+        .append(&[Message::user("one"), Message::user("two")])
+        .unwrap();
+    // Simulate a crash mid-write: an invalid, unterminated final line.
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    write!(f, "{{\"role\":\"assist").unwrap();
+    drop(f);
+
+    let loaded = store.load().unwrap();
+    assert_eq!(loaded.len(), 2, "good lines survive; corrupt tail dropped");
+    assert_eq!(loaded[1].content.as_deref(), Some("two"));
+}
+
+#[test]
+fn load_errors_on_corrupt_non_final_line() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s.jsonl");
+    std::fs::write(
+        &path,
+        "{\"role\":\"user\",\"content\":\"a\"}\nNOT JSON\n{\"role\":\"user\",\"content\":\"b\"}\n",
+    )
+    .unwrap();
+    // A corrupt line in the middle is real corruption — not silently skipped.
+    assert!(SessionStore::new(&path).load().is_err());
+}
+
+#[test]
 fn session_path_is_under_monocle_agent() {
     let p = session_path(Path::new("/home/x"), "work");
     assert!(p.ends_with(".monocle/agent/work.jsonl"), "{}", p.display());

--- a/tests/agent_streaming.rs
+++ b/tests/agent_streaming.rs
@@ -1,0 +1,68 @@
+mod common;
+
+use common::stub_sse;
+use monocle_cli::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
+
+fn req() -> ChatRequest {
+    ChatRequest {
+        model: "m".into(),
+        messages: vec![Message::user("hi")],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn streams_content_deltas_and_assembles_final() {
+    let s = stub_sse(|_a, _m, url, _b| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let body = "\
+data: {\"model\":\"m\",\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        (200, body.to_string())
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    let mut deltas: Vec<String> = Vec::new();
+    let resp = provider
+        .chat_stream(&req(), &mut |d| deltas.push(d.to_string()))
+        .unwrap();
+
+    // Deltas arrive incrementally, and the final content is their assembly.
+    assert_eq!(deltas, vec!["Hel", "lo"]);
+    assert_eq!(resp.content, "Hello");
+    assert_eq!(resp.finish_reason.as_deref(), Some("stop"));
+    assert!(resp.tool_calls.is_empty());
+}
+
+#[test]
+fn assembles_streamed_tool_call_from_fragments() {
+    let s = stub_sse(|_a, _m, url, _b| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        // A tool call whose id/name come first, then `arguments` in fragments.
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"write_file\",\"arguments\":\"\"}}]}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"a.txt\\\"}\"}}]}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
+data: [DONE]\n\n";
+        (200, body.to_string())
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    let resp = provider.chat_stream(&req(), &mut |_d| {}).unwrap();
+
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].id, "call_1");
+    assert_eq!(resp.tool_calls[0].function.name, "write_file");
+    assert_eq!(
+        resp.tool_calls[0].function.arguments,
+        "{\"path\":\"a.txt\"}"
+    );
+    assert_eq!(resp.finish_reason.as_deref(), Some("tool_calls"));
+}

--- a/tests/agent_tools.rs
+++ b/tests/agent_tools.rs
@@ -18,11 +18,11 @@ fn write_then_read_round_trips() {
         "write_file",
         &json!({"path": "a.txt", "content": "hello"}),
     );
-    assert!(!w.is_error, "{}", w.content);
+    assert!(!w.is_error, "{}", w.llm);
 
     let r = reg.run(&ctx, "read_file", &json!({"path": "a.txt"}));
     assert!(!r.is_error);
-    assert_eq!(r.content, "hello");
+    assert_eq!(r.llm, "hello");
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn edit_file_requires_unique_match() {
         &json!({"path": "f.txt", "old_string": "x", "new_string": "y"}),
     );
     assert!(dup.is_error);
-    assert!(dup.content.contains("occurs 2 times"), "{}", dup.content);
+    assert!(dup.llm.contains("occurs 2 times"), "{}", dup.llm);
 
     // Unique → succeeds.
     let ok = reg.run(
@@ -57,9 +57,9 @@ fn edit_file_requires_unique_match() {
         "edit_file",
         &json!({"path": "f.txt", "old_string": "x x", "new_string": "z"}),
     );
-    assert!(!ok.is_error, "{}", ok.content);
+    assert!(!ok.is_error, "{}", ok.llm);
     let r = reg.run(&ctx, "read_file", &json!({"path": "f.txt"}));
-    assert_eq!(r.content, "z");
+    assert_eq!(r.llm, "z");
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn missing_argument_is_an_error_not_a_panic() {
     let reg = ToolRegistry::with_defaults();
     let r = reg.run(&ctx, "read_file", &json!({}));
     assert!(r.is_error);
-    assert!(r.content.contains("path"));
+    assert!(r.llm.contains("path"));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn unknown_tool_is_an_error() {
     let reg = ToolRegistry::with_defaults();
     let r = reg.run(&ctx, "nope", &json!({}));
     assert!(r.is_error);
-    assert!(r.content.contains("unknown tool"));
+    assert!(r.llm.contains("unknown tool"));
 }
 
 /// The shell tool is `bash` on unix / `powershell` on windows and runs in the
@@ -97,7 +97,42 @@ fn shell_runs_in_workdir() {
         "shell tool `{tool}` should be registered"
     );
     let r = reg.run(&ctx, tool, &json!({ "command": cmd }));
-    assert!(!r.is_error, "{}", r.content);
-    assert!(r.content.contains("agent-ran"), "{}", r.content);
-    assert!(r.content.contains("[exit code: 0]"), "{}", r.content);
+    assert!(!r.is_error, "{}", r.llm);
+    assert!(r.llm.contains("agent-ran"), "{}", r.llm);
+    assert!(r.llm.contains("[exit code: 0]"), "{}", r.llm);
+}
+
+/// Dual channel (§9a): the model gets full content; the human gets a summary.
+#[test]
+fn read_file_splits_llm_and_ui_channels() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+    reg.run(&ctx, "write_file", &json!({"path": "a.txt", "content": "hello"}));
+
+    let r = reg.run(&ctx, "read_file", &json!({"path": "a.txt"}));
+    assert_eq!(r.llm, "hello"); // model sees full content
+    assert_ne!(r.ui_text(), r.llm); // human sees a distinct summary
+    assert!(r.ui_text().contains("read a.txt"), "{}", r.ui_text());
+    assert!(r.ui_text().contains("5 chars"), "{}", r.ui_text());
+}
+
+/// The shell's LLM channel is capped (re-sent every turn) while the UI stays concise.
+#[test]
+fn shell_llm_output_is_capped_ui_is_concise() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+
+    #[cfg(not(windows))]
+    let (tool, cmd) = ("bash", "for i in $(seq 1 30000); do printf x; done");
+    #[cfg(windows)]
+    let (tool, cmd) = ("powershell", "Write-Output ('x' * 30000)");
+
+    let r = reg.run(&ctx, tool, &json!({ "command": cmd }));
+    assert!(!r.is_error, "{}", r.llm);
+    assert!(
+        r.llm.contains("characters omitted"),
+        "llm output should be capped (len {})",
+        r.llm.chars().count()
+    );
+    assert_eq!(r.ui_text(), "exit 0");
 }

--- a/tests/agent_tools.rs
+++ b/tests/agent_tools.rs
@@ -1,0 +1,103 @@
+use serde_json::json;
+
+use monocle_cli::agent::tools::{ToolContext, ToolRegistry};
+
+fn ctx() -> (tempfile::TempDir, ToolContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(dir.path());
+    (dir, ctx)
+}
+
+#[test]
+fn write_then_read_round_trips() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+
+    let w = reg.run(
+        &ctx,
+        "write_file",
+        &json!({"path": "a.txt", "content": "hello"}),
+    );
+    assert!(!w.is_error, "{}", w.content);
+
+    let r = reg.run(&ctx, "read_file", &json!({"path": "a.txt"}));
+    assert!(!r.is_error);
+    assert_eq!(r.content, "hello");
+}
+
+#[test]
+fn read_file_is_not_side_effecting() {
+    let reg = ToolRegistry::with_defaults();
+    assert!(!reg.get("read_file").unwrap().is_side_effecting());
+    assert!(reg.get("write_file").unwrap().is_side_effecting());
+}
+
+#[test]
+fn edit_file_requires_unique_match() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+    reg.run(
+        &ctx,
+        "write_file",
+        &json!({"path": "f.txt", "content": "x x"}),
+    );
+
+    // Non-unique → error.
+    let dup = reg.run(
+        &ctx,
+        "edit_file",
+        &json!({"path": "f.txt", "old_string": "x", "new_string": "y"}),
+    );
+    assert!(dup.is_error);
+    assert!(dup.content.contains("occurs 2 times"), "{}", dup.content);
+
+    // Unique → succeeds.
+    let ok = reg.run(
+        &ctx,
+        "edit_file",
+        &json!({"path": "f.txt", "old_string": "x x", "new_string": "z"}),
+    );
+    assert!(!ok.is_error, "{}", ok.content);
+    let r = reg.run(&ctx, "read_file", &json!({"path": "f.txt"}));
+    assert_eq!(r.content, "z");
+}
+
+#[test]
+fn missing_argument_is_an_error_not_a_panic() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+    let r = reg.run(&ctx, "read_file", &json!({}));
+    assert!(r.is_error);
+    assert!(r.content.contains("path"));
+}
+
+#[test]
+fn unknown_tool_is_an_error() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+    let r = reg.run(&ctx, "nope", &json!({}));
+    assert!(r.is_error);
+    assert!(r.content.contains("unknown tool"));
+}
+
+/// The shell tool is `bash` on unix / `powershell` on windows and runs in the
+/// working directory.
+#[test]
+fn shell_runs_in_workdir() {
+    let (_d, ctx) = ctx();
+    let reg = ToolRegistry::with_defaults();
+
+    #[cfg(not(windows))]
+    let (tool, cmd) = ("bash", "echo agent-ran");
+    #[cfg(windows)]
+    let (tool, cmd) = ("powershell", "Write-Output agent-ran");
+
+    assert!(
+        reg.get(tool).is_some(),
+        "shell tool `{tool}` should be registered"
+    );
+    let r = reg.run(&ctx, tool, &json!({ "command": cmd }));
+    assert!(!r.is_error, "{}", r.content);
+    assert!(r.content.contains("agent-ran"), "{}", r.content);
+    assert!(r.content.contains("[exit code: 0]"), "{}", r.content);
+}

--- a/tests/agent_tools.rs
+++ b/tests/agent_tools.rs
@@ -107,7 +107,11 @@ fn shell_runs_in_workdir() {
 fn read_file_splits_llm_and_ui_channels() {
     let (_d, ctx) = ctx();
     let reg = ToolRegistry::with_defaults();
-    reg.run(&ctx, "write_file", &json!({"path": "a.txt", "content": "hello"}));
+    reg.run(
+        &ctx,
+        "write_file",
+        &json!({"path": "a.txt", "content": "hello"}),
+    );
 
     let r = reg.run(&ctx, "read_file", &json!({"path": "a.txt"}));
     assert_eq!(r.llm, "hello"); // model sees full content

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,10 @@
 //! A tiny synchronous stub HTTP server for exercising the `net` facade end to
 //! end without mocking reqwest. Mirrors the `deps.fetch` injection the TS tests
 //! used, but with a real loopback server (keeps everything sync).
+//!
+//! (Each test binary compiles its own copy and uses a different subset, so
+//! unused helpers here are expected.)
+#![allow(dead_code)]
 
 use std::thread;
 
@@ -37,6 +41,35 @@ where
             let _ = req.as_reader().read_to_string(&mut body);
             let (status, resp_body) = handler(&addr_for_thread, &method, &url, &body);
             let _ = req.respond(Response::from_string(resp_body).with_status_code(status));
+        }
+    });
+    Stub { addr }
+}
+
+/// Like [`stub`] but responds with `Content-Type: text/event-stream` so the
+/// provider takes its SSE-parsing path. Handler returns the full SSE body.
+pub fn stub_sse<F>(handler: F) -> Stub
+where
+    F: Fn(&str, &str, &str, &str) -> (u16, String) + Send + 'static,
+{
+    let server = Server::http("127.0.0.1:0").unwrap();
+    let port = server.server_addr().to_ip().unwrap().port();
+    let addr = format!("127.0.0.1:{port}");
+    let addr_for_thread = addr.clone();
+    thread::spawn(move || {
+        let ct =
+            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/event-stream"[..]).unwrap();
+        for mut req in server.incoming_requests() {
+            let method = req.method().as_str().to_string();
+            let url = req.url().to_string();
+            let mut body = String::new();
+            let _ = req.as_reader().read_to_string(&mut body);
+            let (status, resp_body) = handler(&addr_for_thread, &method, &url, &body);
+            let _ = req.respond(
+                Response::from_string(resp_body)
+                    .with_status_code(status)
+                    .with_header(ct.clone()),
+            );
         }
     });
     Stub { addr }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,77 @@
 
 use std::thread;
 
+use serde_json::Value;
 use tiny_http::{Response, Server};
+
+use monocle_cli::agent::providers::{
+    ChatRequest, ChatResponse, FunctionCall, LlmProvider, ToolCall,
+};
+use monocle_cli::error::Result;
+
+// ── mock LLM (isolated loop testing — no network) ───────────────────────────
+
+/// A scripted `LlmProvider` for isolated loop/orchestration tests. The closure
+/// inspects the request (e.g. whether a tool result is already present) and
+/// returns the next response — no HTTP, deterministic.
+pub struct FakeProvider {
+    responder: Box<dyn Fn(&ChatRequest) -> ChatResponse + Send + Sync>,
+}
+
+impl FakeProvider {
+    pub fn new(f: impl Fn(&ChatRequest) -> ChatResponse + Send + Sync + 'static) -> Self {
+        Self {
+            responder: Box::new(f),
+        }
+    }
+}
+
+impl LlmProvider for FakeProvider {
+    fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
+        Ok((self.responder)(req))
+    }
+    // chat_stream uses the trait default (delegates to chat, emits content once),
+    // which is exactly what isolated loop tests want.
+}
+
+/// A final text answer (no tool calls).
+pub fn text_response(content: &str) -> ChatResponse {
+    ChatResponse {
+        content: content.to_string(),
+        tool_calls: vec![],
+        model: None,
+        finish_reason: Some("stop".to_string()),
+    }
+}
+
+/// A response that requests one tool call with the given JSON-encoded args.
+pub fn tool_call_response(id: &str, name: &str, args: Value) -> ChatResponse {
+    tool_call_response_raw(id, name, &args.to_string())
+}
+
+/// Like [`tool_call_response`] but with a raw `arguments` string (e.g. to script
+/// malformed JSON).
+pub fn tool_call_response_raw(id: &str, name: &str, arguments: &str) -> ChatResponse {
+    ChatResponse {
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            id: id.to_string(),
+            kind: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: arguments.to_string(),
+            },
+        }],
+        model: None,
+        finish_reason: Some("tool_calls".to_string()),
+    }
+}
+
+/// Whether the conversation already contains a tool-result message (a common
+/// signal for "second turn" in stateful fakes).
+pub fn has_tool_result(req: &ChatRequest) -> bool {
+    req.messages.iter().any(|m| m.role == "tool")
+}
 
 pub struct Stub {
     /// `host:port` — feed as a tenant domain (resolves to http on 127.0.0.1) or


### PR DESCRIPTION
> **베이스 = `rust-rewrite`** (통합 트렁크 전략). 이 PR은 devel이 아니라 Rust 재작성 브랜치 위에 쌓입니다. Rust 기반이 무르익으면 `rust-rewrite`를 **한 번에 devel로** 랜딩합니다. (PR #43 = TS→Rust 재작성이 이 트렁크.)

설계: warmblood-kr/monocle#158 (SDD) · 구현 상태: warmblood-kr/monocle-cli#44

## 무엇
`monocle`을 **네이티브 Rust 헤드리스 에이전트**로 확장(Path B). 목적은 **코딩 에이전트가 아니라**, monocle **Craft**(및 데스크탑)가 구동하는 **모델‑무관 서버‑에이전트 백엔드** — Craft의 Sonnet 종속 비용을 코어 변경 없이 완화(모델 자유도 G1). async는 (예정된 `src/acp.rs`) ACP 경계에만, 코어 루프는 sync 유지.

## 포함 (Phase 0~2 + 리뷰/정리 + Phase 3 착수)
- **providers**(`LlmProvider`/`MonocleProvider`, G1 seam, 툴콜) · **tools**(read/write/edit + 크로스플랫폼 shell) · **runner**(agent‑core 루프, `Approver`/`Observer`/`Cancel`) · **`monocle agent`**(스트리밍 + 멀티턴 REPL + `--session` resume/persist).
- **비용 효율**(§9a): 듀얼채널 `ToolOutcome`(llm/ui) + 출력 상한, 대화 append‑only(프롬프트 캐시 친화).
- **테스트빌리티**: mock LLM(`FakeProvider`)로 루프 격리 테스트, 경로주입 `SessionStore`.
- **로컬 코드리뷰 수정 5건** + **A2**(장시간 세션 토큰 갱신) + **정리**(`auth_headers` 헬퍼, `chat.rs`→provider 위임).
- **Phase 3 착수**: `agent-client-protocol = "0.9"` 의존성(ACP 서버‑에이전트 표면 예정).

## 검증
`cargo fmt`/`clippy -D warnings` 클린, **56 테스트**, 실 바이너리 e2e(도구 실행·SSE 스트리밍·멀티턴 pty·세션 resume) 통과.

## 다음
`src/acp.rs`(impl Agent + stdio 배선 + sync 루프 브릿지) → `monocle acp`. ACP crate는 교체 가능한 어댑터로 `acp.rs` 한 곳에 격리(0.9→1.0 이관은 국소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
