### PR TITLE
ACP client fs/terminal 콜백: 호스트가 파일·터미널 I/O 소유

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ agent over stdio (JSON-RPC) — an editor, the Monocle desktop app, or Craft spa
 drives sessions. Tool permission is delegated to the client (`session/request_permission`),
 tool calls stream as `ToolCall`/`ToolCallUpdate` updates, and a client may pick the model
 per session via `_meta.monocle.model` on `session/new` (falls back to the default).
+When the client advertises the matching capabilities, the agent routes **file reads/writes
+through the client** (`fs/read_text_file`/`fs/write_text_file`, so unsaved editor buffers are
+honored) and **runs the shell via the client's terminal** (`terminal/*`); otherwise it falls
+back to local disk and a local subprocess.
 
 ## 🔌 Using Monocle from your own app (OpenAI-compatible SDK)
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -9,15 +9,18 @@
 //! a swappable adapter — pinning 0.9 vs migrating to 1.0 is a change to this file
 //! only (the ACP *wire protocol* is the stable contract, not the crate API).
 //!
-//! Scope: initialize / new_session / prompt / cancel; tools run locally; tool
-//! permission is delegated to the client via `session/request_permission`; tool
-//! calls stream as correlated `ToolCall`/`ToolCallUpdate` lifecycle updates.
-//! Follow-ups: client fs/terminal callbacks.
+//! Scope: initialize / new_session / prompt / cancel; tool file I/O is routed
+//! through the client when it advertises `fs` capabilities (editor-mediated
+//! read/write), else runs on local disk; tool permission is delegated to the
+//! client via `session/request_permission`; tool calls stream as correlated
+//! `ToolCall`/`ToolCallUpdate` lifecycle updates. Follow-ups: client terminal
+//! callbacks.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use agent_client_protocol::{self as acp, Agent, Client as _};
 use tokio::sync::{mpsc, oneshot};
@@ -25,7 +28,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
-use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
+use crate::agent::tools::{FsBackend, ToolContext, ToolOutcome, ToolRegistry};
 use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
 use crate::credentials::Credentials;
@@ -39,12 +42,21 @@ const PERM_ALLOW: &str = "allow";
 const PERM_REJECT: &str = "reject";
 
 /// A call the (blocking) agent loop needs the async ACP connection to make on
-/// its behalf — either a fire-and-forget update or a permission round-trip.
+/// its behalf — a fire-and-forget update, a permission round-trip, or a
+/// client-mediated filesystem read/write (when the client advertises fs caps).
 enum ClientCall {
     Notify(acp::SessionNotification),
     Permission(
         acp::RequestPermissionRequest,
         oneshot::Sender<acp::RequestPermissionOutcome>,
+    ),
+    ReadFile(
+        acp::ReadTextFileRequest,
+        oneshot::Sender<std::result::Result<String, String>>,
+    ),
+    WriteFile(
+        acp::WriteTextFileRequest,
+        oneshot::Sender<std::result::Result<(), String>>,
     ),
 }
 
@@ -76,6 +88,10 @@ struct MonocleAgent {
     updates: mpsc::UnboundedSender<ClientCall>,
     sessions: RefCell<HashMap<String, SessionState>>,
     next_id: AtomicU64,
+    /// Capabilities the client advertised at `initialize` — notably whether it
+    /// can serve `fs/read_text_file` + `fs/write_text_file`, which gates whether
+    /// tool file I/O is routed through the client (editor-mediated) or local disk.
+    client_caps: RefCell<acp::ClientCapabilities>,
 }
 
 impl MonocleAgent {
@@ -84,6 +100,7 @@ impl MonocleAgent {
             updates,
             sessions: RefCell::new(HashMap::new()),
             next_id: AtomicU64::new(1),
+            client_caps: RefCell::new(acp::ClientCapabilities::default()),
         }
     }
 }
@@ -94,6 +111,9 @@ impl Agent for MonocleAgent {
         &self,
         args: acp::InitializeRequest,
     ) -> acp::Result<acp::InitializeResponse> {
+        // Remember what the client can do (fs read/write) so `prompt()` can route
+        // tool file I/O through the client when it advertises those capabilities.
+        *self.client_caps.borrow_mut() = args.client_capabilities.clone();
         Ok(acp::InitializeResponse::new(args.protocol_version)
             .agent_capabilities(acp::AgentCapabilities::new()))
     }
@@ -154,6 +174,16 @@ impl Agent for MonocleAgent {
         let updates = self.updates.clone();
         let sid = args.session_id.clone();
 
+        // Route tool file I/O through the client only when it advertises BOTH fs
+        // read and write; otherwise fall back to local disk (default LocalFs). Read
+        // the caps here (brief borrow) so the blocking closure captures plain data.
+        let use_client_fs = {
+            let caps = self.client_caps.borrow();
+            caps.fs.read_text_file && caps.fs.write_text_file
+        };
+        let fs_calls = self.updates.clone();
+        let fs_sid = args.session_id.clone();
+
         // Run the SYNC agent-core loop off the async thread; stream updates back,
         // and route side-effecting tool permission to the client (the editor
         // decides via session/request_permission). The user message is pushed
@@ -177,13 +207,14 @@ impl Agent for MonocleAgent {
             convo.push(Message::user(user));
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
-            let agent = CoreAgent::with_max_steps(
-                &provider,
-                &tools,
-                ToolContext::new(cwd).with_cancel(cancel.clone()),
-                model,
-                DEFAULT_MAX_STEPS,
-            );
+            let mut ctx = ToolContext::new(cwd).with_cancel(cancel.clone());
+            if use_client_fs {
+                ctx = ctx.with_fs(Arc::new(AcpClientFs {
+                    calls: fs_calls,
+                    sid: fs_sid,
+                }));
+            }
+            let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
             (convo, result)
         })
@@ -345,6 +376,52 @@ impl Approver for AcpApprover {
     }
 }
 
+/// Client-mediated [`FsBackend`]: the read/write/edit tools' file I/O is routed
+/// through the ACP client (`fs/read_text_file`, `fs/write_text_file`) instead of
+/// local disk, so the editor can serve unsaved buffers and track changes. Wired
+/// in only when the client advertises both fs capabilities (see `prompt()`).
+///
+/// These methods run on the loop's `spawn_blocking` thread, so they block on the
+/// paired oneshot; the async forwarding task (owning the connection) performs the
+/// actual RPC. Paths passed in are already absolute (`ToolContext::resolve`).
+struct AcpClientFs {
+    calls: mpsc::UnboundedSender<ClientCall>,
+    sid: acp::SessionId,
+}
+
+impl AcpClientFs {
+    /// Send a queued call and block for its ack. Any send/recv failure (the
+    /// forwarding task or connection is gone) collapses to a single unavailable
+    /// message the tool surfaces as an error.
+    fn round_trip<T>(
+        &self,
+        call: ClientCall,
+        rx: oneshot::Receiver<std::result::Result<T, String>>,
+    ) -> std::result::Result<T, String> {
+        if self.calls.send(call).is_err() {
+            return Err("acp client fs unavailable".to_string());
+        }
+        match rx.blocking_recv() {
+            Ok(res) => res,
+            Err(_) => Err("acp client fs unavailable".to_string()),
+        }
+    }
+}
+
+impl FsBackend for AcpClientFs {
+    fn read(&self, path: &std::path::Path) -> std::result::Result<String, String> {
+        let (tx, rx) = oneshot::channel();
+        let req = acp::ReadTextFileRequest::new(self.sid.clone(), path.to_path_buf());
+        self.round_trip(ClientCall::ReadFile(req, tx), rx)
+    }
+
+    fn write(&self, path: &std::path::Path, content: &str) -> std::result::Result<(), String> {
+        let (tx, rx) = oneshot::channel();
+        let req = acp::WriteTextFileRequest::new(self.sid.clone(), path.to_path_buf(), content);
+        self.round_trip(ClientCall::WriteFile(req, tx), rx)
+    }
+}
+
 /// Extract the plain-text portion of an ACP prompt (Text blocks joined).
 fn prompt_text(blocks: &[acp::ContentBlock]) -> String {
     blocks
@@ -402,6 +479,30 @@ async fn run() {
                             Err(_) => acp::RequestPermissionOutcome::Cancelled,
                         };
                         let _ = ack.send(outcome);
+                    });
+                }
+                ClientCall::ReadFile(req, ack) => {
+                    // Client-mediated read; spawn so it can't head-of-line-block
+                    // other queued calls (same rationale as Permission).
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn
+                            .read_text_file(req)
+                            .await
+                            .map(|r| r.content)
+                            .map_err(|e| e.to_string());
+                        let _ = ack.send(res);
+                    });
+                }
+                ClientCall::WriteFile(req, ack) => {
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn
+                            .write_text_file(req)
+                            .await
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        let _ = ack.send(res);
                     });
                 }
             }
