### PR TITLE
ACP available-commands: help/status/config 광고 + 로컬 처리

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -28,6 +28,9 @@ use agent_client_protocol::{self as acp, Agent, Client as _};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+use crate::agent::commands::{
+    config_text, help_text, login_view, management_command, status_text, Management,
+};
 use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{
@@ -124,6 +127,49 @@ impl MonocleAgent {
             client_caps: RefCell::new(acp::ClientCapabilities::default()),
         }
     }
+
+    /// Read a session's model + working directory (brief `RefCell` borrow), for
+    /// rendering the `config`/`status` management responses. Falls back to the
+    /// defaults if the session is unknown (a client only prompts sessions it made).
+    fn session_config(&self, key: &str) -> (String, PathBuf) {
+        self.sessions
+            .borrow()
+            .get(key)
+            .map(|st| (st.model.clone(), st.cwd.clone()))
+            .unwrap_or_else(|| (DEFAULT_MODEL.to_string(), PathBuf::new()))
+    }
+
+    /// Build the text answer for a locally-handled management command, reusing the
+    /// REPL's shared formatters (DRY). Reads only — never touches `convo`/`running`.
+    /// The ACP "session name" shown in the output is the session id string (`key`).
+    fn management_response(&self, key: &str, cmd: Management) -> String {
+        match cmd {
+            Management::Help => help_text(),
+            Management::Config => {
+                let (model, cwd) = self.session_config(key);
+                config_text(&model, DEFAULT_MAX_STEPS, &cwd, Some(key))
+            }
+            Management::Status => {
+                let (model, cwd) = self.session_config(key);
+                let login = login_view(&Credentials::new());
+                status_text(login.as_ref(), &model, DEFAULT_MAX_STEPS, &cwd, Some(key))
+            }
+        }
+    }
+}
+
+/// The management commands advertised to the ACP client on `new_session` (names
+/// WITHOUT a leading slash — the client adds the slash UI). Kept as a tiny builder
+/// so it can be unit-tested independently of the async `new_session` path.
+fn advertised_commands() -> Vec<acp::AvailableCommand> {
+    vec![
+        acp::AvailableCommand::new("help", "Show available commands"),
+        acp::AvailableCommand::new("status", "Show login status and session config"),
+        acp::AvailableCommand::new(
+            "config",
+            "Show the session config (model, working directory)",
+        ),
+    ]
 }
 
 #[async_trait::async_trait(?Send)]
@@ -163,11 +209,41 @@ impl Agent for MonocleAgent {
                 running: false,
             },
         );
+        // Advertise the locally-handled management commands so an ACP client can
+        // surface them (slash menu). These are answered by `prompt()` without ever
+        // reaching the LLM (see `management_command`).
+        let _ = self
+            .updates
+            .send(ClientCall::Notify(acp::SessionNotification::new(
+                id.clone(),
+                acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+                    advertised_commands(),
+                )),
+            )));
         Ok(acp::NewSessionResponse::new(id))
     }
 
     async fn prompt(&self, args: acp::PromptRequest) -> acp::Result<acp::PromptResponse> {
         let key = args.session_id.0.to_string();
+        let user = prompt_text(&args.prompt);
+
+        // Management commands (help/status/config) are answered LOCALLY: a
+        // synchronous local response streamed back as a normal agent turn, never
+        // sent to the LLM. Handle it before the running-guard / mem::take / LLM
+        // path, and do NOT append it (or its output) to the session `convo` — this
+        // keeps management chatter out of the model's conversation history.
+        if let Some(cmd) = management_command(&user) {
+            let text = self.management_response(&key, cmd);
+            let _ = self
+                .updates
+                .send(ClientCall::Notify(acp::SessionNotification::new(
+                    args.session_id.clone(),
+                    acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                        acp::ContentBlock::from(text),
+                    )),
+                )));
+            return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
+        }
 
         // Claim the session and MOVE its conversation out for the turn (leaving an
         // empty Vec behind). Reject an overlapping prompt for the same session —
@@ -191,7 +267,6 @@ impl Agent for MonocleAgent {
             )
         };
 
-        let user = prompt_text(&args.prompt);
         let updates = self.updates.clone();
         let sid = args.session_id.clone();
 
