### PR TITLE
ACP 서버-에이전트 표면 (Phase 3): monocle acp + 권한/ToolCall/세션별 모델

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,13 +34,18 @@ Sonnet 종속 비용을 Craft 코어 변경 없이 완화(= 모델 자유도 G1)
 
 - **설계(SDD/에픽):** warmblood-kr/monocle#158 · **구현 상태:** warmblood-kr/monocle-cli#44
 - **코드:** `src/agent/`(`providers`=LLM 추상화/G1, `tools`=read/write/edit +
-  크로스플랫폼 shell, `runner`=agent-core 루프) + `src/commands/agent.rs`
-  (`monocle agent <prompt>`, experimental). 모든 HTTP는 `src/net.rs` 파사드.
-- **작업 브랜치:** `feature/agent-mode-providers` (base `rust-rewrite`/PR #43).
-  push/PR은 승인 게이트 — 로컬 커밋만.
-- **시퀀스(§9):** Phase 0(얼개)✅ → **Phase 1 스트리밍(동기 SSE)+멀티턴**(다음) →
-  Phase 2 세션/스티어링 → Phase 3 **ACP 표면 + 권한**(G4) → Phase 4 정교화.
-- pi(earendil-works/pi, MIT)를 설계 참고로만(코드 차용 X); ACP = Zed Agent Client Protocol.
+  크로스플랫폼 shell, `runner`=agent-core 루프[동기], `session`=JSONL 세션) +
+  `src/commands/agent.rs`(`monocle agent`, REPL/스트리밍/`--session`) +
+  **`src/acp.rs`(`monocle acp` — ACP stdio 서버; async는 여기에만 격리, 코어는 동기)**.
+  모든 HTTP는 `src/net.rs` 파사드.
+- **작업 브랜치:** `feature/agent-mode-acp` (base `rust-rewrite`; providers/agent는
+  PR #45로 `rust-rewrite`에 머지됨). push/PR은 승인 게이트.
+- **시퀀스(§9):** Phase 0(얼개)✅ → Phase 1 스트리밍+멀티턴✅ → Phase 2 세션/
+  듀얼채널✅ → **Phase 3 ACP 표면**✅(구동/스트리밍/권한 위임/ToolCall 라이프사이클/
+  미로그인 생존/세션별 모델[`_meta.monocle.model`]) → Phase 4 정교화(client fs/
+  terminal 콜백 등 남음).
+- pi(earendil-works/pi, MIT)를 설계 참고로만(코드 차용 X); ACP = Zed Agent Client
+  Protocol, crate `agent-client-protocol` 0.9(교체 가능 어댑터, `acp.rs`에 격리).
 
 ## 지식 관리 — wb-para 스킬 적극 사용
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
+| `monocle agent [prompt] [--workdir <dir>] [--model <id>] [--max-steps <n>] [--session <name>]` | **Experimental.** Headless agent loop with tools (read/write/edit + shell) |
+| `monocle acp` | **Experimental.** Run as an [ACP](https://agentclientprotocol.com) agent over stdio (for editors / desktop / Craft) |
 
 ## 💬 Chat with models
 
@@ -183,6 +185,28 @@ Other terminals and IDE integrations running plain `claude` are unaffected. To g
 
 > [!NOTE]
 > See **[Claude Code integration details](./docs/claude-code.md)** for `ANTHROPIC_API_KEY` handling, global setup, and troubleshooting.
+
+## 🧪 Experimental: agent & ACP
+
+> These are **experimental** and evolving. They require you to be logged in — every
+> LLM call is routed through Monocle (your chosen model, via `monocle login`).
+
+**`monocle agent`** runs a headless agent loop with file (read/write/edit) and shell
+tools in a working directory. Give it a task as an argument, pipe it via stdin, or omit
+it for an interactive REPL. Progress goes to stderr, the answer to stdout; `--session
+<name>` persists/resumes a conversation.
+
+```bash
+monocle agent "summarize the TODOs in this repo" --workdir .
+```
+
+> ⚠️ Tools are auto-approved (read/write/edit + shell). Run only in a directory you trust.
+
+**`monocle acp`** runs Monocle as an **[Agent Client Protocol](https://agentclientprotocol.com)**
+agent over stdio (JSON-RPC) — an editor, the Monocle desktop app, or Craft spawns it and
+drives sessions. Tool permission is delegated to the client (`session/request_permission`),
+tool calls stream as `ToolCall`/`ToolCallUpdate` updates, and a client may pick the model
+per session via `_meta.monocle.model` on `session/new` (falls back to the default).
 
 ## 🔌 Using Monocle from your own app (OpenAI-compatible SDK)
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -9,9 +9,10 @@
 //! a swappable adapter — pinning 0.9 vs migrating to 1.0 is a change to this file
 //! only (the ACP *wire protocol* is the stable contract, not the crate API).
 //!
-//! v1 scope: initialize / new_session / prompt / cancel; tools run locally;
-//! permission is auto-allowed (client `session/request_permission` round-trip and
-//! client fs/terminal callbacks are Phase-3 follow-ups).
+//! Scope: initialize / new_session / prompt / cancel; tools run locally; tool
+//! permission is delegated to the client via `session/request_permission`
+//! (allow/reject). Follow-ups: client fs/terminal callbacks, richer ToolCall
+//! updates, per-session model config.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -19,11 +20,11 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use agent_client_protocol::{self as acp, Agent, Client as _};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::agent::providers::{Message, MonocleProvider};
-use crate::agent::runner::{Agent as CoreAgent, AgentConfig, AllowAll, Cancel, Observer};
+use crate::agent::runner::{Agent as CoreAgent, AgentConfig, Approver, Cancel, Observer};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::auth::get_access_token;
 use crate::credentials::Credentials;
@@ -37,6 +38,16 @@ session's working directory. Take minimal, verified steps. When finished, give a
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 const DEFAULT_MAX_STEPS: usize = 20;
 
+/// A call the (blocking) agent loop needs the async ACP connection to make on
+/// its behalf — either a fire-and-forget update or a permission round-trip.
+enum ClientCall {
+    Notify(acp::SessionNotification),
+    Permission(
+        acp::RequestPermissionRequest,
+        oneshot::Sender<acp::RequestPermissionOutcome>,
+    ),
+}
+
 /// Per-ACP-session state, keyed by session id string.
 struct SessionState {
     convo: Vec<Message>,
@@ -46,13 +57,13 @@ struct SessionState {
 
 struct MonocleAgent {
     /// Outbound `session/update` notifications → forwarded to the connection.
-    updates: mpsc::UnboundedSender<acp::SessionNotification>,
+    updates: mpsc::UnboundedSender<ClientCall>,
     sessions: RefCell<HashMap<String, SessionState>>,
     next_id: AtomicU64,
 }
 
 impl MonocleAgent {
-    fn new(updates: mpsc::UnboundedSender<acp::SessionNotification>) -> Self {
+    fn new(updates: mpsc::UnboundedSender<ClientCall>) -> Self {
         Self {
             updates,
             sessions: RefCell::new(HashMap::new()),
@@ -115,16 +126,26 @@ impl Agent for MonocleAgent {
         let updates = self.updates.clone();
         let sid = args.session_id.clone();
 
-        // Run the SYNC agent-core loop off the async thread; stream updates back.
+        // Run the SYNC agent-core loop off the async thread; stream updates back,
+        // and route side-effecting tool permission to the client (the editor
+        // decides via session/request_permission).
         let joined = tokio::task::spawn_blocking(move || {
-            let mut observer = AcpObserver { updates, sid };
+            let mut observer = AcpObserver {
+                updates: updates.clone(),
+                sid: sid.clone(),
+            };
+            let mut approver = AcpApprover {
+                calls: updates,
+                sid,
+                tool_counter: 0,
+            };
             let session = get_access_token(&Client::new(), &Credentials::new());
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
             let mut config = AgentConfig::new(DEFAULT_MODEL);
             config.max_steps = DEFAULT_MAX_STEPS;
             let agent = CoreAgent::new(&provider, &tools, ToolContext::new(cwd), config);
-            let result = agent.run(&mut convo, &mut AllowAll, &mut observer, &cancel);
+            let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
             (convo, cancel.is_cancelled(), result.map(|_| ()))
         })
         .await
@@ -157,7 +178,7 @@ impl Agent for MonocleAgent {
 /// Bridges the sync loop's `Observer` callbacks to ACP `session/update`
 /// notifications (agent message text + tool progress as thought chunks).
 struct AcpObserver {
-    updates: mpsc::UnboundedSender<acp::SessionNotification>,
+    updates: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
 }
 
@@ -165,7 +186,10 @@ impl AcpObserver {
     fn send(&self, update: acp::SessionUpdate) {
         let _ = self
             .updates
-            .send(acp::SessionNotification::new(self.sid.clone(), update));
+            .send(ClientCall::Notify(acp::SessionNotification::new(
+                self.sid.clone(),
+                update,
+            )));
     }
 }
 
@@ -191,6 +215,48 @@ impl Observer for AcpObserver {
         self.send(acp::SessionUpdate::AgentThoughtChunk(
             acp::ContentChunk::new(acp::ContentBlock::from(msg.to_string())),
         ));
+    }
+}
+
+/// Bridges the sync loop's `Approver` to ACP `session/request_permission`: the
+/// client (editor) decides whether a side-effecting tool may run. Read-only
+/// tools are never gated (the loop doesn't consult the approver for them).
+struct AcpApprover {
+    calls: mpsc::UnboundedSender<ClientCall>,
+    sid: acp::SessionId,
+    tool_counter: u64,
+}
+
+impl Approver for AcpApprover {
+    fn approve(&mut self, tool_name: &str, args: &serde_json::Value) -> bool {
+        self.tool_counter += 1;
+        let tool_call = acp::ToolCallUpdate::new(
+            acp::ToolCallId::new(format!("tc-{}", self.tool_counter)),
+            acp::ToolCallUpdateFields::new().title(format!("{tool_name} {args}")),
+        );
+        let options = vec![
+            acp::PermissionOption::new(
+                acp::PermissionOptionId::new("allow"),
+                "Allow",
+                acp::PermissionOptionKind::AllowOnce,
+            ),
+            acp::PermissionOption::new(
+                acp::PermissionOptionId::new("reject"),
+                "Reject",
+                acp::PermissionOptionKind::RejectOnce,
+            ),
+        ];
+        let req = acp::RequestPermissionRequest::new(self.sid.clone(), tool_call, options);
+
+        let (tx, rx) = oneshot::channel();
+        if self.calls.send(ClientCall::Permission(req, tx)).is_err() {
+            return false; // connection gone → deny
+        }
+        // Block this off-thread loop until the client answers (or the turn ends).
+        matches!(
+            rx.blocking_recv(),
+            Ok(acp::RequestPermissionOutcome::Selected(sel)) if sel.option_id.0.as_ref() == "allow"
+        )
     }
 }
 
@@ -222,17 +288,30 @@ async fn run() {
     let outgoing = tokio::io::stdout().compat_write();
     let incoming = tokio::io::stdin().compat();
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<acp::SessionNotification>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
     let agent = std::rc::Rc::new(MonocleAgent::new(tx));
 
     let (conn, io_task) = acp::AgentSideConnection::new(agent, outgoing, incoming, |fut| {
         tokio::task::spawn_local(fut);
     });
 
-    // Forward the loop's queued notifications to the client over the connection.
+    // Make the loop's queued calls to the client over the connection: fire-and-
+    // forget updates, and permission round-trips whose outcome is returned to the
+    // (blocking) loop via the paired oneshot.
     tokio::task::spawn_local(async move {
-        while let Some(note) = rx.recv().await {
-            let _ = conn.session_notification(note).await;
+        while let Some(call) = rx.recv().await {
+            match call {
+                ClientCall::Notify(note) => {
+                    let _ = conn.session_notification(note).await;
+                }
+                ClientCall::Permission(req, ack) => {
+                    let outcome = match conn.request_permission(req).await {
+                        Ok(resp) => resp.outcome,
+                        Err(_) => acp::RequestPermissionOutcome::Cancelled,
+                    };
+                    let _ = ack.send(outcome);
+                }
+            }
         }
     });
 
@@ -251,5 +330,44 @@ mod tests {
         ];
         assert_eq!(prompt_text(&blocks), "hello\nworld");
         assert_eq!(prompt_text(&[]), "");
+    }
+
+    /// Drive `AcpApprover` against a scripted client that answers the permission
+    /// request with the given option id, off-thread (approve() blocks on it).
+    fn approver_with_response(option: &'static str) -> bool {
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let responder = std::thread::spawn(move || {
+            if let Some(ClientCall::Permission(_req, ack)) = rx.blocking_recv() {
+                let _ = ack.send(acp::RequestPermissionOutcome::Selected(
+                    acp::SelectedPermissionOutcome::new(option),
+                ));
+            }
+        });
+        let mut approver = AcpApprover {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+            tool_counter: 0,
+        };
+        let granted = approver.approve("write_file", &serde_json::json!({"path": "x"}));
+        responder.join().unwrap();
+        granted
+    }
+
+    #[test]
+    fn approver_grants_only_when_client_selects_allow() {
+        assert!(approver_with_response("allow"));
+        assert!(!approver_with_response("reject"));
+    }
+
+    #[test]
+    fn approver_denies_when_connection_is_gone() {
+        let (tx, rx) = mpsc::unbounded_channel::<ClientCall>();
+        drop(rx); // client/connection gone → the send fails → deny, never block.
+        let mut approver = AcpApprover {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+            tool_counter: 0,
+        };
+        assert!(!approver.approve("write_file", &serde_json::json!({})));
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -12,7 +12,7 @@
 //! Scope: initialize / new_session / prompt / cancel; tools run locally; tool
 //! permission is delegated to the client via `session/request_permission`; tool
 //! calls stream as correlated `ToolCall`/`ToolCallUpdate` lifecycle updates.
-//! Follow-ups: client fs/terminal callbacks, per-session model config.
+//! Follow-ups: client fs/terminal callbacks.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -53,6 +53,19 @@ struct SessionState {
     convo: Vec<Message>,
     cwd: PathBuf,
     cancel: Cancel,
+    model: String,
+}
+
+/// The model id for a session: the client's `_meta["monocle.model"]` if present
+/// (a string), else `DEFAULT_MODEL`. The id is still routed/validated by monocle
+/// chat-proxy — we only pass it through. Any fallback (meta absent, key absent,
+/// or key not a string) yields `DEFAULT_MODEL`.
+fn session_model(meta: &Option<acp::Meta>) -> String {
+    meta.as_ref()
+        .and_then(|m| m.get("monocle.model"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(DEFAULT_MODEL)
+        .to_string()
 }
 
 struct MonocleAgent {
@@ -102,6 +115,7 @@ impl Agent for MonocleAgent {
                 convo: vec![Message::system(SYSTEM_PROMPT)],
                 cwd: args.cwd,
                 cancel: Cancel::new(),
+                model: session_model(&args.meta),
             },
         );
         Ok(acp::NewSessionResponse::new(id))
@@ -111,13 +125,18 @@ impl Agent for MonocleAgent {
         let key = args.session_id.0.to_string();
 
         // Snapshot the session state (release the RefCell borrow before awaiting).
-        let (mut convo, cwd, cancel) = {
+        let (mut convo, cwd, cancel, model) = {
             let mut sessions = self.sessions.borrow_mut();
             let st = sessions
                 .get_mut(&key)
                 .ok_or_else(acp::Error::invalid_params)?;
             st.cancel.reset();
-            (st.convo.clone(), st.cwd.clone(), st.cancel.clone())
+            (
+                st.convo.clone(),
+                st.cwd.clone(),
+                st.cancel.clone(),
+                st.model.clone(),
+            )
         };
 
         let user = prompt_text(&args.prompt);
@@ -144,7 +163,7 @@ impl Agent for MonocleAgent {
             };
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
-            let mut config = AgentConfig::new(DEFAULT_MODEL);
+            let mut config = AgentConfig::new(model);
             config.max_steps = DEFAULT_MAX_STEPS;
             let agent = CoreAgent::new(&provider, &tools, ToolContext::new(cwd), config);
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
@@ -348,6 +367,34 @@ async fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build an `acp::Meta` (a `serde_json::Map`) from a JSON object literal.
+    fn meta(value: serde_json::Value) -> acp::Meta {
+        serde_json::from_value(value).expect("meta must be a JSON object")
+    }
+
+    #[test]
+    fn session_model_defaults_when_meta_absent() {
+        assert_eq!(session_model(&None), DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn session_model_defaults_when_key_absent() {
+        let m = meta(serde_json::json!({ "other.key": "x" }));
+        assert_eq!(session_model(&Some(m)), DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn session_model_defaults_when_key_not_a_string() {
+        let m = meta(serde_json::json!({ "monocle.model": 42 }));
+        assert_eq!(session_model(&Some(m)), DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn session_model_uses_meta_key_when_present() {
+        let m = meta(serde_json::json!({ "monocle.model": "claude-haiku-4-5" }));
+        assert_eq!(session_model(&Some(m)), "claude-haiku-4-5");
+    }
 
     #[test]
     fn prompt_text_joins_text_blocks_and_ignores_non_text() {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -10,9 +10,9 @@
 //! only (the ACP *wire protocol* is the stable contract, not the crate API).
 //!
 //! Scope: initialize / new_session / prompt / cancel; tools run locally; tool
-//! permission is delegated to the client via `session/request_permission`
-//! (allow/reject). Follow-ups: client fs/terminal callbacks, richer ToolCall
-//! updates, per-session model config.
+//! permission is delegated to the client via `session/request_permission`; tool
+//! calls stream as correlated `ToolCall`/`ToolCallUpdate` lifecycle updates.
+//! Follow-ups: client fs/terminal callbacks, per-session model config.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -137,7 +137,6 @@ impl Agent for MonocleAgent {
             let mut approver = AcpApprover {
                 calls: updates,
                 sid,
-                tool_counter: 0,
             };
             let session = get_access_token(&Client::new(), &Credentials::new());
             let provider = MonocleProvider::from_session(session);
@@ -175,8 +174,20 @@ impl Agent for MonocleAgent {
     }
 }
 
+/// Map a tool name to the ACP `ToolKind` the client renders it as. The default
+/// (the shell tool, `bash`/`powershell`) is `Execute`.
+fn tool_kind(name: &str) -> acp::ToolKind {
+    match name {
+        "read_file" => acp::ToolKind::Read,
+        "write_file" | "edit_file" => acp::ToolKind::Edit,
+        _ => acp::ToolKind::Execute,
+    }
+}
+
 /// Bridges the sync loop's `Observer` callbacks to ACP `session/update`
-/// notifications (agent message text + tool progress as thought chunks).
+/// notifications (agent message text + tool-call lifecycle updates). The LLM
+/// tool-call id ties a call's `ToolCall` (in-progress) to its `ToolCallUpdate`
+/// (completed/failed) — the same id the client sees in the permission request.
 struct AcpObserver {
     updates: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
@@ -199,16 +210,29 @@ impl Observer for AcpObserver {
             acp::ContentChunk::new(acp::ContentBlock::from(delta.to_string())),
         ));
     }
-    fn on_tool_call(&mut self, name: &str, args: &serde_json::Value) {
-        let text = format!("⏵ {name} {args}");
-        self.send(acp::SessionUpdate::AgentThoughtChunk(
-            acp::ContentChunk::new(acp::ContentBlock::from(text)),
+    fn on_tool_call(&mut self, id: &str, name: &str, args: &serde_json::Value) {
+        self.send(acp::SessionUpdate::ToolCall(
+            acp::ToolCall::new(acp::ToolCallId::new(id.to_string()), name)
+                .kind(tool_kind(name))
+                .status(acp::ToolCallStatus::InProgress)
+                .raw_input(args.clone()),
         ));
     }
-    fn on_tool_result(&mut self, _name: &str, outcome: &ToolOutcome) {
-        let text = format!("  {}", outcome.ui_text());
-        self.send(acp::SessionUpdate::AgentThoughtChunk(
-            acp::ContentChunk::new(acp::ContentBlock::from(text)),
+    fn on_tool_result(&mut self, id: &str, _name: &str, outcome: &ToolOutcome) {
+        let status = if outcome.is_error {
+            acp::ToolCallStatus::Failed
+        } else {
+            acp::ToolCallStatus::Completed
+        };
+        self.send(acp::SessionUpdate::ToolCallUpdate(
+            acp::ToolCallUpdate::new(
+                acp::ToolCallId::new(id.to_string()),
+                acp::ToolCallUpdateFields::new()
+                    .status(status)
+                    .content(vec![acp::ToolCallContent::from(
+                        outcome.ui_text().to_string(),
+                    )]),
+            ),
         ));
     }
     fn on_notice(&mut self, msg: &str) {
@@ -224,14 +248,14 @@ impl Observer for AcpObserver {
 struct AcpApprover {
     calls: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
-    tool_counter: u64,
 }
 
 impl Approver for AcpApprover {
-    fn approve(&mut self, tool_name: &str, args: &serde_json::Value) -> bool {
-        self.tool_counter += 1;
+    fn approve(&mut self, id: &str, tool_name: &str, args: &serde_json::Value) -> bool {
+        // Reuse the streamed ToolCall's id so the client correlates the permission
+        // request with the in-progress tool call it already rendered.
         let tool_call = acp::ToolCallUpdate::new(
-            acp::ToolCallId::new(format!("tc-{}", self.tool_counter)),
+            acp::ToolCallId::new(id.to_string()),
             acp::ToolCallUpdateFields::new().title(format!("{tool_name} {args}")),
         );
         let options = vec![
@@ -346,9 +370,8 @@ mod tests {
         let mut approver = AcpApprover {
             calls: tx,
             sid: acp::SessionId::new("s"),
-            tool_counter: 0,
         };
-        let granted = approver.approve("write_file", &serde_json::json!({"path": "x"}));
+        let granted = approver.approve("call_1", "write_file", &serde_json::json!({"path": "x"}));
         responder.join().unwrap();
         granted
     }
@@ -359,6 +382,64 @@ mod tests {
         assert!(!approver_with_response("reject"));
     }
 
+    /// Build an `AcpObserver` wired to an in-memory channel (no ACP stack), so a
+    /// callback's emitted `SessionUpdate` can be read back synchronously.
+    fn observer_channel() -> (AcpObserver, mpsc::UnboundedReceiver<ClientCall>) {
+        let (tx, rx) = mpsc::unbounded_channel::<ClientCall>();
+        let observer = AcpObserver {
+            updates: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        (observer, rx)
+    }
+
+    /// The single `SessionUpdate` the observer just sent (panics otherwise).
+    fn next_update(rx: &mut mpsc::UnboundedReceiver<ClientCall>) -> acp::SessionUpdate {
+        match rx.try_recv().expect("expected one queued ClientCall") {
+            ClientCall::Notify(n) => n.update,
+            ClientCall::Permission(..) => panic!("expected Notify, got Permission"),
+        }
+    }
+
+    #[test]
+    fn on_tool_call_emits_in_progress_tool_call_with_id_and_kind() {
+        let (mut observer, mut rx) = observer_channel();
+        observer.on_tool_call("call_9", "write_file", &serde_json::json!({"path": "x"}));
+        match next_update(&mut rx) {
+            acp::SessionUpdate::ToolCall(tc) => {
+                assert_eq!(tc.tool_call_id.0.as_ref(), "call_9");
+                assert_eq!(tc.status, acp::ToolCallStatus::InProgress);
+                assert_eq!(tc.kind, acp::ToolKind::Edit);
+            }
+            _ => panic!("expected a ToolCall update"),
+        }
+    }
+
+    #[test]
+    fn on_tool_result_ok_emits_completed_update_with_same_id() {
+        let (mut observer, mut rx) = observer_channel();
+        observer.on_tool_result("call_9", "write_file", &ToolOutcome::ok("hi"));
+        match next_update(&mut rx) {
+            acp::SessionUpdate::ToolCallUpdate(tcu) => {
+                assert_eq!(tcu.tool_call_id.0.as_ref(), "call_9");
+                assert_eq!(tcu.fields.status, Some(acp::ToolCallStatus::Completed));
+            }
+            _ => panic!("expected a ToolCallUpdate update"),
+        }
+    }
+
+    #[test]
+    fn on_tool_result_error_emits_failed_update() {
+        let (mut observer, mut rx) = observer_channel();
+        observer.on_tool_result("call_9", "write_file", &ToolOutcome::error("boom"));
+        match next_update(&mut rx) {
+            acp::SessionUpdate::ToolCallUpdate(tcu) => {
+                assert_eq!(tcu.fields.status, Some(acp::ToolCallStatus::Failed));
+            }
+            _ => panic!("expected a ToolCallUpdate update"),
+        }
+    }
+
     #[test]
     fn approver_denies_when_connection_is_gone() {
         let (tx, rx) = mpsc::unbounded_channel::<ClientCall>();
@@ -366,8 +447,7 @@ mod tests {
         let mut approver = AcpApprover {
             calls: tx,
             sid: acp::SessionId::new("s"),
-            tool_counter: 0,
         };
-        assert!(!approver.approve("write_file", &serde_json::json!({})));
+        assert!(!approver.approve("call_1", "write_file", &serde_json::json!({})));
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -54,6 +54,9 @@ struct SessionState {
     cwd: PathBuf,
     cancel: Cancel,
     model: String,
+    /// True while a `prompt()` turn is executing for this session. Guards against
+    /// concurrent prompts corrupting the `mem::take`-n conversation (see Fix #8).
+    running: bool,
 }
 
 /// The model id for a session: the client's `_meta["monocle.model"]` if present
@@ -116,6 +119,7 @@ impl Agent for MonocleAgent {
                 cwd: args.cwd,
                 cancel: Cancel::new(),
                 model: session_model(&args.meta),
+                running: false,
             },
         );
         Ok(acp::NewSessionResponse::new(id))
@@ -124,15 +128,22 @@ impl Agent for MonocleAgent {
     async fn prompt(&self, args: acp::PromptRequest) -> acp::Result<acp::PromptResponse> {
         let key = args.session_id.0.to_string();
 
-        // Snapshot the session state (release the RefCell borrow before awaiting).
-        let (mut convo, cwd, cancel, model) = {
+        // Claim the session and MOVE its conversation out for the turn (leaving an
+        // empty Vec behind). Reject an overlapping prompt for the same session —
+        // two turns sharing the mem::take-n state would corrupt it (Fix #8). Keep
+        // this borrow short; it is released before the first await.
+        let (convo, cwd, cancel, model) = {
             let mut sessions = self.sessions.borrow_mut();
             let st = sessions
                 .get_mut(&key)
                 .ok_or_else(acp::Error::invalid_params)?;
+            if st.running {
+                return Err(acp::Error::invalid_params()); // session busy
+            }
+            st.running = true;
             st.cancel.reset();
             (
-                st.convo.clone(),
+                std::mem::take(&mut st.convo),
                 st.cwd.clone(),
                 st.cancel.clone(),
                 st.model.clone(),
@@ -140,15 +151,16 @@ impl Agent for MonocleAgent {
         };
 
         let user = prompt_text(&args.prompt);
-        convo.push(Message::user(user));
-
         let updates = self.updates.clone();
         let sid = args.session_id.clone();
 
         // Run the SYNC agent-core loop off the async thread; stream updates back,
         // and route side-effecting tool permission to the client (the editor
-        // decides via session/request_permission).
+        // decides via session/request_permission). The user message is pushed
+        // INSIDE the closure, only after auth succeeds, so an auth failure leaves
+        // the conversation exactly as it was.
         let joined = tokio::task::spawn_blocking(move || {
+            let mut convo = convo;
             let mut observer = AcpObserver {
                 updates: updates.clone(),
                 sid: sid.clone(),
@@ -156,11 +168,13 @@ impl Agent for MonocleAgent {
             let mut approver = AcpApprover {
                 calls: updates,
                 sid,
+                cancel: cancel.clone(),
             };
             let session = match try_access_token(&Client::new(), &Credentials::new()) {
                 Ok(s) => s,
                 Err(e) => return (convo, Err(e)),
             };
+            convo.push(Message::user(user));
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
             let mut config = AgentConfig::new(model);
@@ -172,16 +186,18 @@ impl Agent for MonocleAgent {
         .await
         .map_err(|_| acp::Error::internal_error())?;
 
-        // The loop reports the real stop reason — a cancel landing on the final
-        // (no-tool) step is Cancelled, not a spuriously "completed" EndTurn.
+        // ALWAYS write the (possibly partial) conversation back and release the
+        // running guard — for BOTH Ok and Err — so tools already executed this
+        // turn are not replayed on the client's retry (Fix #1). Then propagate.
         let (updated_convo, result) = joined;
-        let run_stop = result.map_err(acp::Error::into_internal_error)?;
-
-        // Persist the updated conversation for follow-up prompts.
         if let Some(st) = self.sessions.borrow_mut().get_mut(&key) {
             st.convo = updated_convo;
+            st.running = false;
         }
 
+        // The loop reports the real stop reason — a cancel landing on the final
+        // (no-tool) step is Cancelled, not a spuriously "completed" EndTurn.
+        let run_stop = result.map_err(acp::Error::into_internal_error)?;
         let stop = match run_stop {
             RunStop::Cancelled => acp::StopReason::Cancelled,
             RunStop::EndTurn => acp::StopReason::EndTurn,
@@ -272,6 +288,9 @@ impl Observer for AcpObserver {
 struct AcpApprover {
     calls: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
+    /// The session's cancel flag, so a permission wait breaks (denies) when the
+    /// client cancels the turn instead of hanging forever on the oneshot (Fix #5).
+    cancel: Cancel,
 }
 
 impl Approver for AcpApprover {
@@ -296,15 +315,29 @@ impl Approver for AcpApprover {
         ];
         let req = acp::RequestPermissionRequest::new(self.sid.clone(), tool_call, options);
 
-        let (tx, rx) = oneshot::channel();
+        let (tx, mut rx) = oneshot::channel();
         if self.calls.send(ClientCall::Permission(req, tx)).is_err() {
             return false; // connection gone → deny
         }
-        // Block this off-thread loop until the client answers (or the turn ends).
-        matches!(
-            rx.blocking_recv(),
-            Ok(acp::RequestPermissionOutcome::Selected(sel)) if sel.option_id.0.as_ref() == "allow"
-        )
+        // Wait for the client's answer, but honor cancel so a never-answered
+        // permission can't hang this blocking-pool thread forever. Polling (not a
+        // single blocking_recv) lets us observe cancel between checks; the 20ms
+        // sleep is fine here — this runs on a spawn_blocking thread.
+        loop {
+            match rx.try_recv() {
+                Ok(acp::RequestPermissionOutcome::Selected(sel)) => {
+                    return sel.option_id.0.as_ref() == "allow";
+                }
+                Ok(_) => return false, // Cancelled outcome → deny
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    if self.cancel.is_cancelled() {
+                        return false; // turn cancelled → deny, don't hang
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                Err(oneshot::error::TryRecvError::Closed) => return false, // sender gone → deny
+            }
+        }
     }
 }
 
@@ -338,6 +371,8 @@ async fn run() {
 
     let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
     let agent = std::rc::Rc::new(MonocleAgent::new(tx));
+    // Hold a second handle so we can cancel in-flight sessions on shutdown (Fix #6).
+    let shutdown = std::rc::Rc::clone(&agent);
 
     let (conn, io_task) = acp::AgentSideConnection::new(agent, outgoing, incoming, |fut| {
         tokio::task::spawn_local(fut);
@@ -346,6 +381,7 @@ async fn run() {
     // Make the loop's queued calls to the client over the connection: fire-and-
     // forget updates, and permission round-trips whose outcome is returned to the
     // (blocking) loop via the paired oneshot.
+    let conn = std::rc::Rc::new(conn);
     tokio::task::spawn_local(async move {
         while let Some(call) = rx.recv().await {
             match call {
@@ -353,17 +389,29 @@ async fn run() {
                     let _ = conn.session_notification(note).await;
                 }
                 ClientCall::Permission(req, ack) => {
-                    let outcome = match conn.request_permission(req).await {
-                        Ok(resp) => resp.outcome,
-                        Err(_) => acp::RequestPermissionOutcome::Cancelled,
-                    };
-                    let _ = ack.send(outcome);
+                    // Spawn the round-trip so an unanswered permission doesn't
+                    // head-of-line-block queued updates for other sessions (Fix #7).
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let outcome = match conn.request_permission(req).await {
+                            Ok(resp) => resp.outcome,
+                            Err(_) => acp::RequestPermissionOutcome::Cancelled,
+                        };
+                        let _ = ack.send(outcome);
+                    });
                 }
             }
         }
     });
 
     let _ = io_task.await;
+
+    // Client disconnected: signal every in-flight session to stop so the detached
+    // spawn_blocking loops halt at their next step boundary and the runtime can
+    // shut down instead of blocking on LLM calls / tools (Fix #6).
+    for st in shutdown.sessions.borrow().values() {
+        st.cancel.cancel();
+    }
 }
 
 #[cfg(test)]
@@ -422,6 +470,7 @@ mod tests {
         let mut approver = AcpApprover {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         let granted = approver.approve("call_1", "write_file", &serde_json::json!({"path": "x"}));
         responder.join().unwrap();
@@ -432,6 +481,24 @@ mod tests {
     fn approver_grants_only_when_client_selects_allow() {
         assert!(approver_with_response("allow"));
         assert!(!approver_with_response("reject"));
+    }
+
+    #[test]
+    fn approver_denies_without_hanging_when_cancelled_and_no_answer() {
+        // The client never answers the permission (rx kept, never drained), but the
+        // turn is cancelled — approve() must break the wait and deny, not hang.
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let cancel = Cancel::new();
+        cancel.cancel();
+        let mut approver = AcpApprover {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+            cancel,
+        };
+        let start = std::time::Instant::now();
+        assert!(!approver.approve("call_1", "write_file", &serde_json::json!({"path": "x"})));
+        // The 20ms poll means it returns almost immediately; bound it generously.
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     /// Build an `AcpObserver` wired to an in-memory channel (no ACP stack), so a
@@ -499,6 +566,7 @@ mod tests {
         let mut approver = AcpApprover {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         assert!(!approver.approve("call_1", "write_file", &serde_json::json!({})));
     }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1,0 +1,255 @@
+//! ACP server-agent surface (Path B, Phase 3) — lets an ACP client (editor,
+//! monocle desktop, Craft) spawn `monocle acp` and drive our agent over stdio
+//! JSON-RPC (Zed's Agent Client Protocol).
+//!
+//! **Architecture / migration firewall:** this module is the ONLY place that
+//! touches the `agent-client-protocol` crate AND async/tokio. The agent-core
+//! loop stays synchronous; each prompt runs it on `spawn_blocking` and bridges
+//! streamed updates back to the async ACP connection via a channel. The crate is
+//! a swappable adapter — pinning 0.9 vs migrating to 1.0 is a change to this file
+//! only (the ACP *wire protocol* is the stable contract, not the crate API).
+//!
+//! v1 scope: initialize / new_session / prompt / cancel; tools run locally;
+//! permission is auto-allowed (client `session/request_permission` round-trip and
+//! client fs/terminal callbacks are Phase-3 follow-ups).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use agent_client_protocol::{self as acp, Agent, Client as _};
+use tokio::sync::mpsc;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::runner::{Agent as CoreAgent, AgentConfig, AllowAll, Cancel, Observer};
+use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::auth::get_access_token;
+use crate::credentials::Credentials;
+use crate::error::{AppError, Result};
+use crate::net::Client;
+
+const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
+(read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
+session's working directory. Take minimal, verified steps. When finished, give a brief summary.";
+
+const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+const DEFAULT_MAX_STEPS: usize = 20;
+
+/// Per-ACP-session state, keyed by session id string.
+struct SessionState {
+    convo: Vec<Message>,
+    cwd: PathBuf,
+    cancel: Cancel,
+}
+
+struct MonocleAgent {
+    /// Outbound `session/update` notifications → forwarded to the connection.
+    updates: mpsc::UnboundedSender<acp::SessionNotification>,
+    sessions: RefCell<HashMap<String, SessionState>>,
+    next_id: AtomicU64,
+}
+
+impl MonocleAgent {
+    fn new(updates: mpsc::UnboundedSender<acp::SessionNotification>) -> Self {
+        Self {
+            updates,
+            sessions: RefCell::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Agent for MonocleAgent {
+    async fn initialize(
+        &self,
+        args: acp::InitializeRequest,
+    ) -> acp::Result<acp::InitializeResponse> {
+        Ok(acp::InitializeResponse::new(args.protocol_version)
+            .agent_capabilities(acp::AgentCapabilities::new()))
+    }
+
+    async fn authenticate(
+        &self,
+        _args: acp::AuthenticateRequest,
+    ) -> acp::Result<acp::AuthenticateResponse> {
+        // We authenticate out-of-band (stored monocle credentials), so no ACP auth.
+        Ok(acp::AuthenticateResponse::default())
+    }
+
+    async fn new_session(
+        &self,
+        args: acp::NewSessionRequest,
+    ) -> acp::Result<acp::NewSessionResponse> {
+        let n = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let id = acp::SessionId::new(format!("monocle-{n}"));
+        self.sessions.borrow_mut().insert(
+            id.0.to_string(),
+            SessionState {
+                convo: vec![Message::system(SYSTEM_PROMPT)],
+                cwd: args.cwd,
+                cancel: Cancel::new(),
+            },
+        );
+        Ok(acp::NewSessionResponse::new(id))
+    }
+
+    async fn prompt(&self, args: acp::PromptRequest) -> acp::Result<acp::PromptResponse> {
+        let key = args.session_id.0.to_string();
+
+        // Snapshot the session state (release the RefCell borrow before awaiting).
+        let (mut convo, cwd, cancel) = {
+            let mut sessions = self.sessions.borrow_mut();
+            let st = sessions
+                .get_mut(&key)
+                .ok_or_else(acp::Error::invalid_params)?;
+            st.cancel.reset();
+            (st.convo.clone(), st.cwd.clone(), st.cancel.clone())
+        };
+
+        let user = prompt_text(&args.prompt);
+        convo.push(Message::user(user));
+
+        let updates = self.updates.clone();
+        let sid = args.session_id.clone();
+
+        // Run the SYNC agent-core loop off the async thread; stream updates back.
+        let joined = tokio::task::spawn_blocking(move || {
+            let mut observer = AcpObserver { updates, sid };
+            let session = get_access_token(&Client::new(), &Credentials::new());
+            let provider = MonocleProvider::from_session(session);
+            let tools = ToolRegistry::with_defaults();
+            let mut config = AgentConfig::new(DEFAULT_MODEL);
+            config.max_steps = DEFAULT_MAX_STEPS;
+            let agent = CoreAgent::new(&provider, &tools, ToolContext::new(cwd), config);
+            let result = agent.run(&mut convo, &mut AllowAll, &mut observer, &cancel);
+            (convo, cancel.is_cancelled(), result.map(|_| ()))
+        })
+        .await
+        .map_err(|_| acp::Error::internal_error())?;
+
+        let (updated_convo, cancelled, result) = joined;
+        result.map_err(acp::Error::into_internal_error)?;
+
+        // Persist the updated conversation for follow-up prompts.
+        if let Some(st) = self.sessions.borrow_mut().get_mut(&key) {
+            st.convo = updated_convo;
+        }
+
+        let stop = if cancelled {
+            acp::StopReason::Cancelled
+        } else {
+            acp::StopReason::EndTurn
+        };
+        Ok(acp::PromptResponse::new(stop))
+    }
+
+    async fn cancel(&self, args: acp::CancelNotification) -> acp::Result<()> {
+        if let Some(st) = self.sessions.borrow().get(&args.session_id.0.to_string()) {
+            st.cancel.cancel();
+        }
+        Ok(())
+    }
+}
+
+/// Bridges the sync loop's `Observer` callbacks to ACP `session/update`
+/// notifications (agent message text + tool progress as thought chunks).
+struct AcpObserver {
+    updates: mpsc::UnboundedSender<acp::SessionNotification>,
+    sid: acp::SessionId,
+}
+
+impl AcpObserver {
+    fn send(&self, update: acp::SessionUpdate) {
+        let _ = self
+            .updates
+            .send(acp::SessionNotification::new(self.sid.clone(), update));
+    }
+}
+
+impl Observer for AcpObserver {
+    fn on_text_delta(&mut self, delta: &str) {
+        self.send(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(acp::ContentBlock::from(delta.to_string())),
+        ));
+    }
+    fn on_tool_call(&mut self, name: &str, args: &serde_json::Value) {
+        let text = format!("⏵ {name} {args}");
+        self.send(acp::SessionUpdate::AgentThoughtChunk(
+            acp::ContentChunk::new(acp::ContentBlock::from(text)),
+        ));
+    }
+    fn on_tool_result(&mut self, _name: &str, outcome: &ToolOutcome) {
+        let text = format!("  {}", outcome.ui_text());
+        self.send(acp::SessionUpdate::AgentThoughtChunk(
+            acp::ContentChunk::new(acp::ContentBlock::from(text)),
+        ));
+    }
+    fn on_notice(&mut self, msg: &str) {
+        self.send(acp::SessionUpdate::AgentThoughtChunk(
+            acp::ContentChunk::new(acp::ContentBlock::from(msg.to_string())),
+        ));
+    }
+}
+
+/// Extract the plain-text portion of an ACP prompt (Text blocks joined).
+fn prompt_text(blocks: &[acp::ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|b| match b {
+            acp::ContentBlock::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Entry point for `monocle acp`: run the ACP agent over stdio until the client
+/// closes the connection. Sets up a current-thread runtime + `LocalSet` because
+/// the crate's futures are `!Send`.
+pub fn serve() -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .map_err(|e| AppError::new(e.to_string()))?;
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, run());
+    Ok(())
+}
+
+async fn run() {
+    let outgoing = tokio::io::stdout().compat_write();
+    let incoming = tokio::io::stdin().compat();
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<acp::SessionNotification>();
+    let agent = std::rc::Rc::new(MonocleAgent::new(tx));
+
+    let (conn, io_task) = acp::AgentSideConnection::new(agent, outgoing, incoming, |fut| {
+        tokio::task::spawn_local(fut);
+    });
+
+    // Forward the loop's queued notifications to the client over the connection.
+    tokio::task::spawn_local(async move {
+        while let Some(note) = rx.recv().await {
+            let _ = conn.session_notification(note).await;
+        }
+    });
+
+    let _ = io_task.await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_text_joins_text_blocks_and_ignores_non_text() {
+        let blocks = vec![
+            acp::ContentBlock::from("hello".to_string()),
+            acp::ContentBlock::from("world".to_string()),
+        ];
+        assert_eq!(prompt_text(&blocks), "hello\nworld");
+        assert_eq!(prompt_text(&[]), "");
+    }
+}

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -24,7 +24,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::agent::providers::{Message, MonocleProvider};
-use crate::agent::runner::{Agent as CoreAgent, AgentConfig, Approver, Cancel, Observer};
+use crate::agent::runner::{Agent as CoreAgent, AgentConfig, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::auth::try_access_token;
 use crate::credentials::Credentials;
@@ -159,7 +159,7 @@ impl Agent for MonocleAgent {
             };
             let session = match try_access_token(&Client::new(), &Credentials::new()) {
                 Ok(s) => s,
-                Err(e) => return (convo, cancel.is_cancelled(), Err(e)),
+                Err(e) => return (convo, Err(e)),
             };
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
@@ -167,23 +167,25 @@ impl Agent for MonocleAgent {
             config.max_steps = DEFAULT_MAX_STEPS;
             let agent = CoreAgent::new(&provider, &tools, ToolContext::new(cwd), config);
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
-            (convo, cancel.is_cancelled(), result.map(|_| ()))
+            (convo, result)
         })
         .await
         .map_err(|_| acp::Error::internal_error())?;
 
-        let (updated_convo, cancelled, result) = joined;
-        result.map_err(acp::Error::into_internal_error)?;
+        // The loop reports the real stop reason — a cancel landing on the final
+        // (no-tool) step is Cancelled, not a spuriously "completed" EndTurn.
+        let (updated_convo, result) = joined;
+        let run_stop = result.map_err(acp::Error::into_internal_error)?;
 
         // Persist the updated conversation for follow-up prompts.
         if let Some(st) = self.sessions.borrow_mut().get_mut(&key) {
             st.convo = updated_convo;
         }
 
-        let stop = if cancelled {
-            acp::StopReason::Cancelled
-        } else {
-            acp::StopReason::EndTurn
+        let stop = match run_stop {
+            RunStop::Cancelled => acp::StopReason::Cancelled,
+            RunStop::EndTurn => acp::StopReason::EndTurn,
+            RunStop::MaxSteps => acp::StopReason::MaxTurnRequests,
         };
         Ok(acp::PromptResponse::new(stop))
     }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -180,7 +180,7 @@ impl Agent for MonocleAgent {
             let agent = CoreAgent::with_max_steps(
                 &provider,
                 &tools,
-                ToolContext::new(cwd),
+                ToolContext::new(cwd).with_cancel(cancel.clone()),
                 model,
                 DEFAULT_MAX_STEPS,
             );

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -24,19 +24,19 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::agent::providers::{Message, MonocleProvider};
-use crate::agent::runner::{Agent as CoreAgent, AgentConfig, Approver, Cancel, Observer, RunStop};
+use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
 use crate::credentials::Credentials;
 use crate::error::{AppError, Result};
 use crate::net::Client;
 
-const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
-(read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
-session's working directory. Take minimal, verified steps. When finished, give a brief summary.";
-
-const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
-const DEFAULT_MAX_STEPS: usize = 20;
+/// Permission option ids sent to the client on `session/request_permission` and
+/// matched back on its answer. One symbol tying construct↔compare, so a rename
+/// can't silently break approvals.
+const PERM_ALLOW: &str = "allow";
+const PERM_REJECT: &str = "reject";
 
 /// A call the (blocking) agent loop needs the async ACP connection to make on
 /// its behalf — either a fire-and-forget update or a permission round-trip.
@@ -177,9 +177,13 @@ impl Agent for MonocleAgent {
             convo.push(Message::user(user));
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
-            let mut config = AgentConfig::new(model);
-            config.max_steps = DEFAULT_MAX_STEPS;
-            let agent = CoreAgent::new(&provider, &tools, ToolContext::new(cwd), config);
+            let agent = CoreAgent::with_max_steps(
+                &provider,
+                &tools,
+                ToolContext::new(cwd),
+                model,
+                DEFAULT_MAX_STEPS,
+            );
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
             (convo, result)
         })
@@ -303,12 +307,12 @@ impl Approver for AcpApprover {
         );
         let options = vec![
             acp::PermissionOption::new(
-                acp::PermissionOptionId::new("allow"),
+                acp::PermissionOptionId::new(PERM_ALLOW),
                 "Allow",
                 acp::PermissionOptionKind::AllowOnce,
             ),
             acp::PermissionOption::new(
-                acp::PermissionOptionId::new("reject"),
+                acp::PermissionOptionId::new(PERM_REJECT),
                 "Reject",
                 acp::PermissionOptionKind::RejectOnce,
             ),
@@ -326,7 +330,7 @@ impl Approver for AcpApprover {
         loop {
             match rx.try_recv() {
                 Ok(acp::RequestPermissionOutcome::Selected(sel)) => {
-                    return sel.option_id.0.as_ref() == "allow";
+                    return sel.option_id.0.as_ref() == PERM_ALLOW;
                 }
                 Ok(_) => return false, // Cancelled outcome → deny
                 Err(oneshot::error::TryRecvError::Empty) => {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -26,7 +26,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent as CoreAgent, AgentConfig, Approver, Cancel, Observer};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
-use crate::auth::get_access_token;
+use crate::auth::try_access_token;
 use crate::credentials::Credentials;
 use crate::error::{AppError, Result};
 use crate::net::Client;
@@ -138,7 +138,10 @@ impl Agent for MonocleAgent {
                 calls: updates,
                 sid,
             };
-            let session = get_access_token(&Client::new(), &Credentials::new());
+            let session = match try_access_token(&Client::new(), &Credentials::new()) {
+                Ok(s) => s,
+                Err(e) => return (convo, cancel.is_cancelled(), Err(e)),
+            };
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
             let mut config = AgentConfig::new(DEFAULT_MODEL);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,3 +8,19 @@ pub mod providers;
 pub mod runner;
 pub mod session;
 pub mod tools;
+
+/// Shared agent defaults, so the CLI (`monocle agent`), the chat command, and the
+/// ACP surface stay in lock-step instead of each carrying (and drifting) its own
+/// copy.
+///
+/// System prompt for the headless agent loop. Referenced by both
+/// `commands::agent` and `acp`.
+pub const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
+(read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
+session's working directory. Take minimal, verified steps. When finished, give a brief summary.";
+
+/// Default model id (routed/validated by monocle chat-proxy — we only pass it through).
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+
+/// Default agent-loop step budget before giving up.
+pub const DEFAULT_MAX_STEPS: usize = 20;

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -140,6 +140,18 @@ pub struct ChatResponse {
     pub finish_reason: Option<String>,
 }
 
+/// Ensure every assembled tool call has a non-empty `id`, synthesizing a stable
+/// `call_{i}` from position when the wire delivered an empty one. Downstream (ACP)
+/// correlates `ToolCall` / permission / `ToolCallUpdate` by this id, so an empty id
+/// would silently break that correlation. Non-empty ids are left untouched.
+fn ensure_tool_call_ids(tool_calls: &mut [ToolCall]) {
+    for (i, tc) in tool_calls.iter_mut().enumerate() {
+        if tc.id.is_empty() {
+            tc.id = format!("call_{i}");
+        }
+    }
+}
+
 /// Parse an OpenAI-compatible (non-streaming) chat completion body. Errors on a
 /// body with no `choices` (e.g. an error-shaped response) rather than silently
 /// returning an empty assistant turn that the loop would treat as a final answer.
@@ -151,8 +163,9 @@ fn parse_response_value(data: &Value) -> Result<ChatResponse> {
     }
     let message = &data["choices"][0]["message"];
     let content = message["content"].as_str().unwrap_or_default().to_string();
-    let tool_calls: Vec<ToolCall> =
+    let mut tool_calls: Vec<ToolCall> =
         serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    ensure_tool_call_ids(&mut tool_calls);
     let model = data["model"].as_str().map(String::from);
     let finish_reason = data["choices"][0]["finish_reason"]
         .as_str()
@@ -335,7 +348,7 @@ impl LlmProvider for MonocleProvider {
             }
         }
 
-        let tool_calls = tool_acc
+        let mut tool_calls: Vec<ToolCall> = tool_acc
             .into_iter()
             .filter(|a| !a.name.is_empty())
             .map(|a| ToolCall {
@@ -347,6 +360,7 @@ impl LlmProvider for MonocleProvider {
                 },
             })
             .collect();
+        ensure_tool_call_ids(&mut tool_calls);
 
         Ok(ChatResponse {
             content,

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -67,6 +67,20 @@ pub trait Observer {
 pub struct Silent;
 impl Observer for Silent {}
 
+/// Why the loop stopped — the *real* stop reason, reported to callers (the ACP
+/// surface maps it to a `StopReason`). Distinguishing these lets a cancel that
+/// lands during the final step be reported as cancelled rather than a completed
+/// answer, and a step-budget exhaustion as its own condition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunStop {
+    /// The model returned a final answer with no tool calls (normal completion).
+    EndTurn,
+    /// Cancellation was observed at a step boundary; the loop stopped gracefully.
+    Cancelled,
+    /// The step budget (`max_steps`) was exhausted before the model finished.
+    MaxSteps,
+}
+
 pub struct AgentConfig {
     pub model: String,
     pub max_steps: usize,
@@ -107,27 +121,22 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
 
     /// Run the loop to completion, appending this turn's assistant/tool messages
     /// to `conversation` (so callers can continue a multi-turn session) and
-    /// returning the model's final text answer.
+    /// reporting *why* it stopped (see [`RunStop`]). The model's streamed text is
+    /// surfaced through the observer and appended to the conversation, not returned.
     pub fn run(
         &self,
         conversation: &mut Vec<Message>,
         approver: &mut dyn Approver,
         observer: &mut dyn Observer,
         cancel: &Cancel,
-    ) -> Result<String> {
+    ) -> Result<RunStop> {
         let defs = self.tools.defs();
-        let mut last_text = String::new();
 
         for _step in 0..self.config.max_steps {
             // Cancellation is checked at each step boundary (graceful stop).
             if cancel.is_cancelled() {
-                let notice = "[agent cancelled]".to_string();
-                observer.on_notice(&notice);
-                return Ok(if last_text.is_empty() {
-                    notice
-                } else {
-                    format!("{last_text}\n\n{notice}")
-                });
+                observer.on_notice("[agent cancelled]");
+                return Ok(RunStop::Cancelled);
             }
             let req = ChatRequest {
                 model: self.config.model.clone(),
@@ -141,15 +150,12 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 .chat_stream(&req, &mut |delta| observer.on_text_delta(delta))?;
 
             // No tool calls → this is the final answer (already streamed to the
-            // observer; also returned for programmatic / multi-turn callers).
+            // observer; appended to the conversation for multi-turn callers).
             if resp.tool_calls.is_empty() {
                 conversation.push(Message::assistant(resp.content.clone()));
-                return Ok(resp.content);
+                return Ok(RunStop::EndTurn);
             }
 
-            if !resp.content.is_empty() {
-                last_text = resp.content.clone();
-            }
             // Replay the assistant's tool-call turn before the matching results.
             conversation.push(Message::assistant_with_tool_calls(
                 resp.content.clone(),
@@ -162,6 +168,12 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 let args: Value = match serde_json::from_str(&call.function.arguments) {
                     Ok(v) => v,
                     Err(e) => {
+                        // Emit the ToolCall first (with the raw args as a JSON string)
+                        // so an ACP client has a real ToolCall to correlate the
+                        // failure to — otherwise the ToolCallUpdate is an orphan and
+                        // the failure is invisible.
+                        let args_repr = Value::String(call.function.arguments.clone());
+                        observer.on_tool_call(&call.id, &call.function.name, &args_repr);
                         let outcome = ToolOutcome::error(format!(
                             "invalid arguments for `{}` (not valid JSON): {e}",
                             call.function.name
@@ -191,17 +203,12 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             }
         }
 
-        // Step budget exhausted: don't throw away work — return the best text so
-        // far with a clear notice (graceful stop, not a hard error).
-        let notice = format!(
+        // Step budget exhausted: stop gracefully (not a hard error) with a clear
+        // notice; any streamed text is already in the observer / conversation.
+        observer.on_notice(&format!(
             "[agent stopped after {} steps without finishing]",
             self.config.max_steps
-        );
-        observer.on_notice(&notice);
-        Ok(if last_text.is_empty() {
-            notice
-        } else {
-            format!("{last_text}\n\n{notice}")
-        })
+        ));
+        Ok(RunStop::MaxSteps)
     }
 }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -38,23 +38,27 @@ impl Cancel {
 /// Decides whether a *side-effecting* tool call may run. Read-only tools are not
 /// gated. (Default policies: [`AllowAll`].)
 pub trait Approver {
-    fn approve(&mut self, tool_name: &str, args: &Value) -> bool;
+    fn approve(&mut self, id: &str, tool_name: &str, args: &Value) -> bool;
 }
 
 /// Approve everything — for tests and explicit local "yolo" runs.
 pub struct AllowAll;
 impl Approver for AllowAll {
-    fn approve(&mut self, _tool_name: &str, _args: &Value) -> bool {
+    fn approve(&mut self, _id: &str, _tool_name: &str, _args: &Value) -> bool {
         true
     }
 }
 
 /// Observes loop steps (for printing / logging). Default = no-op ([`Silent`]).
+///
+/// The `id` on the tool callbacks is the LLM tool-call id (`call.id`), which ties
+/// a call's start (`on_tool_call`) to its completion (`on_tool_result`) — the ACP
+/// surface uses it to correlate `ToolCall` / `ToolCallUpdate` lifecycle updates.
 pub trait Observer {
     /// A chunk of assistant text as it streams in.
     fn on_text_delta(&mut self, _delta: &str) {}
-    fn on_tool_call(&mut self, _name: &str, _args: &Value) {}
-    fn on_tool_result(&mut self, _name: &str, _outcome: &ToolOutcome) {}
+    fn on_tool_call(&mut self, _id: &str, _name: &str, _args: &Value) {}
+    fn on_tool_result(&mut self, _id: &str, _name: &str, _outcome: &ToolOutcome) {}
     /// A meta/control notice (stopped, cancelled) — NOT model answer text, so the
     /// CLI keeps it off the stdout answer channel.
     fn on_notice(&mut self, _msg: &str) {}
@@ -162,12 +166,12 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                             "invalid arguments for `{}` (not valid JSON): {e}",
                             call.function.name
                         ));
-                        observer.on_tool_result(&call.function.name, &outcome);
+                        observer.on_tool_result(&call.id, &call.function.name, &outcome);
                         conversation.push(Message::tool(call.id.clone(), outcome.llm.clone()));
                         continue;
                     }
                 };
-                observer.on_tool_call(&call.function.name, &args);
+                observer.on_tool_call(&call.id, &call.function.name, &args);
 
                 let side_effecting = self
                     .tools
@@ -175,13 +179,14 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                     .map(|t| t.is_side_effecting())
                     .unwrap_or(true);
 
-                let outcome = if side_effecting && !approver.approve(&call.function.name, &args) {
-                    ToolOutcome::error(format!("tool call `{}` denied", call.function.name))
-                } else {
-                    self.tools.run(&self.ctx, &call.function.name, &args)
-                };
+                let outcome =
+                    if side_effecting && !approver.approve(&call.id, &call.function.name, &args) {
+                        ToolOutcome::error(format!("tool call `{}` denied", call.function.name))
+                    } else {
+                        self.tools.run(&self.ctx, &call.function.name, &args)
+                    };
 
-                observer.on_tool_result(&call.function.name, &outcome);
+                observer.on_tool_result(&call.id, &call.function.name, &outcome);
                 conversation.push(Message::tool(call.id.clone(), outcome.llm.clone()));
             }
         }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -119,6 +119,21 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
         }
     }
 
+    /// Convenience constructor for the default config with a custom step budget —
+    /// the shape both `monocle agent` and the ACP surface build. Keeps the
+    /// `AgentConfig::new` + `max_steps` two-step in one place.
+    pub fn with_max_steps(
+        provider: &'a P,
+        tools: &'a ToolRegistry,
+        ctx: ToolContext,
+        model: impl Into<String>,
+        max_steps: usize,
+    ) -> Self {
+        let mut config = AgentConfig::new(model);
+        config.max_steps = max_steps;
+        Self::new(provider, tools, ctx, config)
+    }
+
     /// Run the loop to completion, appending this turn's assistant/tool messages
     /// to `conversation` (so callers can continue a multi-turn session) and
     /// reporting *why* it stopped (see [`RunStop`]). The model's streamed text is

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -215,6 +215,14 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
 
                 observer.on_tool_result(&call.id, &call.function.name, &outcome);
                 conversation.push(Message::tool(call.id.clone(), outcome.llm.clone()));
+
+                // A cancel that landed during this tool (e.g. a killed shell
+                // command) should stop us promptly: skip the remaining tool calls
+                // in this step so the top-of-step check reports `Cancelled` rather
+                // than running more side effects first.
+                if cancel.is_cancelled() {
+                    break;
+                }
             }
         }
 

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -7,23 +7,40 @@
 //! seam (see `loop`); tools here just execute. Paths resolve relative to the
 //! tool context's working directory.
 
+use std::io::Read;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use serde_json::{json, Value};
 
 use crate::agent::providers::ToolDef;
+use crate::agent::runner::Cancel;
 
-/// Execution context shared by all tools (the working directory the agent acts in).
+/// Execution context shared by all tools (the working directory the agent acts in,
+/// plus the turn's [`Cancel`] flag so long-running tools can be interrupted mid-run).
 pub struct ToolContext {
     pub workdir: PathBuf,
+    /// Cancellation flag for the current turn. Defaults to a fresh, never-set
+    /// `Cancel` (= "not cancellable") so the many `ToolContext::new(cwd)` call
+    /// sites and tests keep working; the real callers attach the turn's flag via
+    /// [`ToolContext::with_cancel`].
+    pub cancel: Cancel,
 }
 
 impl ToolContext {
     pub fn new(workdir: impl Into<PathBuf>) -> Self {
         Self {
             workdir: workdir.into(),
+            cancel: Cancel::new(),
         }
+    }
+
+    /// Attach the turn's cancellation flag so cancellable tools (the shell) can be
+    /// interrupted mid-run instead of only at the step boundary.
+    pub fn with_cancel(mut self, cancel: Cancel) -> Self {
+        self.cancel = cancel;
+        self
     }
 
     /// Resolve a (possibly relative) path against the working directory.
@@ -304,6 +321,11 @@ impl Tool for Shell {
             Err(e) => return e,
         };
 
+        // Honor a cancel that landed before we even spawned — don't start work.
+        if ctx.cancel.is_cancelled() {
+            return ToolOutcome::error("shell command cancelled before it started");
+        }
+
         #[cfg(windows)]
         let mut cmd = {
             let mut c = Command::new("powershell");
@@ -316,35 +338,97 @@ impl Tool for Shell {
             c.arg("-c").arg(command);
             c
         };
-        cmd.current_dir(&ctx.workdir);
+        cmd.current_dir(&ctx.workdir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
-        match cmd.output() {
-            Ok(out) => {
-                let code = out.status.code().unwrap_or(-1);
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let stderr = String::from_utf8_lossy(&out.stderr);
-                let mut combined = String::new();
-                if !stdout.is_empty() {
-                    combined.push_str(&stdout);
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => return ToolOutcome::error(format!("failed to run shell: {e}")),
+        };
+
+        // Drain stdout/stderr on their own threads so a chatty long-running command
+        // can't deadlock the poll loop by filling a pipe buffer.
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+        let drain = |pipe: Option<std::process::ChildStdout>| {
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                if let Some(mut p) = pipe {
+                    let _ = p.read_to_end(&mut buf);
                 }
-                if !stderr.is_empty() {
-                    if !combined.is_empty() && !combined.ends_with('\n') {
-                        combined.push('\n');
+                buf
+            })
+        };
+        let drain_err = |pipe: Option<std::process::ChildStderr>| {
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                if let Some(mut p) = pipe {
+                    let _ = p.read_to_end(&mut buf);
+                }
+                buf
+            })
+        };
+        let out_handle = drain(stdout_pipe);
+        let err_handle = drain_err(stderr_pipe);
+
+        // Poll: exit → done; cancel → kill+reap; else nap and re-check.
+        let mut cancelled = false;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Some(status),
+                Ok(None) => {
+                    if ctx.cancel.is_cancelled() {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        cancelled = true;
+                        break None;
                     }
-                    combined.push_str(&stderr);
+                    std::thread::sleep(Duration::from_millis(50));
                 }
-                // Cap the LLM-facing output (re-sent every turn — §9a).
-                let llm = format!(
-                    "{}\n[exit code: {code}]",
-                    cap_output(&combined, MAX_SHELL_CHARS)
-                );
-                ToolOutcome {
-                    llm,
-                    ui: Some(format!("exit {code}")),
-                    is_error: !out.status.success(),
+                Err(e) => {
+                    let _ = child.wait();
+                    return ToolOutcome::error(format!("failed to wait on shell: {e}"));
                 }
             }
-            Err(e) => ToolOutcome::error(format!("failed to run shell: {e}")),
+        };
+
+        // Reader threads finish once the pipes close (on exit or kill).
+        let stdout = out_handle.join().unwrap_or_default();
+        let stderr = err_handle.join().unwrap_or_default();
+        let stdout = String::from_utf8_lossy(&stdout);
+        let stderr = String::from_utf8_lossy(&stderr);
+        let mut combined = String::new();
+        if !stdout.is_empty() {
+            combined.push_str(&stdout);
+        }
+        if !stderr.is_empty() {
+            if !combined.is_empty() && !combined.ends_with('\n') {
+                combined.push('\n');
+            }
+            combined.push_str(&stderr);
+        }
+        // Cap the LLM-facing output (re-sent every turn — §9a).
+        let capped = cap_output(&combined, MAX_SHELL_CHARS);
+
+        if cancelled {
+            let partial = if capped.is_empty() {
+                String::new()
+            } else {
+                format!("\n[partial output before cancel]\n{capped}")
+            };
+            return ToolOutcome::error(format!("shell command cancelled{partial}"))
+                .with_ui("cancelled".to_string());
+        }
+
+        let code = status.and_then(|s| s.code()).unwrap_or(-1);
+        let success = status.map(|s| s.success()).unwrap_or(false);
+        let llm = format!("{capped}\n[exit code: {code}]");
+        ToolOutcome {
+            llm,
+            ui: Some(format!("exit {code}")),
+            is_error: !success,
         }
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,6 +4,7 @@
 //! credentials exist or refresh fails — callers don't handle those cases.
 
 use crate::credentials::{Credentials, CredentialsData};
+use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::refresh::refresh_access_token;
 use crate::util::{now_ms, parse_iso_ms};
@@ -25,12 +26,16 @@ pub fn router_url_for(creds: &CredentialsData) -> String {
     format!("{scheme}://{}", creds.tenant_domain)
 }
 
-pub fn get_access_token(client: &Client, creds: &Credentials) -> AuthSession {
+/// Non-exiting variant of [`get_access_token`]. Returns an [`AppError`] instead
+/// of printing to stderr and calling `std::process::exit(1)`, so long-lived
+/// callers (e.g. the ACP server) can fail a single request and stay alive.
+pub fn try_access_token(client: &Client, creds: &Credentials) -> Result<AuthSession> {
     let stored = match creds.read() {
         Some(c) => c,
         None => {
-            eprintln!("Not logged in. Run `monocle login --tenant <domain>` first.");
-            std::process::exit(1);
+            return Err(AppError::new(
+                "Not logged in. Run `monocle login --tenant <domain>` first.",
+            ));
         }
     };
 
@@ -42,16 +47,46 @@ pub fn get_access_token(client: &Client, creds: &Credentials) -> AuthSession {
             match refresh_access_token(client, &stored, creds) {
                 Ok(refreshed) => active = refreshed,
                 Err(e) => {
-                    eprintln!("Token refresh failed: {e}");
-                    std::process::exit(1);
+                    return Err(AppError::new(format!("Token refresh failed: {e}")));
                 }
             }
         }
     }
 
     let router_url = router_url_for(&active);
-    AuthSession {
+    Ok(AuthSession {
         token: active.access_token,
         router_url,
+    })
+}
+
+pub fn get_access_token(client: &Client, creds: &Credentials) -> AuthSession {
+    match try_access_token(client, creds) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_access_token_errors_when_not_logged_in() {
+        // Point at an empty temp home so no real `~/.monocle` is consulted and
+        // the missing-credentials branch fires without any network access.
+        let dir = tempfile::tempdir().unwrap();
+        let creds = Credentials::with_home(dir.path());
+
+        match try_access_token(&Client::new(), &creds) {
+            Ok(_) => panic!("absent credentials must return Err, not Ok"),
+            Err(err) => assert!(
+                err.to_string().starts_with("Not logged in"),
+                "unexpected message: {err}"
+            ),
+        }
     }
 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -40,7 +40,7 @@ impl Observer for CliObserver {
         let _ = out.write_all(delta.as_bytes());
         let _ = out.flush();
     }
-    fn on_tool_call(&mut self, name: &str, args: &Value) {
+    fn on_tool_call(&mut self, _id: &str, name: &str, args: &Value) {
         eprintln!(
             "\n{} {} {}",
             c::cyan("⏵"),
@@ -48,7 +48,7 @@ impl Observer for CliObserver {
             c::dim(&one_line(&args.to_string(), 120))
         );
     }
-    fn on_tool_result(&mut self, _name: &str, outcome: &ToolOutcome) {
+    fn on_tool_result(&mut self, _id: &str, _name: &str, outcome: &ToolOutcome) {
         let tag = if outcome.is_error {
             c::red("✗")
         } else {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -82,7 +82,7 @@ impl Repl<'_> {
         let agent = Agent::with_max_steps(
             &provider,
             &self.tools,
-            ToolContext::new(self.workdir.clone()),
+            ToolContext::new(self.workdir.clone()).with_cancel(self.cancel.clone()),
             self.model.as_str(),
             self.max_steps,
         );

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,19 +10,16 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::providers::{Message, MonocleProvider};
-use crate::agent::runner::{Agent, AgentConfig, AllowAll, Cancel, Observer};
+use crate::agent::runner::{Agent, AllowAll, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
 use crate::util::home_dir;
-
-const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provided tools \
-(read_file, write_file, edit_file, and the shell) to accomplish the user's task within the \
-working directory. Take minimal, verified steps. When finished, give a brief summary.";
 
 pub struct AgentOptions {
     pub prompt: Option<String>,
@@ -82,13 +79,12 @@ impl Repl<'_> {
         // Fresh token each turn (get_access_token refreshes if near expiry).
         let auth = get_access_token(self.client, self.creds);
         let provider = MonocleProvider::from_session(auth);
-        let mut config = AgentConfig::new(self.model.as_str());
-        config.max_steps = self.max_steps;
-        let agent = Agent::new(
+        let agent = Agent::with_max_steps(
             &provider,
             &self.tools,
             ToolContext::new(self.workdir.clone()),
-            config,
+            self.model.as_str(),
+            self.max_steps,
         );
 
         // Clear any cancel from an idle Ctrl-C press before starting this turn.

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -3,6 +3,7 @@ use std::io::{IsTerminal, Write};
 use serde_json::Value;
 
 use crate::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
+use crate::agent::DEFAULT_MODEL;
 use crate::auth::get_access_token;
 use crate::credentials::Credentials;
 use crate::endpoints;
@@ -10,7 +11,6 @@ use crate::error::Result;
 use crate::net::Client;
 use crate::origin::auth_headers;
 
-const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS: i64 = 4096;
 
 pub struct ChatOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Library surface for the `monocle` CLI. The binary (`src/main.rs`) is a thin
 //! clap front-end over these modules; tests import them directly.
 
+pub mod acp;
 pub mod agent;
 pub mod audio_io;
 pub mod auth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,10 @@ enum Commands {
         #[arg(long)]
         workdir: Option<String>,
         /// Model id to use (routed via Monocle)
-        #[arg(long, default_value = "claude-sonnet-4-6")]
+        #[arg(long, default_value = monocle_cli::agent::DEFAULT_MODEL)]
         model: String,
         /// Maximum loop steps before giving up
-        #[arg(long = "max-steps", default_value = "20")]
+        #[arg(long = "max-steps", default_value_t = monocle_cli::agent::DEFAULT_MAX_STEPS)]
         max_steps: usize,
         /// Named session to persist/resume (~/.monocle/agent/<name>.jsonl)
         #[arg(long)]
@@ -100,7 +100,7 @@ enum Commands {
 #[derive(Args)]
 struct ChatArgs {
     /// Model ID to use
-    #[arg(long, default_value = "claude-sonnet-4-6")]
+    #[arg(long, default_value = monocle_cli::agent::DEFAULT_MODEL)]
     model: String,
     /// System prompt text
     #[arg(long = "system-prompt")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
         args: Vec<String>,
     },
+    /// [Experimental] Run as an ACP agent over stdio (editors / desktop / Craft)
+    Acp,
     /// List available models from the Monocle router
     Models,
     /// Chat with LLM via Monocle router (interactive REPL or pipe from stdin)
@@ -244,6 +246,7 @@ fn main() {
             claude_command(&creds, &args);
             Ok(())
         }
+        Commands::Acp => monocle_cli::acp::serve(),
         Commands::Models => model_list_command(&client, &creds),
         Commands::Chat(args) => chat_command(&client, &creds, args.into()),
         Commands::Agent {

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -50,7 +50,7 @@ fn loop_executes_tool_then_returns_final_answer() {
         calls: Vec<String>,
     }
     impl Observer for Rec {
-        fn on_tool_call(&mut self, name: &str, _args: &Value) {
+        fn on_tool_call(&mut self, _id: &str, name: &str, _args: &Value) {
             self.calls.push(name.to_string());
         }
     }
@@ -87,7 +87,7 @@ fn denied_side_effecting_tool_is_not_executed() {
 
     struct DenyAll;
     impl Approver for DenyAll {
-        fn approve(&mut self, _name: &str, _args: &Value) -> bool {
+        fn approve(&mut self, _id: &str, _name: &str, _args: &Value) -> bool {
             false
         }
     }

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -9,9 +9,9 @@ use common::{
 };
 use monocle_cli::agent::providers::Message;
 use monocle_cli::agent::runner::{
-    Agent, AgentConfig, AllowAll, Approver, Cancel, Observer, Silent,
+    Agent, AgentConfig, AllowAll, Approver, Cancel, Observer, RunStop, Silent,
 };
-use monocle_cli::agent::tools::{ToolContext, ToolRegistry};
+use monocle_cli::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 
 // These tests exercise the loop IN ISOLATION via a scripted `FakeProvider` — no
 // HTTP, no wire format. The wire (Chat Completions / SSE) is covered separately
@@ -60,11 +60,13 @@ fn loop_executes_tool_then_returns_final_answer() {
         Message::system("be helpful"),
         Message::user("write out.txt"),
     ];
-    let answer = agent
+    let stop = agent
         .run(&mut convo, &mut AllowAll, &mut rec, &Cancel::new())
         .unwrap();
 
-    assert_eq!(answer, "done");
+    // A plain text answer ends the turn normally; the final text lands in the convo.
+    assert!(matches!(stop, RunStop::EndTurn));
+    assert_eq!(convo.last().unwrap().content.as_deref(), Some("done"));
     assert_eq!(rec.calls, vec!["write_file"]);
     assert_eq!(
         std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
@@ -92,7 +94,7 @@ fn denied_side_effecting_tool_is_not_executed() {
         }
     }
 
-    let answer = agent
+    let stop = agent
         .run(
             &mut vec![Message::user("write out.txt")],
             &mut DenyAll,
@@ -101,7 +103,7 @@ fn denied_side_effecting_tool_is_not_executed() {
         )
         .unwrap();
 
-    assert_eq!(answer, "done");
+    assert!(matches!(stop, RunStop::EndTurn));
     assert!(
         !dir.path().join("out.txt").exists(),
         "denied write must not touch disk"
@@ -117,7 +119,7 @@ fn loop_stops_at_max_steps() {
     let dir = tempfile::tempdir().unwrap();
     let agent = agent(&provider, &tools, dir.path(), 3);
 
-    let answer = agent
+    let stop = agent
         .run(
             &mut vec![Message::user("loop forever")],
             &mut AllowAll,
@@ -125,7 +127,7 @@ fn loop_stops_at_max_steps() {
             &Cancel::new(),
         )
         .unwrap();
-    assert!(answer.contains("stopped after 3 steps"), "got: {answer}");
+    assert!(matches!(stop, RunStop::MaxSteps), "expected MaxSteps");
 }
 
 #[test]
@@ -141,16 +143,16 @@ fn conversation_persists_across_turns() {
     let agent = agent(&provider, &tools, dir.path(), 20);
 
     let mut convo = vec![Message::system("s"), Message::user("first")];
-    let a1 = agent
+    agent
         .run(&mut convo, &mut AllowAll, &mut Silent, &Cancel::new())
         .unwrap();
-    assert_eq!(a1, "seen 1");
+    assert_eq!(convo.last().unwrap().content.as_deref(), Some("seen 1"));
 
     convo.push(Message::user("second"));
-    let a2 = agent
+    agent
         .run(&mut convo, &mut AllowAll, &mut Silent, &Cancel::new())
         .unwrap();
-    assert_eq!(a2, "seen 2");
+    assert_eq!(convo.last().unwrap().content.as_deref(), Some("seen 2"));
 
     // system, user, assistant, user, assistant
     assert_eq!(convo.len(), 5);
@@ -169,7 +171,7 @@ fn malformed_tool_args_are_reported_to_model_not_swallowed() {
     let dir = tempfile::tempdir().unwrap();
     let agent = agent(&provider, &tools, dir.path(), 20);
 
-    let answer = agent
+    let stop = agent
         .run(
             &mut vec![Message::user("do it")],
             &mut AllowAll,
@@ -177,7 +179,55 @@ fn malformed_tool_args_are_reported_to_model_not_swallowed() {
             &Cancel::new(),
         )
         .unwrap();
-    assert_eq!(answer, "recovered");
+    assert!(matches!(stop, RunStop::EndTurn));
+}
+
+#[test]
+fn malformed_tool_args_emit_tool_call_before_result() {
+    // Finding #2: even for unparseable args the loop must first surface a
+    // `on_tool_call` (so an ACP client has a ToolCall to correlate) and THEN the
+    // failure `on_tool_result` — never an orphan result the client ignores.
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("recovered")
+        } else {
+            tool_call_response_raw("c", "write_file", "{not json")
+        }
+    });
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = agent(&provider, &tools, dir.path(), 20);
+
+    #[derive(Default)]
+    struct Rec {
+        events: Vec<String>,
+    }
+    impl Observer for Rec {
+        fn on_tool_call(&mut self, id: &str, name: &str, args: &Value) {
+            // args_repr for malformed input is the raw string wrapped as a JSON string.
+            self.events
+                .push(format!("call:{id}:{name}:str={}", args.is_string()));
+        }
+        fn on_tool_result(&mut self, id: &str, name: &str, _o: &ToolOutcome) {
+            self.events.push(format!("result:{id}:{name}"));
+        }
+    }
+    let mut rec = Rec::default();
+
+    agent
+        .run(
+            &mut vec![Message::user("do it")],
+            &mut AllowAll,
+            &mut rec,
+            &Cancel::new(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        rec.events,
+        vec!["call:c:write_file:str=true", "result:c:write_file"],
+        "on_tool_call must precede on_tool_result, both present"
+    );
 }
 
 #[test]
@@ -197,7 +247,7 @@ fn loop_can_be_cancelled_mid_run() {
     let dir = tempfile::tempdir().unwrap();
     let agent = agent(&provider, &tools, dir.path(), 100);
 
-    let answer = agent
+    let stop = agent
         .run(
             &mut vec![Message::user("go")],
             &mut AllowAll,
@@ -205,5 +255,5 @@ fn loop_can_be_cancelled_mid_run() {
             &cancel,
         )
         .unwrap();
-    assert!(answer.contains("cancelled"), "got: {answer}");
+    assert!(matches!(stop, RunStop::Cancelled), "expected Cancelled");
 }

--- a/tests/agent_providers.rs
+++ b/tests/agent_providers.rs
@@ -105,3 +105,30 @@ fn chat_errors_when_response_has_no_choices() {
         .to_string();
     assert!(err.contains("no choices"), "got: {err}");
 }
+
+#[test]
+fn tool_call_with_empty_id_gets_synthesized_id() {
+    // Finding #4 (non-streaming path): a tool call served with an empty `id` would
+    // break ACP correlation; the provider synthesizes a stable id from position.
+    let s = stub(|_a, _m, url, _b| {
+        if url.starts_with("/v1/chat/completions") {
+            (
+                200,
+                r#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"","type":"function","function":{"name":"read_file","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"#
+                    .to_string(),
+            )
+        } else {
+            (404, String::new())
+        }
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+    let resp = provider
+        .chat(&ChatRequest {
+            model: "m".into(),
+            messages: vec![Message::user("hi")],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].id, "call_0");
+}

--- a/tests/agent_streaming.rs
+++ b/tests/agent_streaming.rs
@@ -66,3 +66,30 @@ data: [DONE]\n\n";
     );
     assert_eq!(resp.finish_reason.as_deref(), Some("tool_calls"));
 }
+
+#[test]
+fn streamed_tool_call_with_empty_id_gets_synthesized_id() {
+    // Finding #4: a streamed tool call may arrive with no `id` (acc.id stays "").
+    // ACP correlates ToolCall/permission/ToolCallUpdate by id, so finalize must
+    // synthesize a stable non-empty id from position.
+    let s = stub_sse(|_a, _m, url, _b| {
+        if !url.starts_with("/v1/chat/completions") {
+            return (404, String::new());
+        }
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{}\"}}]}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
+data: [DONE]\n\n";
+        (200, body.to_string())
+    });
+    let provider = MonocleProvider::new("tok", s.router_url());
+
+    let resp = provider.chat_stream(&req(), &mut |_d| {}).unwrap();
+
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert!(
+        !resp.tool_calls[0].id.is_empty(),
+        "empty id must be synthesized"
+    );
+    assert_eq!(resp.tool_calls[0].id, "call_0");
+}

--- a/tests/agent_tools.rs
+++ b/tests/agent_tools.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
 
+use monocle_cli::agent::runner::Cancel;
 use monocle_cli::agent::tools::{ToolContext, ToolRegistry};
 
 fn ctx() -> (tempfile::TempDir, ToolContext) {
@@ -139,4 +140,76 @@ fn shell_llm_output_is_capped_ui_is_concise() {
         r.llm.chars().count()
     );
     assert_eq!(r.ui_text(), "exit 0");
+}
+
+/// A cancel already set before the shell tool runs returns immediately (well under
+/// the command's 5s runtime) as an error — proves the pre-spawn cancel check.
+#[cfg(unix)]
+#[test]
+fn shell_honors_cancel_set_before_running() {
+    let dir = tempfile::tempdir().unwrap();
+    let cancel = Cancel::new();
+    cancel.cancel();
+    let ctx = ToolContext::new(dir.path()).with_cancel(cancel);
+    let reg = ToolRegistry::with_defaults();
+
+    let start = std::time::Instant::now();
+    let r = reg.run(&ctx, "bash", &json!({ "command": "sleep 5" }));
+    let elapsed = start.elapsed();
+
+    assert!(r.is_error, "cancelled shell should be an error: {}", r.llm);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "should return promptly, took {elapsed:?}"
+    );
+}
+
+/// A cancel flipped ~100ms into a 5s command kills it mid-run — proves the poll
+/// loop's `child.kill()` path (the whole point of Fix #9).
+#[cfg(unix)]
+#[test]
+fn shell_is_killed_mid_run_on_cancel() {
+    let dir = tempfile::tempdir().unwrap();
+    let cancel = Cancel::new();
+    let ctx = ToolContext::new(dir.path()).with_cancel(cancel.clone());
+    let reg = ToolRegistry::with_defaults();
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        cancel.cancel();
+    });
+
+    let start = std::time::Instant::now();
+    let r = reg.run(&ctx, "bash", &json!({ "command": "sleep 5" }));
+    let elapsed = start.elapsed();
+
+    assert!(r.is_error, "cancelled shell should be an error: {}", r.llm);
+    assert!(
+        r.llm.contains("cancelled"),
+        "message should mention cancel: {}",
+        r.llm
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "kill should be prompt, took {elapsed:?}"
+    );
+}
+
+/// Regression: the piped/threaded/poll path still runs a normal quick command and
+/// returns its output successfully (a non-cancelled context is the common case).
+#[test]
+fn shell_normal_command_still_succeeds_with_non_cancelled_ctx() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(dir.path()).with_cancel(Cancel::new());
+    let reg = ToolRegistry::with_defaults();
+
+    #[cfg(not(windows))]
+    let (tool, cmd) = ("bash", "echo hi");
+    #[cfg(windows)]
+    let (tool, cmd) = ("powershell", "Write-Output hi");
+
+    let r = reg.run(&ctx, tool, &json!({ "command": cmd }));
+    assert!(!r.is_error, "{}", r.llm);
+    assert!(r.llm.contains("hi"), "{}", r.llm);
+    assert!(r.llm.contains("[exit code: 0]"), "{}", r.llm);
 }


### PR DESCRIPTION
> **베이스 = `rust-rewrite`** (통합 트렁크 전략, PR #45에 이어 스택). Rust 기반이 무르익으면 `rust-rewrite`를 한 번에 devel로 랜딩.

설계: warmblood-kr/monocle#158 · 구현 상태: warmblood-kr/monocle-cli#44

## 무엇
`monocle`을 **ACP(Zed Agent Client Protocol) 서버‑에이전트**로 노출(`monocle acp`). 에디터·**monocle 데스크탑**·**Craft**가 프로세스를 spawn해 stdio JSON‑RPC로 우리 에이전트를 구동 — Craft의 Sonnet 종속 비용을 코어 변경 없이 완화(모델 자유도 G1). **async는 `src/acp.rs`에만 격리**, agent-core 루프는 동기 유지(prompt마다 `spawn_blocking` + 채널 브릿지).

## 포함
- **`src/acp.rs` + `monocle acp`**: `impl acp::Agent`(initialize/authenticate/new_session/prompt/cancel), current-thread tokio + LocalSet + tokio_util compat로 stdio 배선.
- **스트리밍**: 어시스턴트 텍스트 → `session/update`(agent_message_chunk).
- **권한 위임**: 부작용 툴 실행 전 `session/request_permission` → 클라이언트가 allow/reject(우리 `Approver` seam).
- **ToolCall 라이프사이클**: `ToolCall`(in_progress)→권한(같은 id)→`ToolCallUpdate`(completed/failed), LLM tool id로 상관.
- **미로그인 생존**: 인증 실패 시 프로세스 종료 대신 그 prompt만 ACP 에러(`auth::try_access_token`).
- **세션별 모델(G1)**: `session/new`의 `_meta.monocle.model`로 세션마다 모델 선택(없으면 기본). 모델은 monocle chat-proxy 라우팅.

## 검증
`cargo clippy -D warnings` 클린, **67 테스트**(격리 단위: FakeProvider 루프, approver 브릿지, ToolCall emit, session_model, auth). 실 바이너리 e2e: initialize→new→prompt 전체 턴, 권한 allow/deny(파일 기록/차단), ToolCall 상관, 미로그인 생존, `_meta` 모델→실제 요청 도달.

## 이관 방화벽
ACP crate(`agent-client-protocol` 0.9) 사용은 `src/acp.rs` 한 곳에만 — 와이어(ACP v1)가 안정 계약이라 0.9→1.0 이관은 이 파일 국소.

## 남음 (후속)
client fs/terminal 콜백(에디터가 파일/터미널 매개; 서버 백엔드엔 우선순위 낮아 로컬 툴 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
