### PR TITLE
Release workflow: drop macOS Intel target + document supported platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             name: monocle-macos-arm64
-          - target: x86_64-apple-darwin
-            os: macos-13
-            name: monocle-macos-x64
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: monocle-linux-x64
@@ -91,7 +88,6 @@ jobs:
         with:
           files: |
             monocle-macos-arm64.tar.gz
-            monocle-macos-x64.tar.gz
             monocle-linux-x64.tar.gz
             monocle-linux-arm64.tar.gz
             monocle-windows-x64.zip

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ irm https://raw.githubusercontent.com/warmblood-kr/monocle-cli/main/install.ps1 
 monocle login
 ```
 
+> **Prebuilt binaries:** macOS (Apple Silicon), Linux (x86-64 / arm64), and Windows (x64).
+> Intel Macs are not shipped as a prebuilt binary — build from source (below).
+
 A browser opens — sign in with your organization account. In headless/SSH
 environments it falls back automatically to device-code login (or force it with
 `monocle login --device-code`).

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -26,6 +26,9 @@ irm https://raw.githubusercontent.com/warmblood-kr/monocle-cli/main/install.ps1 
 monocle login
 ```
 
+> **미리 빌드된 바이너리:** macOS (Apple Silicon), Linux (x86-64 / arm64), Windows (x64).
+> Intel Mac은 미리 빌드된 바이너리를 제공하지 않아요 — 아래 소스 빌드를 이용해 주세요.
+
 브라우저가 열리면 회사 계정으로 로그인해 주세요. SSH·헤드리스 환경에서는
 자동으로 device-code 로그인으로 전환돼요 (`monocle login --device-code`로 강제할 수도 있어요).
 

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ detect_platform() {
     Darwin)
       case "$ARCH" in
         arm64|aarch64) echo "macos-arm64" ;;
-        x86_64|amd64) echo "macos-x64" ;;
+        x86_64|amd64) echo "unsupported: macOS Intel (x86_64) is not shipped — use an Apple Silicon Mac or build from source" && exit 1 ;;
         *) echo "unsupported: macOS $ARCH" && exit 1 ;;
       esac
       ;;


### PR DESCRIPTION
Post-1.0.0 follow-up landing the fixes made during the v1.0.0 release onto `devel` (they currently exist only on `rust-rewrite`, where v1.0.0 was tagged).

## What changed
- **Drop the macOS Intel (`x86_64-apple-darwin`) release target.** The `macos-13` runner is deprecated and queue-prone, which stalled the v1.0.0 release. Supported prebuilt targets are now: macOS arm64, Linux x64 / arm64 (musl), Windows x64. `install.sh` reports a clear "unsupported — build from source" message on Intel Macs.
- **README (EN/KO): document supported platforms** so new installers aren't confused (Intel Macs → build from source).

## Notes
- v1.0.0 is already released (GitHub Releases, 4 binaries); this only brings the workflow/docs fix to `devel` so future releases cut from `devel`/`main` use it.
- npm deprecation for `@warmblood/monocle-cli` (frozen at 0.5.0) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)