### PR TITLE
툴 레이어 가상화 테스트킷 (RecordingShell/InMemoryFs/RecordingObserver)

### DIFF
--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 
 use common::{
     has_tool_result, text_response, tool_call_response, tool_call_response_raw, FakeProvider,
+    RecordingObserver,
 };
 use monocle_cli::agent::providers::Message;
 use monocle_cli::agent::runner::{
@@ -45,16 +46,9 @@ fn loop_executes_tool_then_returns_final_answer() {
     let dir = tempfile::tempdir().unwrap();
     let agent = agent(&provider, &tools, dir.path(), 20);
 
-    #[derive(Default)]
-    struct Rec {
-        calls: Vec<String>,
-    }
-    impl Observer for Rec {
-        fn on_tool_call(&mut self, _id: &str, name: &str, _args: &Value) {
-            self.calls.push(name.to_string());
-        }
-    }
-    let mut rec = Rec::default();
+    // Reuse the shared RecordingObserver from the testkit (tests/common) instead
+    // of a bespoke inline observer.
+    let mut rec = RecordingObserver::new();
 
     let mut convo = vec![
         Message::system("be helpful"),
@@ -67,7 +61,15 @@ fn loop_executes_tool_then_returns_final_answer() {
     // A plain text answer ends the turn normally; the final text lands in the convo.
     assert!(matches!(stop, RunStop::EndTurn));
     assert_eq!(convo.last().unwrap().content.as_deref(), Some("done"));
-    assert_eq!(rec.calls, vec!["write_file"]);
+    let calls: Vec<String> = rec
+        .events()
+        .into_iter()
+        .filter(|e| e.starts_with("call:"))
+        .collect();
+    assert_eq!(
+        calls,
+        vec!["call:write_file:{\"path\":\"out.txt\",\"content\":\"hi\"}"]
+    );
     assert_eq!(
         std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
         "hi"

--- a/tests/agent_virtual_tools.rs
+++ b/tests/agent_virtual_tools.rs
@@ -1,0 +1,166 @@
+//! Tool-layer virtualization — the whole agent tool-calling loop, deterministic
+//! and side-effect-free.
+//!
+//! The pattern (three seams, one harness):
+//! - **`FakeProvider` scripts the model.** Each turn the closure inspects the
+//!   conversation and returns the next `ChatResponse` — a tool call, then another,
+//!   then a final text answer — with no HTTP.
+//! - **Mock backends capture/serve tool I/O.** `ToolRegistry::with_defaults()` is
+//!   the REAL shell + read/write/edit tools; only their *backends* are swapped via
+//!   the same `ToolContext::with_shell`/`with_fs` seam the ACP surface uses. A
+//!   `RecordingShell` records the exact command the LLM asked to run (no process
+//!   spawns); an `InMemoryFs` serves/captures file I/O (no disk touches).
+//! - **`RecordingObserver` asserts the calls.** It records `call:`/`result:` for
+//!   every tool the loop drove, so we can assert *what tool calls the agent made*
+//!   and in what order.
+//!
+//! Swap `FakeProvider` for a real `MonocleProvider` and the SAME harness becomes a
+//! MODEL tool-calling eval: the mock backends still capture what the model chose to
+//! do (which commands, which writes) and the observer still records the call
+//! sequence — you just assert on the model's behavior instead of a scripted one.
+//! (No network test is added here; this is the documented extension point.)
+
+mod common;
+
+use serde_json::json;
+
+use common::{
+    has_tool_result, text_response, tool_call_response, FakeProvider, InMemoryFs,
+    RecordingObserver, RecordingShell,
+};
+use monocle_cli::agent::providers::Message;
+use monocle_cli::agent::runner::{Agent, AgentConfig, AllowAll, Cancel, RunStop};
+use monocle_cli::agent::tools::{Shell, Tool, ToolContext, ToolRegistry};
+use std::sync::Arc;
+
+/// The shell tool's platform-specific name (`bash` on unix, `powershell` on
+/// Windows) — the model must call it by this name for the call to route.
+fn shell_tool_name() -> String {
+    Shell.name().to_string()
+}
+
+#[test]
+fn virtualized_loop_routes_tool_calls_to_mock_backends() {
+    let shell_name = shell_tool_name();
+
+    // ── the model: shell `echo hi` → write_file out.txt → final answer ──────
+    let shell_name_for_provider = shell_name.clone();
+    let provider = FakeProvider::new(move |req| {
+        // Count how many tool results the conversation already carries to decide
+        // which scripted step we're on (0 → shell, 1 → write, 2 → done).
+        let done = req.messages.iter().filter(|m| m.role == "tool").count();
+        match done {
+            0 => tool_call_response(
+                "c1",
+                &shell_name_for_provider,
+                json!({"command": "echo hi"}),
+            ),
+            1 => tool_call_response(
+                "c2",
+                "write_file",
+                json!({"path": "out.txt", "content": "data"}),
+            ),
+            _ => text_response("all done"),
+        }
+    });
+
+    // ── mock backends (kept as Arc clones for post-run assertions) ──────────
+    let shell = Arc::new(RecordingShell::new());
+    let fs = Arc::new(InMemoryFs::new());
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(dir.path())
+        .with_shell(shell.clone())
+        .with_fs(fs.clone());
+
+    let tools = ToolRegistry::with_defaults();
+    let agent = Agent::new(&provider, &tools, ctx, AgentConfig::new("any"));
+
+    let mut observer = RecordingObserver::new();
+    let stop = agent
+        .run(
+            &mut vec![Message::user("do the thing")],
+            &mut AllowAll,
+            &mut observer,
+            &Cancel::new(),
+        )
+        .unwrap();
+
+    // (d) normal completion.
+    assert!(matches!(stop, RunStop::EndTurn), "expected EndTurn");
+
+    // (a) the LLM's shell call reached the MOCK shell — not real bash.
+    assert_eq!(
+        shell.commands(),
+        vec!["echo hi".to_string()],
+        "the exact command the model asked for must reach the mock shell"
+    );
+
+    // (b) the write landed in the in-memory fs — no real file on disk. The tool
+    // resolves `out.txt` against the workdir, so key/assert on the resolved path.
+    let resolved = dir.path().join("out.txt");
+    assert_eq!(fs.get(&resolved).as_deref(), Some("data"));
+    assert_eq!(fs.writes(), vec![resolved.clone()]);
+    assert!(
+        !resolved.exists(),
+        "virtualized write must NOT touch the real disk"
+    );
+
+    // (c) the observer saw the tool calls in order, each followed by its result.
+    let events = observer.events();
+    let calls_and_results: Vec<String> = events
+        .into_iter()
+        .filter(|e| e.starts_with("call:") || e.starts_with("result:"))
+        .collect();
+    assert_eq!(
+        calls_and_results,
+        vec![
+            format!("call:{shell_name}:{{\"command\":\"echo hi\"}}"),
+            format!("result:{shell_name}:false"),
+            "call:write_file:{\"path\":\"out.txt\",\"content\":\"data\"}".to_string(),
+            "result:write_file:false".to_string(),
+        ],
+        "the agent's tool calls must appear in order, each with its result"
+    );
+}
+
+#[test]
+fn virtualized_read_of_missing_file_surfaces_a_tool_error() {
+    // Error path: the model reads a file the in-memory fs doesn't have. The tool
+    // must surface an error (is_error) to the observer AND feed it back to the
+    // model, which then answers — the failure is reported, not swallowed.
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("could not read it")
+        } else {
+            tool_call_response("r1", "read_file", json!({"path": "missing.txt"}))
+        }
+    });
+
+    let fs = Arc::new(InMemoryFs::new()); // empty — the read must miss
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(dir.path()).with_fs(fs.clone());
+
+    let tools = ToolRegistry::with_defaults();
+    let agent = Agent::new(&provider, &tools, ctx, AgentConfig::new("any"));
+
+    let mut observer = RecordingObserver::new();
+    let stop = agent
+        .run(
+            &mut vec![Message::user("read missing.txt")],
+            &mut AllowAll,
+            &mut observer,
+            &Cancel::new(),
+        )
+        .unwrap();
+
+    assert!(matches!(stop, RunStop::EndTurn));
+
+    // The tool result was flagged as an error to the observer.
+    let events = observer.events();
+    assert!(
+        events.contains(&"result:read_file:true".to_string()),
+        "missing-file read must surface as a tool error: {events:?}"
+    );
+    // And the model got to answer after the error was fed back.
+    assert!(events.iter().any(|e| e == "text:could not read it"));
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,9 @@
 //! unused helpers here are expected.)
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use serde_json::Value;
@@ -14,6 +17,8 @@ use tiny_http::{Response, Server};
 use monocle_cli::agent::providers::{
     ChatRequest, ChatResponse, FunctionCall, LlmProvider, ToolCall,
 };
+use monocle_cli::agent::runner::{Cancel, Observer};
+use monocle_cli::agent::tools::{FsBackend, ShellExec, ShellResult, ToolOutcome};
 use monocle_cli::error::Result;
 
 // ── mock LLM (isolated loop testing — no network) ───────────────────────────
@@ -143,4 +148,172 @@ where
         }
     });
     Stub { addr }