@@ -1148,6 +1223,46 @@ mod tests {
         assert!(!r.cancelled);
         assert_eq!(r.exit_code, None);
         assert!(r.output.contains("unavailable"), "{}", r.output);
+    }
+
+    #[test]
+    fn advertised_commands_names_help_status_config() {
+        let names: Vec<String> = advertised_commands()
+            .iter()
+            .map(|c| c.name.clone())
+            .collect();
+        assert_eq!(names, vec!["help", "status", "config"]);
+    }
+
+    #[test]
+    fn new_session_advertises_management_commands() {
+        // Drive the real `new_session` and drain the updates channel to confirm it
+        // enqueues an AvailableCommandsUpdate naming help/status/config.
+        let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
+        let agent = MonocleAgent::new(tx);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        rt.block_on(agent.new_session(acp::NewSessionRequest::new("/work")))
+            .expect("new_session");
+
+        let mut names: Option<Vec<String>> = None;
+        while let Ok(call) = rx.try_recv() {
+            if let ClientCall::Notify(n) = call {
+                if let acp::SessionUpdate::AvailableCommandsUpdate(u) = n.update {
+                    names = Some(
+                        u.available_commands
+                            .iter()
+                            .map(|c| c.name.clone())
+                            .collect(),
+                    );
+                }
+            }
+        }
+        let names = names.expect("expected an AvailableCommandsUpdate notification");
+        for cmd in ["help", "status", "config"] {
+            assert!(names.iter().any(|n| n == cmd), "missing {cmd} in {names:?}");
+        }
     }
 
     #[test]

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -20,14 +20,17 @@ pub(crate) enum Management {
     Config,
 }
 
-/// Recognize a bare management-command invocation (with or without a leading `/`).
-/// Returns `None` for anything else (normal input). Used by BOTH the REPL and ACP.
-/// Case-sensitive, exact word only — `helpme` / `/bogus` are not management.
+/// Recognize a management-command invocation. The leading `/` is REQUIRED so a
+/// legitimate one-word prompt like `help` (meaning "help me") reaches the model
+/// instead of being hijacked into a local response. ACP clients advertise these
+/// with slash-less names (`help`) but render/transmit them with the slash
+/// (`/help`), matching how the REPL's own dispatch works. Returns `None` for
+/// anything else (normal input). Case-sensitive, exact word only.
 pub(crate) fn management_command(input: &str) -> Option<Management> {
     match input.trim() {
-        "help" | "/help" => Some(Management::Help),
-        "status" | "/status" => Some(Management::Status),
-        "config" | "/config" => Some(Management::Config),
+        "/help" => Some(Management::Help),
+        "/status" => Some(Management::Status),
+        "/config" => Some(Management::Config),
         _ => None,
     }
 }