@@ -520,7 +621,7 @@ mod tests {
     fn next_update(rx: &mut mpsc::UnboundedReceiver<ClientCall>) -> acp::SessionUpdate {
         match rx.try_recv().expect("expected one queued ClientCall") {
             ClientCall::Notify(n) => n.update,
-            ClientCall::Permission(..) => panic!("expected Notify, got Permission"),
+            _ => panic!("expected Notify, got another ClientCall variant"),
         }
     }
 
@@ -573,5 +674,57 @@ mod tests {
             cancel: Cancel::new(),
         };
         assert!(!approver.approve("call_1", "write_file", &serde_json::json!({})));
+    }
+
+    #[test]
+    fn client_fs_read_returns_client_content() {
+        // Scripted client: receive the ReadFile call off-thread and reply with
+        // content, mirroring `approver_with_response` (read() blocks on the ack).
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let responder = std::thread::spawn(move || {
+            if let Some(ClientCall::ReadFile(req, ack)) = rx.blocking_recv() {
+                assert_eq!(req.path, std::path::PathBuf::from("/abs/file.txt"));
+                let _ = ack.send(Ok("hello from client".to_string()));
+            }
+        });
+        let fs = AcpClientFs {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        let got = fs.read(std::path::Path::new("/abs/file.txt"));
+        responder.join().unwrap();
+        assert_eq!(got.unwrap(), "hello from client");
+    }
+
+    #[test]
+    fn client_fs_write_acks_ok() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let responder = std::thread::spawn(move || {
+            if let Some(ClientCall::WriteFile(req, ack)) = rx.blocking_recv() {
+                assert_eq!(req.path, std::path::PathBuf::from("/abs/out.txt"));
+                assert_eq!(req.content, "payload");
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let fs = AcpClientFs {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        let got = fs.write(std::path::Path::new("/abs/out.txt"), "payload");
+        responder.join().unwrap();
+        assert!(got.is_ok());
+    }
+
+    #[test]
+    fn client_fs_read_errors_when_forwarder_gone() {
+        // No receiver → the queued call can't be delivered → surface an error
+        // instead of blocking the tool forever.
+        let (tx, rx) = mpsc::unbounded_channel::<ClientCall>();
+        drop(rx);
+        let fs = AcpClientFs {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        assert!(fs.read(std::path::Path::new("/abs/file.txt")).is_err());
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -32,6 +32,7 @@ use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{
     shell_invocation, FsBackend, ShellExec, ShellResult, ToolContext, ToolOutcome, ToolRegistry,
+    SHELL_POLL_INTERVAL,
 };
 use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
@@ -195,8 +196,10 @@ impl Agent for MonocleAgent {
         let sid = args.session_id.clone();
 
         // Route tool file I/O through the client only when it advertises BOTH fs
-        // read and write; otherwise fall back to local disk (default LocalFs). Read
-        // the caps here (brief borrow) so the blocking closure captures plain data.
+        // read AND write. It's all-or-nothing on purpose: `edit_file`'s read+write
+        // must hit the SAME backend, so we never read from the client but write to
+        // disk (or vice versa), which would produce inconsistent edits. Read the
+        // caps here (brief borrow) so the blocking closure captures plain data.
         let use_client_fs = {
             let caps = self.client_caps.borrow();
             caps.fs.read_text_file && caps.fs.write_text_file
@@ -204,10 +207,11 @@ impl Agent for MonocleAgent {
         // Route the shell tool through the client's terminal when it advertises the
         // `terminal` capability; otherwise run a local subprocess (default LocalShell).
         let use_client_terminal = self.client_caps.borrow().terminal;
-        let fs_calls = self.updates.clone();
-        let fs_sid = args.session_id.clone();
-        let term_calls = self.updates.clone();
-        let term_sid = args.session_id.clone();
+        // Only clone the sender/session id when the cap is actually advertised (the
+        // backend is moved into the blocking closure below); no cap → no clone.
+        let fs_backend = use_client_fs.then(|| (self.updates.clone(), args.session_id.clone()));
+        let term_backend =
+            use_client_terminal.then(|| (self.updates.clone(), args.session_id.clone()));
 
         // Run the SYNC agent-core loop off the async thread; stream updates back,
         // and route side-effecting tool permission to the client (the editor
@@ -233,16 +237,18 @@ impl Agent for MonocleAgent {
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
             let mut ctx = ToolContext::new(cwd).with_cancel(cancel.clone());
-            if use_client_fs {
+            if let Some((calls, sid)) = fs_backend {
                 ctx = ctx.with_fs(Arc::new(AcpClientFs {
-                    calls: fs_calls,
-                    sid: fs_sid,
+                    calls,
+                    sid,
+                    cancel: cancel.clone(),
                 }));
             }
-            if use_client_terminal {
+            if let Some((calls, sid)) = term_backend {
                 ctx = ctx.with_shell(Arc::new(AcpClientShell {
-                    calls: term_calls,
-                    sid: term_sid,
+                    calls,
+                    sid,
+                    cancel: cancel.clone(),
                 }));
             }
             let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
@@ -407,49 +413,88 @@ impl Approver for AcpApprover {
     }
 }
 
+/// Queue a [`ClientCall`] and block for its ack, but poll so a cancel can break
+/// the wait — the shared body behind `AcpClientFs`/`AcpClientShell`'s round trips
+/// (dedup). Without this, a connected-but-silent client that never answers an
+/// `fs/*` or `terminal/*` call would park this `spawn_blocking` thread forever:
+/// `session/cancel` (only checked at step boundaries) and disconnect-shutdown
+/// couldn't free it and the session's `running` guard would stay set. Mirrors
+/// `AcpApprover::approve`'s cancel-aware poll — `try_recv` + 20ms sleep instead of
+/// `blocking_recv` (the sleep is fine on a blocking-pool thread). Send/recv
+/// failure (forwarding task or connection gone) collapses to `unavailable`; a
+/// cancel while waiting yields `"<op> cancelled"`.
+fn client_round_trip<T>(
+    calls: &mpsc::UnboundedSender<ClientCall>,
+    call: ClientCall,
+    mut rx: oneshot::Receiver<std::result::Result<T, String>>,
+    cancel: &Cancel,
+    op: &str,
+    unavailable: &str,
+) -> std::result::Result<T, String> {
+    if calls.send(call).is_err() {
+        return Err(unavailable.to_string());
+    }
+    loop {
+        match rx.try_recv() {
+            Ok(res) => return res,
+            Err(oneshot::error::TryRecvError::Empty) => {
+                if cancel.is_cancelled() {
+                    return Err(format!("{op} cancelled"));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(oneshot::error::TryRecvError::Closed) => return Err(unavailable.to_string()),
+        }
+    }
+}
+
 /// Client-mediated [`FsBackend`]: the read/write/edit tools' file I/O is routed
 /// through the ACP client (`fs/read_text_file`, `fs/write_text_file`) instead of
 /// local disk, so the editor can serve unsaved buffers and track changes. Wired
 /// in only when the client advertises both fs capabilities (see `prompt()`).
 ///
 /// These methods run on the loop's `spawn_blocking` thread, so they block on the
-/// paired oneshot; the async forwarding task (owning the connection) performs the
-/// actual RPC. Paths passed in are already absolute (`ToolContext::resolve`).
+/// paired oneshot (cancel-aware, via `client_round_trip`); the async forwarding
+/// task (owning the connection) performs the actual RPC. Paths passed in are
+/// already absolute (`ToolContext::resolve`).
+///
+/// NOTE (TOCTOU): `edit_file` reads, modifies, then writes back through this same
+/// client backend. Because ACP `fs/write_text_file` carries no version/etag guard,
+/// a user edit in the editor between our read and write is silently clobbered
+/// (last-writer-wins). Acceptable for the agent's own edits; a known limitation.
 struct AcpClientFs {
     calls: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
-}
-
-impl AcpClientFs {
-    /// Send a queued call and block for its ack. Any send/recv failure (the
-    /// forwarding task or connection is gone) collapses to a single unavailable
-    /// message the tool surfaces as an error.
-    fn round_trip<T>(
-        &self,
-        call: ClientCall,
-        rx: oneshot::Receiver<std::result::Result<T, String>>,
-    ) -> std::result::Result<T, String> {
-        if self.calls.send(call).is_err() {
-            return Err("acp client fs unavailable".to_string());
-        }
-        match rx.blocking_recv() {
-            Ok(res) => res,
-            Err(_) => Err("acp client fs unavailable".to_string()),
-        }
-    }
+    /// The turn's cancel flag, so a never-answered fs call breaks (errors) on
+    /// cancel instead of hanging this blocking thread (see `client_round_trip`).
+    cancel: Cancel,
 }
 
 impl FsBackend for AcpClientFs {
     fn read(&self, path: &std::path::Path) -> std::result::Result<String, String> {
         let (tx, rx) = oneshot::channel();
         let req = acp::ReadTextFileRequest::new(self.sid.clone(), path.to_path_buf());
-        self.round_trip(ClientCall::ReadFile(req, tx), rx)
+        client_round_trip(
+            &self.calls,
+            ClientCall::ReadFile(req, tx),
+            rx,
+            &self.cancel,
+            "fs read",
+            "acp client fs unavailable",
+        )
     }
 
     fn write(&self, path: &std::path::Path, content: &str) -> std::result::Result<(), String> {
         let (tx, rx) = oneshot::channel();
         let req = acp::WriteTextFileRequest::new(self.sid.clone(), path.to_path_buf(), content);
-        self.round_trip(ClientCall::WriteFile(req, tx), rx)
+        client_round_trip(
+            &self.calls,
+            ClientCall::WriteFile(req, tx),
+            rx,
+            &self.cancel,
+            "fs write",
+            "acp client fs unavailable",
+        )
     }
 }
 
@@ -465,27 +510,29 @@ impl FsBackend for AcpClientFs {
 struct AcpClientShell {
     calls: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
+    /// The turn's cancel flag, so a never-answered terminal call breaks (errors)
+    /// on cancel instead of hanging this blocking thread — so `create`/`kill`/
+    /// `release` can't wedge the session past a cancel (see `client_round_trip`).
+    cancel: Cancel,
 }
 
-/// How often to poll `terminal/output` while the command runs.
-const TERMINAL_POLL: std::time::Duration = std::time::Duration::from_millis(150);
-
 impl AcpClientShell {
-    /// Send a queued call and block for its ack (mirrors `AcpClientFs::round_trip`).
-    /// Any send/recv failure (forwarding task or connection gone) collapses to a
-    /// single unavailable message.
+    /// Send a queued call and block (cancel-aware) for its ack, delegating to the
+    /// shared [`client_round_trip`]. `op` names the operation for the cancel error.
     fn round_trip<T>(
         &self,
+        op: &str,
         call: ClientCall,
         rx: oneshot::Receiver<std::result::Result<T, String>>,
     ) -> std::result::Result<T, String> {
-        if self.calls.send(call).is_err() {
-            return Err("acp client terminal unavailable".to_string());
-        }
-        match rx.blocking_recv() {
-            Ok(res) => res,
-            Err(_) => Err("acp client terminal unavailable".to_string()),
-        }
+        client_round_trip(
+            &self.calls,
+            call,
+            rx,
+            &self.cancel,
+            op,
+            "acp client terminal unavailable",
+        )
     }
 
     fn create(
@@ -494,12 +541,18 @@ impl AcpClientShell {
         cwd: &std::path::Path,
     ) -> std::result::Result<acp::TerminalId, String> {
         let (program, args) = shell_invocation(command);
+        // Forward the agent's environment so the client terminal runs with the same
+        // env as a local subprocess (which inherits it) — parity with LocalShell.
+        let env: Vec<acp::EnvVariable> = std::env::vars()
+            .map(|(name, value)| acp::EnvVariable::new(name, value))
+            .collect();
         let req = acp::CreateTerminalRequest::new(self.sid.clone(), program)
             .args(args)
+            .env(env)
             .cwd(cwd.to_path_buf())
             .output_byte_limit(MAX_TERMINAL_BYTES);
         let (tx, rx) = oneshot::channel();
-        self.round_trip(ClientCall::CreateTerminal(req, tx), rx)
+        self.round_trip("terminal create", ClientCall::CreateTerminal(req, tx), rx)
     }
 
     fn output(
@@ -508,19 +561,19 @@ impl AcpClientShell {
     ) -> std::result::Result<acp::TerminalOutputResponse, String> {
         let req = acp::TerminalOutputRequest::new(self.sid.clone(), terminal_id.clone());
         let (tx, rx) = oneshot::channel();
-        self.round_trip(ClientCall::TerminalOutput(req, tx), rx)
+        self.round_trip("terminal output", ClientCall::TerminalOutput(req, tx), rx)
     }
 
     fn kill(&self, terminal_id: &acp::TerminalId) -> std::result::Result<(), String> {
         let req = acp::KillTerminalCommandRequest::new(self.sid.clone(), terminal_id.clone());
         let (tx, rx) = oneshot::channel();
-        self.round_trip(ClientCall::KillTerminal(req, tx), rx)
+        self.round_trip("terminal kill", ClientCall::KillTerminal(req, tx), rx)
     }
 
     fn release(&self, terminal_id: &acp::TerminalId) -> std::result::Result<(), String> {
         let req = acp::ReleaseTerminalRequest::new(self.sid.clone(), terminal_id.clone());
         let (tx, rx) = oneshot::channel();
-        self.round_trip(ClientCall::ReleaseTerminal(req, tx), rx)
+        self.round_trip("terminal release", ClientCall::ReleaseTerminal(req, tx), rx)
     }
 }
 
@@ -586,7 +639,9 @@ impl AcpClientShell {
                             cancelled: true,
                         };
                     }
-                    std::thread::sleep(TERMINAL_POLL);
+                    // Match the local subprocess poll cadence so client-mediated
+                    // shell isn't slower to detect exit/cancel (shared const).
+                    std::thread::sleep(SHELL_POLL_INTERVAL);
                 }
                 Err(e) => {
                     return ShellResult {
@@ -908,6 +963,7 @@ mod tests {
         let fs = AcpClientFs {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         let got = fs.read(std::path::Path::new("/abs/file.txt"));
         responder.join().unwrap();
@@ -927,6 +983,7 @@ mod tests {
         let fs = AcpClientFs {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         let got = fs.write(std::path::Path::new("/abs/out.txt"), "payload");
         responder.join().unwrap();
@@ -942,8 +999,27 @@ mod tests {
         let fs = AcpClientFs {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         assert!(fs.read(std::path::Path::new("/abs/file.txt")).is_err());
+    }
+
+    #[test]
+    fn client_fs_read_returns_err_without_hanging_when_cancelled_and_no_answer() {
+        // The client is connected but never answers the read (rx kept, never
+        // drained), yet the turn is cancelled — read() must break the wait and
+        // error, not park this thread forever (mirrors the approver's behavior).
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let cancel = Cancel::new();
+        cancel.cancel();
+        let fs = AcpClientFs {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+            cancel,
+        };
+        let start = std::time::Instant::now();
+        assert!(fs.read(std::path::Path::new("/abs/file.txt")).is_err());
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     #[test]
@@ -976,6 +1052,7 @@ mod tests {
         let shell = AcpClientShell {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         let r = shell.exec("echo hi", std::path::Path::new("/work"), &Cancel::new());
         responder.join().unwrap();
@@ -1024,6 +1101,7 @@ mod tests {
         let shell = AcpClientShell {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: cancel.clone(),
         };
         let start = std::time::Instant::now();
         let r = shell.exec("sleep 5", std::path::Path::new("/work"), &cancel);
@@ -1049,10 +1127,32 @@ mod tests {
         let shell = AcpClientShell {
             calls: tx,
             sid: acp::SessionId::new("s"),
+            cancel: Cancel::new(),
         };
         let r = shell.exec("echo hi", std::path::Path::new("/work"), &Cancel::new());
         assert!(!r.cancelled);
         assert_eq!(r.exit_code, None);
         assert!(r.output.contains("unavailable"), "{}", r.output);
+    }
+
+    #[test]
+    fn client_shell_round_trip_returns_err_without_hanging_when_cancelled_and_no_answer() {
+        // The client is connected but never answers (rx kept, never drained), yet
+        // the turn is cancelled — an individual round_trip (create) must break the
+        // wait and error rather than parking this thread forever, so create/kill/
+        // release can't wedge the session past a cancel.
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let cancel = Cancel::new();
+        cancel.cancel();
+        let shell = AcpClientShell {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+            cancel,
+        };
+        let start = std::time::Instant::now();
+        assert!(shell
+            .create("echo hi", std::path::Path::new("/work"))
+            .is_err());
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -11,10 +11,12 @@
 //!
 //! Scope: initialize / new_session / prompt / cancel; tool file I/O is routed
 //! through the client when it advertises `fs` capabilities (editor-mediated
-//! read/write), else runs on local disk; tool permission is delegated to the
-//! client via `session/request_permission`; tool calls stream as correlated
-//! `ToolCall`/`ToolCallUpdate` lifecycle updates. Follow-ups: client terminal
-//! callbacks.
+//! read/write), else runs on local disk; the shell tool runs through the client's
+//! terminal (`terminal/create` → poll `terminal/output` → `terminal/kill` on
+//! cancel → `terminal/release`) when it advertises the `terminal` capability, else
+//! runs a local subprocess; tool permission is delegated to the client via
+//! `session/request_permission`; tool calls stream as correlated
+//! `ToolCall`/`ToolCallUpdate` lifecycle updates.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -28,7 +30,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
-use crate::agent::tools::{FsBackend, ToolContext, ToolOutcome, ToolRegistry};
+use crate::agent::tools::{
+    shell_invocation, FsBackend, ShellExec, ShellResult, ToolContext, ToolOutcome, ToolRegistry,
+};
 use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
 use crate::credentials::Credentials;
@@ -56,6 +60,22 @@ enum ClientCall {
     ),
     WriteFile(
         acp::WriteTextFileRequest,
+        oneshot::Sender<std::result::Result<(), String>>,
+    ),
+    CreateTerminal(
+        acp::CreateTerminalRequest,
+        oneshot::Sender<std::result::Result<acp::TerminalId, String>>,
+    ),
+    TerminalOutput(
+        acp::TerminalOutputRequest,
+        oneshot::Sender<std::result::Result<acp::TerminalOutputResponse, String>>,
+    ),
+    KillTerminal(
+        acp::KillTerminalCommandRequest,
+        oneshot::Sender<std::result::Result<(), String>>,
+    ),
+    ReleaseTerminal(
+        acp::ReleaseTerminalRequest,
         oneshot::Sender<std::result::Result<(), String>>,
     ),
 }
@@ -181,8 +201,13 @@ impl Agent for MonocleAgent {
             let caps = self.client_caps.borrow();
             caps.fs.read_text_file && caps.fs.write_text_file
         };
+        // Route the shell tool through the client's terminal when it advertises the
+        // `terminal` capability; otherwise run a local subprocess (default LocalShell).
+        let use_client_terminal = self.client_caps.borrow().terminal;
         let fs_calls = self.updates.clone();
         let fs_sid = args.session_id.clone();
+        let term_calls = self.updates.clone();
+        let term_sid = args.session_id.clone();
 
         // Run the SYNC agent-core loop off the async thread; stream updates back,
         // and route side-effecting tool permission to the client (the editor
@@ -212,6 +237,12 @@ impl Agent for MonocleAgent {
                 ctx = ctx.with_fs(Arc::new(AcpClientFs {
                     calls: fs_calls,
                     sid: fs_sid,
+                }));
+            }
+            if use_client_terminal {
+                ctx = ctx.with_shell(Arc::new(AcpClientShell {
+                    calls: term_calls,
+                    sid: term_sid,
                 }));
             }
             let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
@@ -422,6 +453,153 @@ impl FsBackend for AcpClientFs {
     }
 }
 
+/// Client-mediated [`ShellExec`]: the shell tool runs THROUGH the ACP client's
+/// terminal (`terminal/create` → poll `terminal/output` → `terminal/kill` on
+/// cancel → `terminal/release`) instead of a local subprocess, so the editor owns
+/// and mediates the terminal. Wired in only when the client advertises the
+/// `terminal` capability (see `prompt()`).
+///
+/// Like [`AcpClientFs`], `exec` runs on the loop's `spawn_blocking` thread and
+/// blocks on paired oneshots; the async forwarding task (owning the connection)
+/// performs the actual RPCs. The `cwd` passed in is already absolute.
+struct AcpClientShell {
+    calls: mpsc::UnboundedSender<ClientCall>,
+    sid: acp::SessionId,
+}
+
+/// How often to poll `terminal/output` while the command runs.
+const TERMINAL_POLL: std::time::Duration = std::time::Duration::from_millis(150);
+
+impl AcpClientShell {
+    /// Send a queued call and block for its ack (mirrors `AcpClientFs::round_trip`).
+    /// Any send/recv failure (forwarding task or connection gone) collapses to a
+    /// single unavailable message.
+    fn round_trip<T>(
+        &self,
+        call: ClientCall,
+        rx: oneshot::Receiver<std::result::Result<T, String>>,
+    ) -> std::result::Result<T, String> {
+        if self.calls.send(call).is_err() {
+            return Err("acp client terminal unavailable".to_string());
+        }
+        match rx.blocking_recv() {
+            Ok(res) => res,
+            Err(_) => Err("acp client terminal unavailable".to_string()),
+        }
+    }
+
+    fn create(
+        &self,
+        command: &str,
+        cwd: &std::path::Path,
+    ) -> std::result::Result<acp::TerminalId, String> {
+        let (program, args) = shell_invocation(command);
+        let req = acp::CreateTerminalRequest::new(self.sid.clone(), program)
+            .args(args)
+            .cwd(cwd.to_path_buf())
+            .output_byte_limit(MAX_TERMINAL_BYTES);
+        let (tx, rx) = oneshot::channel();
+        self.round_trip(ClientCall::CreateTerminal(req, tx), rx)
+    }
+
+    fn output(
+        &self,
+        terminal_id: &acp::TerminalId,
+    ) -> std::result::Result<acp::TerminalOutputResponse, String> {
+        let req = acp::TerminalOutputRequest::new(self.sid.clone(), terminal_id.clone());
+        let (tx, rx) = oneshot::channel();
+        self.round_trip(ClientCall::TerminalOutput(req, tx), rx)
+    }
+
+    fn kill(&self, terminal_id: &acp::TerminalId) -> std::result::Result<(), String> {
+        let req = acp::KillTerminalCommandRequest::new(self.sid.clone(), terminal_id.clone());
+        let (tx, rx) = oneshot::channel();
+        self.round_trip(ClientCall::KillTerminal(req, tx), rx)
+    }
+
+    fn release(&self, terminal_id: &acp::TerminalId) -> std::result::Result<(), String> {
+        let req = acp::ReleaseTerminalRequest::new(self.sid.clone(), terminal_id.clone());
+        let (tx, rx) = oneshot::channel();
+        self.round_trip(ClientCall::ReleaseTerminal(req, tx), rx)
+    }
+}
+
+/// Byte cap requested from the client's terminal (the client truncates from the
+/// front). The shell tool caps again for the LLM channel; this just bounds what
+/// the client retains.
+const MAX_TERMINAL_BYTES: u64 = 1_000_000;
+
+impl ShellExec for AcpClientShell {
+    fn exec(&self, command: &str, cwd: &std::path::Path, cancel: &Cancel) -> ShellResult {
+        // Honor a cancel that landed before we created the terminal.
+        if cancel.is_cancelled() {
+            return ShellResult {
+                output: String::new(),
+                exit_code: None,
+                cancelled: true,
+            };
+        }
+
+        let terminal_id = match self.create(command, cwd) {
+            Ok(id) => id,
+            Err(e) => {
+                return ShellResult {
+                    output: e,
+                    exit_code: None,
+                    cancelled: false,
+                }
+            }
+        };
+
+        // Poll the client's terminal until it exits, we're cancelled, or the RPC
+        // fails. Always release the terminal afterwards (best-effort).
+        let result = self.poll(&terminal_id, cancel);
+        let _ = self.release(&terminal_id);
+        result
+    }
+}
+
+impl AcpClientShell {
+    /// Poll `terminal/output` until exit / cancel / RPC failure, returning the
+    /// accumulated [`ShellResult`] (release is the caller's job).
+    fn poll(&self, terminal_id: &acp::TerminalId, cancel: &Cancel) -> ShellResult {
+        loop {
+            match self.output(terminal_id) {
+                Ok(resp) => {
+                    if let Some(status) = resp.exit_status {
+                        return ShellResult {
+                            output: resp.output,
+                            exit_code: status.exit_code.map(|c| c as i32),
+                            cancelled: false,
+                        };
+                    }
+                    if cancel.is_cancelled() {
+                        // Kill, then grab whatever partial output the client has.
+                        let _ = self.kill(terminal_id);
+                        let output = self
+                            .output(terminal_id)
+                            .map(|r| r.output)
+                            .unwrap_or(resp.output);
+                        return ShellResult {
+                            output,
+                            exit_code: None,
+                            cancelled: true,
+                        };
+                    }
+                    std::thread::sleep(TERMINAL_POLL);
+                }
+                Err(e) => {
+                    return ShellResult {
+                        output: e,
+                        exit_code: None,
+                        cancelled: false,
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Extract the plain-text portion of an ACP prompt (Text blocks joined).
 fn prompt_text(blocks: &[acp::ContentBlock]) -> String {
     blocks
@@ -499,6 +677,46 @@ async fn run() {
                     tokio::task::spawn_local(async move {
                         let res = conn
                             .write_text_file(req)
+                            .await
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        let _ = ack.send(res);
+                    });
+                }
+                ClientCall::CreateTerminal(req, ack) => {
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn
+                            .create_terminal(req)
+                            .await
+                            .map(|r| r.terminal_id)
+                            .map_err(|e| e.to_string());
+                        let _ = ack.send(res);
+                    });
+                }
+                ClientCall::TerminalOutput(req, ack) => {
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn.terminal_output(req).await.map_err(|e| e.to_string());
+                        let _ = ack.send(res);
+                    });
+                }
+                ClientCall::KillTerminal(req, ack) => {
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn
+                            .kill_terminal_command(req)
+                            .await
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        let _ = ack.send(res);
+                    });
+                }
+                ClientCall::ReleaseTerminal(req, ack) => {
+                    let conn = std::rc::Rc::clone(&conn);
+                    tokio::task::spawn_local(async move {
+                        let res = conn
+                            .release_terminal(req)
                             .await
                             .map(|_| ())
                             .map_err(|e| e.to_string());
@@ -726,5 +944,115 @@ mod tests {
             sid: acp::SessionId::new("s"),
         };
         assert!(fs.read(std::path::Path::new("/abs/file.txt")).is_err());
+    }
+
+    #[test]
+    fn client_shell_happy_path_returns_output_and_exit() {
+        // Scripted client: create → terminal id, first output → exited with code 0
+        // and "hi", release → ok. Mirrors the fs responder style (exec blocks on
+        // each ack from its spawn_blocking thread).
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let responder = std::thread::spawn(move || {
+            while let Some(call) = rx.blocking_recv() {
+                match call {
+                    ClientCall::CreateTerminal(req, ack) => {
+                        // The shell wrapping flows through as command + args.
+                        assert_eq!(req.cwd, Some(std::path::PathBuf::from("/work")));
+                        let _ = ack.send(Ok(acp::TerminalId::new("t1")));
+                    }
+                    ClientCall::TerminalOutput(_req, ack) => {
+                        let resp = acp::TerminalOutputResponse::new("hi", false)
+                            .exit_status(acp::TerminalExitStatus::new().exit_code(0u32));
+                        let _ = ack.send(Ok(resp));
+                    }
+                    ClientCall::ReleaseTerminal(_req, ack) => {
+                        let _ = ack.send(Ok(()));
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+        let shell = AcpClientShell {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        let r = shell.exec("echo hi", std::path::Path::new("/work"), &Cancel::new());
+        responder.join().unwrap();
+        assert_eq!(r.output, "hi");
+        assert_eq!(r.exit_code, Some(0));
+        assert!(!r.cancelled);
+    }
+
+    #[test]
+    fn client_shell_cancel_kills_terminal() {
+        // The command never exits (output always exit_status=None); the turn is
+        // cancelled shortly after start → exec must kill the terminal and return
+        // cancelled=true promptly.
+        use std::sync::atomic::AtomicBool;
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let killed = std::sync::Arc::new(AtomicBool::new(false));
+        let killed2 = std::sync::Arc::clone(&killed);
+        let responder = std::thread::spawn(move || {
+            while let Some(call) = rx.blocking_recv() {
+                match call {
+                    ClientCall::CreateTerminal(_req, ack) => {
+                        let _ = ack.send(Ok(acp::TerminalId::new("t1")));
+                    }
+                    ClientCall::TerminalOutput(_req, ack) => {
+                        // Still running: no exit status.
+                        let _ = ack.send(Ok(acp::TerminalOutputResponse::new("partial", false)));
+                    }
+                    ClientCall::KillTerminal(_req, ack) => {
+                        killed2.store(true, Ordering::SeqCst);
+                        let _ = ack.send(Ok(()));
+                    }
+                    ClientCall::ReleaseTerminal(_req, ack) => {
+                        let _ = ack.send(Ok(()));
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+        let cancel = Cancel::new();
+        let flip = cancel.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            flip.cancel();
+        });
+        let shell = AcpClientShell {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        let start = std::time::Instant::now();
+        let r = shell.exec("sleep 5", std::path::Path::new("/work"), &cancel);
+        responder.join().unwrap();
+        assert!(r.cancelled, "should report cancelled");
+        assert!(
+            killed.load(Ordering::SeqCst),
+            "a KillTerminal must have been requested"
+        );
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "cancel should be prompt, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn client_shell_errors_when_forwarder_gone() {
+        // No receiver → create_terminal can't be delivered → surface an error as
+        // output instead of blocking the tool forever.
+        let (tx, rx) = mpsc::unbounded_channel::<ClientCall>();
+        drop(rx);
+        let shell = AcpClientShell {
+            calls: tx,
+            sid: acp::SessionId::new("s"),
+        };
+        let r = shell.exec("echo hi", std::path::Path::new("/work"), &Cancel::new());
+        assert!(!r.cancelled);
+        assert_eq!(r.exit_code, None);
+        assert!(r.output.contains("unavailable"), "{}", r.output);
     }
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -47,6 +47,159 @@ impl FsBackend for LocalFs {
     }
 }
 
+/// Outcome of running a shell command through a [`ShellExec`] backend: combined
+/// stdout+stderr (`output`), the process exit code (`None` if killed / no code),
+/// and whether the run was cut short by a cancel. The shell tool formats this into
+/// a [`ToolOutcome`] (cap + `[exit code: N]` / `exit N` / cancelled → error).
+pub struct ShellResult {
+    pub output: String,
+    pub exit_code: Option<i32>,
+    pub cancelled: bool,
+}
+
+/// Executes a shell command for the shell tool. The default ([`LocalShell`])
+/// spawns a local subprocess (today's behavior); under ACP, when the client
+/// advertises the `terminal` capability, an editor-mediated backend is injected
+/// instead so the client owns/mediates the terminal (see `acp::AcpClientShell`).
+pub trait ShellExec: Send + Sync {
+    /// Run `command` (the raw shell command string the tool received) in `cwd`,
+    /// honoring `cancel` (both before starting and mid-run).
+    fn exec(&self, command: &str, cwd: &Path, cancel: &Cancel) -> ShellResult;
+}
+
+/// The platform shell invocation for a raw command string: `(program, args)`.
+/// `bash -c <cmd>` on unix, `powershell … -Command <cmd>` on Windows. Shared by
+/// both the local subprocess backend and the ACP client-terminal backend so the
+/// shell wrapping is defined once.
+pub fn shell_invocation(command: &str) -> (String, Vec<String>) {
+    #[cfg(windows)]
+    {
+        (
+            "powershell".to_string(),
+            vec![
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-Command".to_string(),
+                command.to_string(),
+            ],
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        (
+            "bash".to_string(),
+            vec!["-c".to_string(), command.to_string()],
+        )
+    }
+}
+
+/// Default backend: run the command as a local subprocess (today's behavior).
+pub struct LocalShell;
+
+impl ShellExec for LocalShell {
+    fn exec(&self, command: &str, cwd: &Path, cancel: &Cancel) -> ShellResult {
+        // Honor a cancel that landed before we even spawned — don't start work.
+        if cancel.is_cancelled() {
+            return ShellResult {
+                output: String::new(),
+                exit_code: None,
+                cancelled: true,
+            };
+        }
+
+        let (program, args) = shell_invocation(command);
+        let mut cmd = Command::new(program);
+        cmd.args(&args)
+            .current_dir(cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ShellResult {
+                    output: format!("failed to run shell: {e}"),
+                    exit_code: None,
+                    cancelled: false,
+                }
+            }
+        };
+
+        // Drain stdout/stderr on their own threads so a chatty long-running command
+        // can't deadlock the poll loop by filling a pipe buffer.
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+        let drain = |pipe: Option<std::process::ChildStdout>| {
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                if let Some(mut p) = pipe {
+                    let _ = p.read_to_end(&mut buf);
+                }
+                buf
+            })
+        };
+        let drain_err = |pipe: Option<std::process::ChildStderr>| {
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                if let Some(mut p) = pipe {
+                    let _ = p.read_to_end(&mut buf);
+                }
+                buf
+            })
+        };
+        let out_handle = drain(stdout_pipe);
+        let err_handle = drain_err(stderr_pipe);
+
+        // Poll: exit → done; cancel → kill+reap; else nap and re-check.
+        let mut cancelled = false;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Some(status),
+                Ok(None) => {
+                    if cancel.is_cancelled() {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        cancelled = true;
+                        break None;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => {
+                    let _ = child.wait();
+                    return ShellResult {
+                        output: format!("failed to wait on shell: {e}"),
+                        exit_code: None,
+                        cancelled: false,
+                    };
+                }
+            }
+        };
+
+        // Reader threads finish once the pipes close (on exit or kill).
+        let stdout = out_handle.join().unwrap_or_default();
+        let stderr = err_handle.join().unwrap_or_default();
+        let stdout = String::from_utf8_lossy(&stdout);
+        let stderr = String::from_utf8_lossy(&stderr);
+        let mut combined = String::new();
+        if !stdout.is_empty() {
+            combined.push_str(&stdout);
+        }
+        if !stderr.is_empty() {
+            if !combined.is_empty() && !combined.ends_with('\n') {
+                combined.push('\n');
+            }
+            combined.push_str(&stderr);
+        }
+
+        ShellResult {
+            output: combined,
+            exit_code: status.and_then(|s| s.code()),
+            cancelled,
+        }
+    }
+}
+
 /// Execution context shared by all tools (the working directory the agent acts in,
 /// plus the turn's [`Cancel`] flag so long-running tools can be interrupted mid-run).
 pub struct ToolContext {
@@ -60,6 +213,10 @@ pub struct ToolContext {
     /// (local disk) so every existing caller/test is unaffected; the ACP surface
     /// swaps in a client-mediated backend via [`ToolContext::with_fs`].
     pub fs: Arc<dyn FsBackend>,
+    /// Shell backend for the shell tool. Defaults to [`LocalShell`] (local
+    /// subprocess) so every existing caller/test is unaffected; the ACP surface
+    /// swaps in a client-terminal backend via [`ToolContext::with_shell`].
+    pub shell: Arc<dyn ShellExec>,
 }
 
 impl ToolContext {
@@ -68,6 +225,7 @@ impl ToolContext {
             workdir: workdir.into(),
             cancel: Cancel::new(),
             fs: Arc::new(LocalFs),
+            shell: Arc::new(LocalShell),
         }
     }
 
@@ -82,6 +240,13 @@ impl ToolContext {
     /// (e.g. an ACP client-mediated one) instead of the default local disk.
     pub fn with_fs(mut self, fs: Arc<dyn FsBackend>) -> Self {
         self.fs = fs;
+        self
+    }
+
+    /// Route the shell tool through a custom shell backend (e.g. an ACP
+    /// client-mediated terminal) instead of the default local subprocess.
+    pub fn with_shell(mut self, shell: Arc<dyn ShellExec>) -> Self {
+        self.shell = shell;
         self
     }
 
@@ -354,98 +519,14 @@ impl Tool for Shell {
             Err(e) => return e,
         };
 
-        // Honor a cancel that landed before we even spawned — don't start work.
-        if ctx.cancel.is_cancelled() {
-            return ToolOutcome::error("shell command cancelled before it started");
-        }
+        // Run through the context's shell backend (local subprocess by default,
+        // ACP client terminal when the client advertises `terminal`).
+        let result = ctx.shell.exec(command, &ctx.workdir, &ctx.cancel);
 
-        #[cfg(windows)]
-        let mut cmd = {
-            let mut c = Command::new("powershell");
-            c.args(["-NoProfile", "-NonInteractive", "-Command", command]);
-            c
-        };
-        #[cfg(not(windows))]
-        let mut cmd = {
-            let mut c = Command::new("bash");
-            c.arg("-c").arg(command);
-            c
-        };
-        cmd.current_dir(&ctx.workdir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => return ToolOutcome::error(format!("failed to run shell: {e}")),
-        };
-
-        // Drain stdout/stderr on their own threads so a chatty long-running command
-        // can't deadlock the poll loop by filling a pipe buffer.
-        let stdout_pipe = child.stdout.take();
-        let stderr_pipe = child.stderr.take();
-        let drain = |pipe: Option<std::process::ChildStdout>| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                if let Some(mut p) = pipe {
-                    let _ = p.read_to_end(&mut buf);
-                }
-                buf
-            })
-        };
-        let drain_err = |pipe: Option<std::process::ChildStderr>| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                if let Some(mut p) = pipe {
-                    let _ = p.read_to_end(&mut buf);
-                }
-                buf
-            })
-        };
-        let out_handle = drain(stdout_pipe);
-        let err_handle = drain_err(stderr_pipe);
-
-        // Poll: exit → done; cancel → kill+reap; else nap and re-check.
-        let mut cancelled = false;
-        let status = loop {
-            match child.try_wait() {
-                Ok(Some(status)) => break Some(status),
-                Ok(None) => {
-                    if ctx.cancel.is_cancelled() {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        cancelled = true;
-                        break None;
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-                Err(e) => {
-                    let _ = child.wait();
-                    return ToolOutcome::error(format!("failed to wait on shell: {e}"));
-                }
-            }
-        };
-
-        // Reader threads finish once the pipes close (on exit or kill).
-        let stdout = out_handle.join().unwrap_or_default();
-        let stderr = err_handle.join().unwrap_or_default();
-        let stdout = String::from_utf8_lossy(&stdout);
-        let stderr = String::from_utf8_lossy(&stderr);
-        let mut combined = String::new();
-        if !stdout.is_empty() {
-            combined.push_str(&stdout);
-        }
-        if !stderr.is_empty() {
-            if !combined.is_empty() && !combined.ends_with('\n') {
-                combined.push('\n');
-            }
-            combined.push_str(&stderr);
-        }
         // Cap the LLM-facing output (re-sent every turn — §9a).
-        let capped = cap_output(&combined, MAX_SHELL_CHARS);
+        let capped = cap_output(&result.output, MAX_SHELL_CHARS);
 
-        if cancelled {
+        if result.cancelled {
             let partial = if capped.is_empty() {
                 String::new()
             } else {
@@ -455,8 +536,8 @@ impl Tool for Shell {
                 .with_ui("cancelled".to_string());
         }
 
-        let code = status.and_then(|s| s.code()).unwrap_or(-1);
-        let success = status.map(|s| s.success()).unwrap_or(false);
+        let code = result.exit_code.unwrap_or(-1);
+        let success = result.exit_code == Some(0);
         let llm = format!("{capped}\n[exit code: {code}]");
         ToolOutcome {
             llm,
@@ -540,5 +621,66 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nope.txt");
         assert!(LocalFs.read(&path).is_err());
+    }
+
+    #[test]
+    fn shell_invocation_wraps_the_command() {
+        let (program, args) = shell_invocation("echo hi");
+        #[cfg(windows)]
+        {
+            assert_eq!(program, "powershell");
+            assert_eq!(args.last().unwrap(), "echo hi");
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(program, "bash");
+            assert_eq!(args, vec!["-c".to_string(), "echo hi".to_string()]);
+        }
+    }
+
+    #[test]
+    fn localshell_runs_command_and_reports_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(windows)]
+        let cmd = "Write-Output hi";
+        #[cfg(not(windows))]
+        let cmd = "echo hi";
+        let r = LocalShell.exec(cmd, dir.path(), &Cancel::new());
+        assert!(r.output.contains("hi"), "{}", r.output);
+        assert_eq!(r.exit_code, Some(0));
+        assert!(!r.cancelled);
+    }
+
+    #[test]
+    fn localshell_honors_cancel_set_before_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = Cancel::new();
+        cancel.cancel();
+        // A pre-set cancel returns immediately without spawning the 5s command.
+        let start = std::time::Instant::now();
+        #[cfg(windows)]
+        let cmd = "Start-Sleep -Seconds 5";
+        #[cfg(not(windows))]
+        let cmd = "sleep 5";
+        let r = LocalShell.exec(cmd, dir.path(), &cancel);
+        assert!(r.cancelled);
+        assert!(r.output.is_empty(), "{}", r.output);
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn localshell_is_killed_mid_run_on_cancel() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = Cancel::new();
+        let flip = cancel.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            flip.cancel();
+        });
+        let start = std::time::Instant::now();
+        let r = LocalShell.exec("sleep 5", dir.path(), &cancel);
+        assert!(r.cancelled);
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
     }
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -8,14 +8,44 @@
 //! tool context's working directory.
 
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::{json, Value};
 
 use crate::agent::providers::ToolDef;
 use crate::agent::runner::Cancel;
+
+/// Filesystem backend for the read/write/edit tools. The default ([`LocalFs`])
+/// is plain local disk I/O; under ACP, when the client advertises fs
+/// capabilities, an editor-mediated backend is injected instead so unsaved
+/// buffers and change-tracking flow through the client (see `acp::AcpClientFs`).
+/// Errors are already-human-readable messages the tool drops into
+/// [`ToolOutcome::error`].
+pub trait FsBackend: Send + Sync {
+    fn read(&self, path: &Path) -> std::result::Result<String, String>;
+    fn write(&self, path: &Path, content: &str) -> std::result::Result<(), String>;
+}
+
+/// Default backend: read/write straight to local disk (today's behavior).
+pub struct LocalFs;
+
+impl FsBackend for LocalFs {
+    fn read(&self, path: &Path) -> std::result::Result<String, String> {
+        std::fs::read_to_string(path).map_err(|e| e.to_string())
+    }
+
+    fn write(&self, path: &Path, content: &str) -> std::result::Result<(), String> {
+        // Create parent directories as needed (moved here from the write_file tool).
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+        }
+        std::fs::write(path, content).map_err(|e| e.to_string())
+    }
+}
 
 /// Execution context shared by all tools (the working directory the agent acts in,
 /// plus the turn's [`Cancel`] flag so long-running tools can be interrupted mid-run).
@@ -26,6 +56,10 @@ pub struct ToolContext {
     /// sites and tests keep working; the real callers attach the turn's flag via
     /// [`ToolContext::with_cancel`].
     pub cancel: Cancel,
+    /// Filesystem backend for the read/write/edit tools. Defaults to [`LocalFs`]
+    /// (local disk) so every existing caller/test is unaffected; the ACP surface
+    /// swaps in a client-mediated backend via [`ToolContext::with_fs`].
+    pub fs: Arc<dyn FsBackend>,
 }
 
 impl ToolContext {
@@ -33,6 +67,7 @@ impl ToolContext {
         Self {
             workdir: workdir.into(),
             cancel: Cancel::new(),
+            fs: Arc::new(LocalFs),
         }
     }
 
@@ -40,6 +75,13 @@ impl ToolContext {
     /// interrupted mid-run instead of only at the step boundary.
     pub fn with_cancel(mut self, cancel: Cancel) -> Self {
         self.cancel = cancel;
+        self
+    }
+
+    /// Route the read/write/edit tools through a custom filesystem backend
+    /// (e.g. an ACP client-mediated one) instead of the default local disk.
+    pub fn with_fs(mut self, fs: Arc<dyn FsBackend>) -> Self {
+        self.fs = fs;
         self
     }
 
@@ -158,7 +200,7 @@ impl Tool for ReadFile {
             Ok(p) => p,
             Err(e) => return e,
         };
-        match std::fs::read_to_string(ctx.resolve(path)) {
+        match ctx.fs.read(&ctx.resolve(path)) {
             // Cap large reads so one file can't blow the model's context window.
             Ok(content) => {
                 let total = content.chars().count();
@@ -212,16 +254,7 @@ impl Tool for WriteFile {
             Ok(c) => c,
             Err(e) => return e,
         };
-        let full = ctx.resolve(path);
-        if let Some(parent) = full.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return ToolOutcome::error(format!(
-                    "write_file failed to create {}: {e}",
-                    parent.display()
-                ));
-            }
-        }
-        match std::fs::write(&full, content) {
+        match ctx.fs.write(&ctx.resolve(path), content) {
             Ok(()) => ToolOutcome::ok(format!("Wrote {} bytes to {path}", content.len())),
             Err(e) => ToolOutcome::error(format!("write_file failed for {path}: {e}")),
         }
@@ -263,7 +296,7 @@ impl Tool for EditFile {
             Err(e) => return e,
         };
         let full = ctx.resolve(path);
-        let original = match std::fs::read_to_string(&full) {
+        let original = match ctx.fs.read(&full) {
             Ok(c) => c,
             Err(e) => return ToolOutcome::error(format!("edit_file failed to read {path}: {e}")),
         };
@@ -277,7 +310,7 @@ impl Tool for EditFile {
             ));
         }
         let updated = original.replacen(old, new, 1);
-        match std::fs::write(&full, updated) {
+        match ctx.fs.write(&full, &updated) {
             Ok(()) => ToolOutcome::ok(format!("Edited {path}")),
             Err(e) => ToolOutcome::error(format!("edit_file failed to write {path}: {e}")),
         }
@@ -475,5 +508,37 @@ impl ToolRegistry {
             Some(tool) => tool.run(ctx, args),
             None => ToolOutcome::error(format!("unknown tool: {name}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn localfs_write_then_read_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.txt");
+        let fs = LocalFs;
+        fs.write(&path, "hello disk").unwrap();
+        assert_eq!(fs.read(&path).unwrap(), "hello disk");
+    }
+
+    #[test]
+    fn localfs_write_creates_missing_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nested path whose parent directories do not yet exist.
+        let path = dir.path().join("a").join("b").join("deep.txt");
+        let fs = LocalFs;
+        fs.write(&path, "made the dirs").unwrap();
+        assert!(path.exists());
+        assert_eq!(fs.read(&path).unwrap(), "made the dirs");
+    }
+
+    #[test]
+    fn localfs_read_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.txt");
+        assert!(LocalFs.read(&path).is_err());
     }
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -7,10 +7,10 @@
 //! seam (see `loop`); tools here just execute. Paths resolve relative to the
 //! tool context's working directory.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use serde_json::{json, Value};
@@ -96,6 +96,24 @@ pub fn shell_invocation(command: &str) -> (String, Vec<String>) {
 /// Default backend: run the command as a local subprocess (today's behavior).
 pub struct LocalShell;
 
+/// How often the shell poll loops re-check for exit/cancel — shared by the local
+/// subprocess ([`LocalShell`]) and the ACP client terminal (`acp::AcpClientShell`)
+/// so client-mediated shell reacts to cancel/exit as fast as local, not slower.
+pub const SHELL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Read a child pipe to EOF on its own thread, returning the bytes. One generic
+/// drainer for both stdout and stderr so a chatty command can't deadlock the poll
+/// loop by filling a pipe buffer.
+fn drain<R: std::io::Read + Send + 'static>(pipe: Option<R>) -> JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    })
+}
+
 impl ShellExec for LocalShell {
     fn exec(&self, command: &str, cwd: &Path, cancel: &Cancel) -> ShellResult {
         // Honor a cancel that landed before we even spawned — don't start work.
@@ -128,28 +146,8 @@ impl ShellExec for LocalShell {
 
         // Drain stdout/stderr on their own threads so a chatty long-running command
         // can't deadlock the poll loop by filling a pipe buffer.
-        let stdout_pipe = child.stdout.take();
-        let stderr_pipe = child.stderr.take();
-        let drain = |pipe: Option<std::process::ChildStdout>| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                if let Some(mut p) = pipe {
-                    let _ = p.read_to_end(&mut buf);
-                }
-                buf
-            })
-        };
-        let drain_err = |pipe: Option<std::process::ChildStderr>| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                if let Some(mut p) = pipe {
-                    let _ = p.read_to_end(&mut buf);
-                }
-                buf
-            })
-        };
-        let out_handle = drain(stdout_pipe);
-        let err_handle = drain_err(stderr_pipe);
+        let out_handle = drain(child.stdout.take());
+        let err_handle = drain(child.stderr.take());
 
         // Poll: exit → done; cancel → kill+reap; else nap and re-check.
         let mut cancelled = false;
@@ -163,7 +161,7 @@ impl ShellExec for LocalShell {
                         cancelled = true;
                         break None;
                     }
-                    std::thread::sleep(Duration::from_millis(50));
+                    std::thread::sleep(SHELL_POLL_INTERVAL);
                 }
                 Err(e) => {
                     let _ = child.wait();


### PR DESCRIPTION
> 베이스 = `rust-rewrite`(통합 트렁크). ACP 서버-에이전트(#46)의 마지막 후속.

설계: monocle#158 · 구현 상태: monocle-cli#44

## 무엇
클라이언트가 능력을 광고하면 에이전트의 **파일·터미널 I/O를 클라이언트(호스트)에 위임** — 에디터가 미저장 버퍼·변경 추적·터미널 표시를 관장. 능력이 없으면 **로컬 폴백**(Craft 서버 백엔드 등). 방금 CLAUDE.md에 박은 유닉스 원칙("엔진과 UI 분리, 호스트가 I/O 소유")의 구현.

## 포함
- **D1 파일** (`17ab673`): `FsBackend`(LocalFs/AcpClientFs) + `ToolContext.fs`. `fs.read_text_file && write_text_file` 광고 시 read/write/edit가 `fs/read|write_text_file`로 라우팅(절대경로), 아니면 `std::fs`.
- **D2 터미널** (`e86cbd4`): `ShellExec`(LocalShell/AcpClientShell) + `shell_invocation` 단일화. `terminal` 광고 시 shell이 `terminal/create`→`terminal/output` 폴링→취소 시 `terminal/kill`→`terminal/release`, 아니면 로컬 subprocess(취소 가능).
- 능력은 `initialize`의 `client_capabilities`에서 저장 → prompt마다 백엔드 선택. 블로킹↔async 브릿지는 기존 권한 패턴 재사용(ClientCall 라운드트립 + spawn_local).

## 검증
`cargo clippy -D warnings` 클린, **87 테스트**(LocalFs/AcpClientFs·LocalShell/AcpClientShell 격리 단위 포함). 실 바이너리 e2e: fs 광고 시 write가 `fs/write_text_file`로 라우팅(로컬 디스크 미기록), terminal 광고 시 shell이 `terminal/create`로 라우팅(로컬 미실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