+}
+
+// ── tool-layer virtualization testkit ────────────────────────────────────────
+//
+// The same seam the ACP surface uses to inject a client-mediated shell/fs (see
+// `tools::ToolContext::with_shell`/`with_fs`) lets a test swap in *mock* backends:
+// capture the exact commands / file writes the agent makes and assert on them,
+// with NO real process spawn and NO disk I/O. Paired with `FakeProvider` (scripts
+// the model) and `RecordingObserver` (captures the loop's callbacks), a whole
+// tool-calling loop runs deterministically. Mirrors `FakeProvider`'s Arc/closure
+// style. See `tests/agent_virtual_tools.rs` for the end-to-end demonstrator.
+
+/// A mock [`ShellExec`] that records every command it's asked to run and serves a
+/// canned [`ShellResult`] — never spawns a real process. Wrap in `Arc` and keep a
+/// clone (`Arc<RecordingShell>` coerces to `Arc<dyn ShellExec>` at `with_shell`)
+/// to read [`commands`](RecordingShell::commands) back after the run.
+pub struct RecordingShell {
+    commands: Arc<Mutex<Vec<String>>>,
+    stdout: String,
+    exit_code: Option<i32>,
+}
+
+impl RecordingShell {
+    /// Records commands; every `exec` returns success with empty output.
+    pub fn new() -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(Vec::new())),
+            stdout: String::new(),
+            exit_code: Some(0),
+        }
+    }
+
+    /// Like [`new`](RecordingShell::new) but serves canned stdout + exit code.
+    pub fn with_output(stdout: impl Into<String>, exit_code: i32) -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(Vec::new())),
+            stdout: stdout.into(),
+            exit_code: Some(exit_code),
+        }
+    }
+
+    /// The commands passed to `exec`, in order — for assertions.
+    pub fn commands(&self) -> Vec<String> {
+        self.commands.lock().unwrap().clone()
+    }
+}
+
+impl Default for RecordingShell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShellExec for RecordingShell {
+    fn exec(&self, command: &str, _cwd: &Path, _cancel: &Cancel) -> ShellResult {
+        self.commands.lock().unwrap().push(command.to_string());
+        ShellResult {
+            output: self.stdout.clone(),
+            exit_code: self.exit_code,
+            cancelled: false,
+        }
+    }
+}
+
+/// A mock [`FsBackend`] backed by an in-memory `HashMap<PathBuf, String>` — the
+/// read/write/edit tools hit this instead of disk. Files are keyed by the tool's
+/// *resolved* absolute path (`workdir.join(path)`), so seed / assert with the same
+/// resolved path. Wrap in `Arc` and keep a clone to inspect it after the run.
+pub struct InMemoryFs {
+    files: Arc<Mutex<HashMap<PathBuf, String>>>,
+    writes: Arc<Mutex<Vec<PathBuf>>>,
+}
+
+impl InMemoryFs {
+    /// Empty filesystem.
+    pub fn new() -> Self {
+        Self {
+            files: Arc::new(Mutex::new(HashMap::new())),
+            writes: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Pre-seed files (each `(resolved-path, contents)`).
+    pub fn seeded(entries: impl IntoIterator<Item = (PathBuf, String)>) -> Self {
+        let fs = Self::new();
+        {
+            let mut files = fs.files.lock().unwrap();
+            for (path, content) in entries {
+                files.insert(path, content);
+            }
+        }
+        fs
+    }
+
+    /// Current contents of `path` (the resolved absolute path), if present.
+    pub fn get(&self, path: &Path) -> Option<String> {
+        self.files.lock().unwrap().get(path).cloned()
+    }
+
+    /// The paths written via `write`, in order — for assertions.
+    pub fn writes(&self) -> Vec<PathBuf> {
+        self.writes.lock().unwrap().clone()
+    }
+}
+
+impl Default for InMemoryFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FsBackend for InMemoryFs {
+    fn read(&self, path: &Path) -> std::result::Result<String, String> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(path)
+            .cloned()
+            // Same shape the trait expects for a missing file: a human-readable
+            // String error the tool drops into `ToolOutcome::error`.
+            .ok_or_else(|| format!("{}: no such file (in-memory)", path.display()))
+    }
+
+    fn write(&self, path: &Path, content: &str) -> std::result::Result<(), String> {
+        self.files
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf(), content.to_string());
+        self.writes.lock().unwrap().push(path.to_path_buf());
+        Ok(())
+    }
+}
+
+/// An [`Observer`] that records a compact string for each loop callback, so a test
+/// can assert exactly which tool calls the agent made and in what order:
+/// - `call:<name>:<args-compact-json>`
+/// - `result:<name>:<is_error>`
+/// - `text:<delta>` · `notice:<msg>`
+#[derive(Default)]
+pub struct RecordingObserver {
+    events: Vec<String>,
+}
+
+impl RecordingObserver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The recorded events, in order — for assertions.
+    pub fn events(&self) -> Vec<String> {
+        self.events.clone()
+    }
+}
+
+impl Observer for RecordingObserver {
+    fn on_text_delta(&mut self, delta: &str) {
+        self.events.push(format!("text:{delta}"));
+    }
+    fn on_tool_call(&mut self, _id: &str, name: &str, args: &Value) {
+        self.events.push(format!("call:{name}:{args}"));
+    }
+    fn on_tool_result(&mut self, _id: &str, name: &str, outcome: &ToolOutcome) {
+        self.events
+            .push(format!("result:{name}:{}", outcome.is_error));
+    }
+    fn on_notice(&mut self, msg: &str) {
+        self.events.push(format!("notice:{msg}"));
+    }
 }


