### PR TITLE
Release v1.1.0: version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "CLI authentication tool for Claude Code with Stark OIDC PKCE integration"
 license = "MIT"


### PR DESCRIPTION
Bump version 1.0.0 → 1.1.0 for the v1.1.0 release (agent tool-approval safety + REPL UX: slash completion, /model, multiline paste — all already on devel). GitHub Releases channel.