@@ -115,22 +118,23 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn management_command_recognizes_bare_and_slashed() {
-        assert_eq!(management_command("help"), Some(Management::Help));
+    fn management_command_requires_leading_slash() {
         assert_eq!(management_command("/help"), Some(Management::Help));
-        assert_eq!(management_command("status"), Some(Management::Status));
         assert_eq!(management_command("/status"), Some(Management::Status));
-        assert_eq!(management_command("config"), Some(Management::Config));
         assert_eq!(management_command("/config"), Some(Management::Config));
     }
 
     #[test]
     fn management_command_trims_surrounding_whitespace() {
-        assert_eq!(management_command("  help  "), Some(Management::Help));
+        assert_eq!(management_command("  /help  "), Some(Management::Help));
     }
 
     #[test]
     fn management_command_returns_none_for_normal_input() {
+        // Bare words are NOT commands — a legit prompt "help" reaches the model.
+        assert_eq!(management_command("help"), None);
+        assert_eq!(management_command("status"), None);
+        assert_eq!(management_command("config"), None);
         assert_eq!(management_command("hello"), None);
         assert_eq!(management_command(""), None);
         assert_eq!(management_command("/bogus"), None);

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -1,0 +1,196 @@
+//! Shared management commands (`help`/`status`/`config`) for the agent surfaces.
+//!
+//! These are handled **locally** — never sent to the agent/LLM — by BOTH the
+//! interactive REPL (`crate::commands::agent`) and the ACP server (`crate::acp`).
+//! This module is the single source of truth: the classifier that recognizes a
+//! management-command invocation and the formatters that render their output, so
+//! the two surfaces can't drift (DRY).
+
+use std::path::Path;
+
+use crate::credentials::Credentials;
+use crate::util::{now_ms, parse_iso_ms};
+
+/// A recognized management command. Handled locally on both surfaces; never
+/// reaches the LLM.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum Management {
+    Help,
+    Status,
+    Config,
+}
+
+/// Recognize a bare management-command invocation (with or without a leading `/`).
+/// Returns `None` for anything else (normal input). Used by BOTH the REPL and ACP.
+/// Case-sensitive, exact word only — `helpme` / `/bogus` are not management.
+pub(crate) fn management_command(input: &str) -> Option<Management> {
+    match input.trim() {
+        "help" | "/help" => Some(Management::Help),
+        "status" | "/status" => Some(Management::Status),
+        "config" | "/config" => Some(Management::Config),
+        _ => None,
+    }
+}
+
+/// Plain login snapshot for `status`, built from `creds.read()` so the formatter
+/// stays pure (no IO / no `Credentials` dependency).
+pub(crate) struct LoginView {
+    pub(crate) tenant: String,
+    pub(crate) email: String,
+    pub(crate) expired: bool,
+}
+
+/// Same 5-minute buffer the auth refresh path uses, so "expired" here matches
+/// when a turn would actually trigger a refresh.
+const EXPIRY_BUFFER_MS: i64 = 5 * 60 * 1000;
+
+/// Build a plain login snapshot from stored credentials, without calling
+/// `get_access_token` (which would refresh / exit the process). Reads only —
+/// shared by the REPL's `/status` and ACP's `status` handler.
+pub(crate) fn login_view(creds: &Credentials) -> Option<LoginView> {
+    let data = creds.read()?;
+    let expired = match parse_iso_ms(&data.access_token_expires_at) {
+        Some(exp) => now_ms() + EXPIRY_BUFFER_MS > exp,
+        None => true,
+    };
+    Some(LoginView {
+        tenant: format!("{} ({})", data.tenant_name, data.tenant_domain),
+        email: data.email,
+        expired,
+    })
+}
+
+pub(crate) fn help_text() -> String {
+    [
+        "commands:",
+        "  /help    show this help",
+        "  /config  show session config (model, max-steps, workdir, session)",
+        "  /status  show login status and session config",
+        "  /exit    quit the REPL (also /quit, Ctrl-D)",
+    ]
+    .join("\n")
+}
+
+pub(crate) fn config_text(
+    model: &str,
+    max_steps: usize,
+    workdir: &Path,
+    session: Option<&str>,
+) -> String {
+    format!(
+        "model:     {}\nmax-steps: {}\nworkdir:   {}\nsession:   {}",
+        model,
+        max_steps,
+        workdir.display(),
+        session.unwrap_or("(none)"),
+    )
+}
+
+pub(crate) fn status_text(
+    login: Option<&LoginView>,
+    model: &str,
+    max_steps: usize,
+    workdir: &Path,
+    session: Option<&str>,
+) -> String {
+    let head = match login {
+        Some(v) => format!(
+            "logged in as {} — {}\naccess token: {}",
+            v.email,
+            v.tenant,
+            if v.expired { "expired" } else { "valid" },
+        ),
+        None => "not logged in".to_string(),
+    };
+    format!(
+        "{}\n{}",
+        head,
+        config_text(model, max_steps, workdir, session)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn management_command_recognizes_bare_and_slashed() {
+        assert_eq!(management_command("help"), Some(Management::Help));
+        assert_eq!(management_command("/help"), Some(Management::Help));
+        assert_eq!(management_command("status"), Some(Management::Status));
+        assert_eq!(management_command("/status"), Some(Management::Status));
+        assert_eq!(management_command("config"), Some(Management::Config));
+        assert_eq!(management_command("/config"), Some(Management::Config));
+    }
+
+    #[test]
+    fn management_command_trims_surrounding_whitespace() {
+        assert_eq!(management_command("  help  "), Some(Management::Help));
+    }
+
+    #[test]
+    fn management_command_returns_none_for_normal_input() {
+        assert_eq!(management_command("hello"), None);
+        assert_eq!(management_command(""), None);
+        assert_eq!(management_command("/bogus"), None);
+        assert_eq!(management_command("helpme"), None);
+        assert_eq!(management_command("help me"), None);
+    }
+
+    #[test]
+    fn help_text_lists_each_command() {
+        let h = help_text();
+        for cmd in ["/help", "/config", "/status", "/exit"] {
+            assert!(h.contains(cmd), "help missing {cmd}: {h}");
+        }
+    }
+
+    #[test]
+    fn config_text_shows_fields_and_none_session() {
+        let wd = PathBuf::from("/tmp/work");
+        let out = config_text("claude-x", 12, &wd, None);
+        assert!(out.contains("claude-x"), "{out}");
+        assert!(out.contains("12"), "{out}");
+        assert!(out.contains("/tmp/work"), "{out}");
+        assert!(out.contains("(none)"), "{out}");
+    }
+
+    #[test]
+    fn config_text_shows_named_session() {
+        let wd = PathBuf::from("/tmp/work");
+        let out = config_text("claude-x", 12, &wd, Some("mysess"));
+        assert!(out.contains("mysess"), "{out}");
+        assert!(!out.contains("(none)"), "{out}");
+    }
+
+    #[test]
+    fn status_text_logged_out() {
+        let wd = PathBuf::from("/tmp/work");
+        let out = status_text(None, "m", 3, &wd, None);
+        assert!(out.contains("not logged in"), "{out}");
+        // Config block is still shown.
+        assert!(out.contains("/tmp/work"), "{out}");
+    }
+
+    #[test]
+    fn status_text_logged_in_valid_and_expired() {
+        let wd = PathBuf::from("/tmp/work");
+        let view = LoginView {
+            tenant: "Acme (acme.example.com)".to_string(),
+            email: "a@b.com".to_string(),
+            expired: false,
+        };
+        let out = status_text(Some(&view), "m", 3, &wd, None);
+        assert!(out.contains("logged in as a@b.com"), "{out}");
+        assert!(out.contains("Acme (acme.example.com)"), "{out}");
+        assert!(out.contains("valid"), "{out}");
+
+        let expired = LoginView {
+            expired: true,
+            ..view
+        };
+        let out = status_text(Some(&expired), "m", 3, &wd, None);
+        assert!(out.contains("expired"), "{out}");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@
 //! This is the §9 step-1 spike: the `providers` abstraction only. The agent loop,
 //! tools, permission/sandboxing, session, and ACP surface come later.
 
+pub mod commands;
 pub mod providers;
 pub mod runner;
 pub mod session;

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -5,12 +5,13 @@
 //! stderr, and the final answer to stdout.
 
 use std::io::{IsTerminal, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
 use serde_json::Value;
 
+use crate::agent::commands::{config_text, help_text, login_view, status_text};
 use crate::agent::providers::{Message, MonocleProvider};
 use crate::agent::runner::{Agent, AllowAll, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
@@ -21,7 +22,7 @@ use crate::colors as c;
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
-use crate::util::{home_dir, now_ms, parse_iso_ms};
+use crate::util::home_dir;
 
 pub struct AgentOptions {
     pub prompt: Option<String>,
@@ -84,21 +85,6 @@ impl Repl<'_> {
             .as_ref()
             .and_then(|s| s.path().file_stem())
             .and_then(|s| s.to_str())
-    }
-
-    /// Build a plain login snapshot from stored credentials, without calling
-    /// `get_access_token` (which would refresh / exit the process). Reads only.
-    fn login_view(&self) -> Option<LoginView> {
-        let data = self.creds.read()?;
-        let expired = match parse_iso_ms(&data.access_token_expires_at) {
-            Some(exp) => now_ms() + EXPIRY_BUFFER_MS > exp,
-            None => true,
-        };
-        Some(LoginView {
-            tenant: format!("{} ({})", data.tenant_name, data.tenant_domain),
-            email: data.email,
-            expired,
-        })
     }
 
     fn run_turn(&mut self, user: String) -> Result<()> {
@@ -168,62 +154,6 @@ fn dispatch_command(input: &str) -> Command {
         "/exit" | "/quit" => Command::Quit,
         other => Command::Unknown(other.to_string()),
     }
-}
-
-/// Plain login snapshot for `/status`, built by the REPL from `creds.read()` so
-/// the formatter stays pure (no IO / no `Credentials` dependency).
-struct LoginView {
-    tenant: String,
-    email: String,
-    expired: bool,
-}
-
-/// Same 5-minute buffer the auth refresh path uses, so "expired" here matches
-/// when a turn would actually trigger a refresh.
-const EXPIRY_BUFFER_MS: i64 = 5 * 60 * 1000;
-
-fn help_text() -> String {
-    [
-        "commands:",
-        "  /help    show this help",
-        "  /config  show session config (model, max-steps, workdir, session)",
-        "  /status  show login status and session config",
-        "  /exit    quit the REPL (also /quit, Ctrl-D)",
-    ]
-    .join("\n")
-}
-
-fn config_text(model: &str, max_steps: usize, workdir: &Path, session: Option<&str>) -> String {
-    format!(
-        "model:     {}\nmax-steps: {}\nworkdir:   {}\nsession:   {}",
-        model,
-        max_steps,
-        workdir.display(),
-        session.unwrap_or("(none)"),
-    )
-}
-
-fn status_text(
-    login: Option<&LoginView>,
-    model: &str,
-    max_steps: usize,
-    workdir: &Path,
-    session: Option<&str>,
-) -> String {
-    let head = match login {
-        Some(v) => format!(
-            "logged in as {} — {}\naccess token: {}",
-            v.email,
-            v.tenant,
-            if v.expired { "expired" } else { "valid" },
-        ),
-        None => "not logged in".to_string(),
-    };
-    format!(
-        "{}\n{}",
-        head,
-        config_text(model, max_steps, workdir, session)
-    )
 }
 
 pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -> Result<()> {
@@ -358,7 +288,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                         )
                     ),
                     Command::Status => {
-                        let login = repl.login_view();
+                        let login = login_view(repl.creds);
                         eprintln!(
                             "{}",
                             status_text(
@@ -413,7 +343,6 @@ fn one_line(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn dispatch_recognizes_management_commands() {
@@ -436,61 +365,5 @@ mod tests {
     fn dispatch_passes_through_plain_text() {
         assert_eq!(dispatch_command("hello world"), Command::Turn);
         assert_eq!(dispatch_command("summarize the /etc dir"), Command::Turn);
-    }
-
-    #[test]
-    fn help_text_lists_each_command() {
-        let h = help_text();
-        for cmd in ["/help", "/config", "/status", "/exit"] {
-            assert!(h.contains(cmd), "help missing {cmd}: {h}");
-        }
-    }
-
-    #[test]
-    fn config_text_shows_fields_and_none_session() {
-        let wd = PathBuf::from("/tmp/work");
-        let out = config_text("claude-x", 12, &wd, None);
-        assert!(out.contains("claude-x"), "{out}");
-        assert!(out.contains("12"), "{out}");
-        assert!(out.contains("/tmp/work"), "{out}");
-        assert!(out.contains("(none)"), "{out}");
-    }
-
-    #[test]
-    fn config_text_shows_named_session() {
-        let wd = PathBuf::from("/tmp/work");
-        let out = config_text("claude-x", 12, &wd, Some("mysess"));
-        assert!(out.contains("mysess"), "{out}");
-        assert!(!out.contains("(none)"), "{out}");
-    }
-
-    #[test]
-    fn status_text_logged_out() {
-        let wd = PathBuf::from("/tmp/work");
-        let out = status_text(None, "m", 3, &wd, None);
-        assert!(out.contains("not logged in"), "{out}");
-        // Config block is still shown.
-        assert!(out.contains("/tmp/work"), "{out}");
-    }
-
-    #[test]
-    fn status_text_logged_in_valid_and_expired() {
-        let wd = PathBuf::from("/tmp/work");
-        let view = LoginView {
-            tenant: "Acme (acme.example.com)".to_string(),
-            email: "a@b.com".to_string(),
-            expired: false,
-        };
-        let out = status_text(Some(&view), "m", 3, &wd, None);
-        assert!(out.contains("logged in as a@b.com"), "{out}");
-        assert!(out.contains("Acme (acme.example.com)"), "{out}");
-        assert!(out.contains("valid"), "{out}");
-
-        let expired = LoginView {
-            expired: true,
-            ..view
-        };
-        let out = status_text(Some(&expired), "m", 3, &wd, None);
-        assert!(out.contains("expired"), "{out}");
     }
 }


### PR DESCRIPTION
> 베이스 = `rust-rewrite`. 앞서 논의한 (b). #48(REPL 관리명령)의 ACP 대응.

ACP 클라이언트(에디터/데스크탑/Craft)가 `help`/`status`/`config`를 **슬래시 메뉴로 노출**(AvailableCommandsUpdate)하고, 에이전트가 **LLM 없이 로컬 응답**. #48 포매터를 공유 모듈화(DRY).

## 포함
- **`src/agent/commands.rs`**(신설): `help_text`/`config_text`/`status_text`/`LoginView`/`login_view(creds)` (#48에서 이동) + `management_command(&str) -> Option<Management>` 분류기. REPL·ACP 공유(중복 제거).
- **acp advertise**: `new_session`이 `AvailableCommandsUpdate`(help/status/config) 전송.
- **acp handle**: `prompt` 상단에서 명령 감지 → 공유 포매터로 `AgentMessageChunk` 스트리밍 + `EndTurn`, `running`/`convo`/`spawn_blocking` 미개입(관리 대화 = LLM 히스토리 오염 없음).

## 검증
`cargo clippy -D warnings` 클린, **102 테스트**. ACP e2e: session/new → 광고 `[help,status,config]`, `help` prompt → 로컬 help 응답 + end_turn(LLM 미호출).

## 알려진 흠
공유 `help_text`가 REPL 전용 `/exit`도 나열 → ACP help 응답에 표기(무해). 원하면 ACP 전용 help 변형으로 후속 다듬기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