### PR DESCRIPTION
> 베이스 = `rust-rewrite`. 테스터빌리티 원칙을 툴 레이어에 실현.

에이전트의 **툴콜링을 실제 부작용 없이 테스트/평가**할 수 있는 목 백엔드 테스트킷. "배쉬 목을 물려주면 이 LLM이 어떤 툴콜을 하는지 확인" 요구를 코드로 실현 — 우리 기존 seam(`ShellExec`/`FsBackend`/`Observer` trait + `FakeProvider`)에 바로 얹힘, lib 변경 없음.

## 포함
- `tests/common`: **RecordingShell**(명령 기록·스크립트 출력·프로세스 없음), **InMemoryFs**(인메모리 파일맵·디스크 없음), **RecordingObserver**(툴콜 순서 기록). 전부 이미 `pub`인 표면만 사용 — **visibility 확대 없음**.
- `tests/agent_virtual_tools.rs`: FakeProvider가 shell·write_file 툴콜 스크립트 → 목 백엔드 캡처. 단언: LLM 명령이 백엔드 도달(실제 bash 아님), write가 인메모리로(디스크 미기록), observer 순서 캡처, EndTurn + 에러 경로.
- **확장**: FakeProvider를 실제 `MonocleProvider`로 바꾸면 동일 하네스가 **모델 툴콜 eval**(G1: 값싼 모델의 툴콜 능력 비교)이 됨 — 문서화(네트워크 테스트 없음).

## 검증
`cargo clippy -D warnings` 클린, **104 테스트**(virtual tools 2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
