### PR TITLE
ACP 전송 seam: serve_over<I,O> (원격 전송 양방향 문)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "futures-io",
  "open",
  "rand 0.8.6",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ agent-client-protocol = "0.9"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "io-std", "macros", "sync"] }
 tokio-util = { version = "0.7", features = ["compat"] }
+# Trait-only crate (already in the tree) to name the ACP transport's byte-stream
+# bound (AsyncRead/AsyncWrite), so `acp::serve_over` is generic over the transport
+# — stdio today, socket/WebSocket later (two-way door). No heavy runtime deps.
+futures-io = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -675,14 +675,29 @@ pub fn serve() -> Result<()> {
         .build()
         .map_err(|e| AppError::new(e.to_string()))?;
     let local = tokio::task::LocalSet::new();
-    local.block_on(&rt, run());
+    local.block_on(&rt, run_stdio());
     Ok(())
 }
 
-async fn run() {
+/// Set up stdio as the transport and drive the ACP agent over it. stdio is ACP's
+/// standard (and today only) transport — the client spawns us and talks over
+/// stdin/stdout.
+async fn run_stdio() {
     let outgoing = tokio::io::stdout().compat_write();
     let incoming = tokio::io::stdin().compat();
+    serve_over(incoming, outgoing).await;
+}
 
+/// Drive the ACP agent over an arbitrary transport: raw byte streams carrying
+/// newline-delimited JSON-RPC. `run_stdio` is today's only caller; a future
+/// socket / WebSocket channel is just another caller with different streams — the
+/// JSON-RPC message layer is identical, so a new transport is additive, not a
+/// rewrite (two-way door, per the interop design principle in CLAUDE.md).
+async fn serve_over<I, O>(incoming: I, outgoing: O)
+where
+    I: futures_io::AsyncRead + Unpin + 'static,
+    O: futures_io::AsyncWrite + Unpin + 'static,
+{
     let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
     let agent = std::rc::Rc::new(MonocleAgent::new(tx));
     // Hold a second handle so we can cancel in-flight sessions on shutdown (Fix #6).


### PR DESCRIPTION
> 베이스 = `rust-rewrite`. 순수 리팩터(동작 불변), 무거운 의존성 없음.

## 배경
ACP 차기 원격 전송은 **RFD "Streamable HTTP & WebSocket"**(PR agentclientprotocol#721, **Draft**)로 수렴 중이나, ① 아직 Draft(2주에 2번 개정, 인증 별도 RFD) ② 재사용 가능한 Rust crate 없음(SDK는 stdio 전용, HTTP/WS는 Phase 3 미착수; 레퍼런스는 Goose 내부). → **지금 원격 전송을 만들지 않되, 나중 추가가 국소 변경이 되도록 전송 계층만 분리**(seam).

## 변경
- `acp::run()` → **`serve_over<I, O>(incoming, outgoing)`**(전송 = `futures_io::AsyncRead`/`AsyncWrite` 바이트스트림) + **`run_stdio()`**(stdio 조립). `serve()`는 `run_stdio` 호출.
- `futures-io`(트레이트 전용, 이미 트리에 transitive로 존재)로 바운드 명명 — axum/hyper/tungstenite 등 무거운 dep 없음.
- 향후 socket/WebSocket은 새 caller(다른 스트림)일 뿐, JSON-RPC 메시지 계층 동일 → additive. **stdio는 ACP 표준·기본 유지.**

## 검증
`cargo clippy -D warnings` 클린, **89 테스트**, stdio e2e 회귀 없음(initialize 정상 응답).

## 다음(별도)
WebSocket 채널 실제 구현은 클라 필요 시점 또는 ACP SDK Phase 3(공식 crate) 시 — 그때 `serve_over`에 새 전송을 꽂으면 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
