### PR TITLE
에이전트 REPL 라인 편집(rustyline) — #44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -259,6 +265,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -322,7 +337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -389,6 +404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +424,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -430,6 +457,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -593,6 +631,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -960,6 +1007,7 @@ dependencies = [
  "open",
  "rand 0.8.6",
  "reqwest",
+ "rustyline",
  "serde",
  "serde_json",
  "sha2",
@@ -970,6 +1018,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,7 +1046,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -1086,7 +1155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -1126,7 +1195,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1154,6 +1223,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -1357,6 +1436,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1784,6 +1885,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 tiny_http = "0.12"
 open = "5"
 ctrlc = "3"
+# Line editing for the interactive `agent` REPL only (arrows/history/Emacs keys).
+# Default features bring the Emacs keymap + FileHistory; used solely on the
+# interactive TTY path (see src/commands/agent.rs) — never in headless/ACP.
+rustyline = "14"
 # ACP server-agent surface (Phase 3). async stays confined to src/acp.rs; the
 # core loop is sync. Pin 0.9 (trait-based `impl Agent`); 1.0 is a builder rewrite.
 agent-client-protocol = "0.9"

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ tools in a working directory. Give it a task as an argument, pipe it via stdin, 
 it for an interactive REPL. Progress goes to stderr, the answer to stdout; `--session
 <name>` persists/resumes a conversation.
 
+The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
+and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
+Command history persists across sessions in `~/.monocle/agent_history`.
+
 In the interactive REPL, lines starting with `/` are local management commands (handled
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -7,6 +7,8 @@
 use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
 use serde_json::Value;
 
 use crate::agent::providers::{Message, MonocleProvider};
@@ -305,63 +307,95 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     eprintln!(
         "{}",
         c::dim(
-            "Interactive — /help for commands; Ctrl-C aborts the turn; Ctrl-D or /exit to quit."
+            "Interactive — ↑/↓ history, ←/→ & Ctrl-A/E/K/Y editing; /help for commands; Ctrl-C aborts the turn; Ctrl-D or /exit to quit."
         )
     );
-    let stdin = std::io::stdin();
+
+    // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
+    // Ctrl-A/E/K/Y) with its default Emacs keymap + file history. It is used
+    // ONLY here, on the interactive TTY path — the headless / piped / ACP paths
+    // above never touch it, keeping the engine UI-free (CLAUDE.md 설계 원칙:
+    // rich UI is the host's job via `monocle acp`). This is input-line editing
+    // only; it does not take over scrollback/paging.
+    let mut rl = DefaultEditor::new().map_err(|e| crate::error::AppError::new(e.to_string()))?;
+    let history_path = home_dir().join(".monocle").join("agent_history");
+    if let Some(parent) = history_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Best-effort history persistence: a missing/unreadable file just means an
+    // empty history this session.
+    let _ = rl.load_history(&history_path);
+
+    // rustyline reads the prompt in raw mode, where Ctrl-C surfaces as
+    // `Interrupted` WITHOUT raising SIGINT — so the `ctrlc` turn-cancel handler
+    // is not triggered at the idle prompt (we just start a fresh line). During a
+    // turn the terminal is back in cooked mode, so Ctrl-C raises SIGINT and that
+    // handler cancels the running turn, exactly as before.
+    let prompt = format!("{} ", c::cyan("»"));
     loop {
-        eprint!("\n{} ", c::cyan("»"));
-        let _ = std::io::stderr().flush();
-        let mut line = String::new();
-        if stdin.read_line(&mut line)? == 0 {
-            eprintln!("\nBye.");
-            break;
-        }
-        let msg = line.trim();
-        if msg.is_empty() {
-            continue;
-        }
-        // Slash commands are handled locally (never sent to the agent/LLM), and
-        // printed to stderr so stdout stays the clean answer channel.
-        match dispatch_command(msg) {
-            Command::Quit => {
+        match rl.readline(&prompt) {
+            Ok(line) => {
+                let msg = line.trim();
+                if msg.is_empty() {
+                    continue;
+                }
+                let _ = rl.add_history_entry(line.as_str());
+                // Slash commands are handled locally (never sent to the agent/LLM),
+                // and printed to stderr so stdout stays the clean answer channel.
+                match dispatch_command(msg) {
+                    Command::Quit => {
+                        eprintln!("Bye.");
+                        break;
+                    }
+                    Command::Help => eprintln!("{}", help_text()),
+                    Command::Config => eprintln!(
+                        "{}",
+                        config_text(
+                            &repl.model,
+                            repl.max_steps,
+                            &repl.workdir,
+                            repl.session_name()
+                        )
+                    ),
+                    Command::Status => {
+                        let login = repl.login_view();
+                        eprintln!(
+                            "{}",
+                            status_text(
+                                login.as_ref(),
+                                &repl.model,
+                                repl.max_steps,
+                                &repl.workdir,
+                                repl.session_name(),
+                            )
+                        );
+                    }
+                    Command::Unknown(cmd) => {
+                        eprintln!("unknown command: {cmd} (try /help)");
+                    }
+                    Command::Turn => {
+                        // A transient per-turn error must not tear down the session.
+                        if let Err(e) = repl.run_turn(msg.to_string()) {
+                            eprintln!("{} {e}", c::red("Error:"));
+                        }
+                    }
+                }
+            }
+            // Ctrl-C at the idle prompt: don't quit — just start a fresh prompt.
+            Err(ReadlineError::Interrupted) => continue,
+            // Ctrl-D (EOF): quit, matching the previous read_line behavior.
+            Err(ReadlineError::Eof) => {
                 eprintln!("Bye.");
                 break;
             }
-            Command::Help => eprintln!("{}", help_text()),
-            Command::Config => eprintln!(
-                "{}",
-                config_text(
-                    &repl.model,
-                    repl.max_steps,
-                    &repl.workdir,
-                    repl.session_name()
-                )
-            ),
-            Command::Status => {
-                let login = repl.login_view();
-                eprintln!(
-                    "{}",
-                    status_text(
-                        login.as_ref(),
-                        &repl.model,
-                        repl.max_steps,
-                        &repl.workdir,
-                        repl.session_name(),
-                    )
-                );
-            }
-            Command::Unknown(cmd) => {
-                eprintln!("unknown command: {cmd} (try /help)");
-            }
-            Command::Turn => {
-                // A transient per-turn error must not tear down the interactive session.
-                if let Err(e) = repl.run_turn(msg.to_string()) {
-                    eprintln!("{} {e}", c::red("Error:"));
-                }
+            Err(e) => {
+                eprintln!("{} {e}", c::red("Error:"));
+                break;
             }
         }
     }
+
+    let _ = rl.save_history(&history_path);
     Ok(())
 }
 


### PR DESCRIPTION
> 베이스 = `rust-rewrite`. monocle-cli#44(터미널 readline 모드) 구현.

대화형 `monocle agent` REPL에 방향키(←/→)·히스토리(↑/↓)·Emacs 바인딩(Ctrl-A/E/K/Y)을 `rustyline`으로 추가.

## 원칙 정합
입력 **라인 편집만**, **대화형 TTY 경로에만**(is_terminal). 스크롤/버퍼 관리를 탈취하는 TUI 아님 — 리치 UI는 호스트가 `monocle acp`로 소유(CLAUDE.md 설계 원칙). 헤드리스/ACP·비대화형(arg/파이프) 경로 무영향.

## 포함
- `rustyline = "14"`(기본 features: Emacs 키맵 + FileHistory).
- DefaultEditor로 프롬프트 입력; `dispatch_command`(#48 /help·/config·/status·/exit) 그대로. Ctrl-C(프롬프트 idle)=계속, Ctrl-D=종료, 턴 중 Ctrl-C=기존 ctrlc 취소(충돌 없음: raw 모드가 프롬프트 ^C를 Interrupted로 잡아 SIGINT 미발생).
- 히스토리 `~/.monocle/agent_history`(best-effort 로드/저장). 배너·README 갱신.

## 검증
`cargo clippy -D warnings` 클린, **97 테스트**. pty e2e: 배너/`/help`/Ctrl-D 종료/히스토리 파일 생성 확인. 비대화형 경로 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
