### PR TITLE
monocle upgrade: 셀프 업그레이드 커맨드

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,15 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ascii"
@@ -315,6 +330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +363,17 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -470,10 +505,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -983,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,18 +1068,23 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "flate2",
  "futures-io",
  "open",
  "rand 0.8.6",
  "reqwest",
  "rustyline",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "tiny_http",
  "tokio",
  "tokio-util",
+ "zip",
 ]
 
 [[package]]
@@ -1503,6 +1573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1672,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1682,6 +1769,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2282,6 +2380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,7 +2493,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,20 @@ tokio-util = { version = "0.7", features = ["compat"] }
 # bound (AsyncRead/AsyncWrite), so `acp::serve_over` is generic over the transport
 # — stdio today, socket/WebSocket later (two-way door). No heavy runtime deps.
 futures-io = "0.3"
+# Self-update (`monocle upgrade`). semver compares release tags; self-replace does
+# the running-binary swap on both unix and windows; flate2+tar unpack the unix
+# `.tar.gz` asset. All downloads still go through the net.rs facade (no extra HTTP
+# client) — these only handle version math and archive extraction.
+semver = "1"
+self-replace = "1"
+flate2 = "1"
+tar = "0.4"
+
+# `zip` is only needed to unpack the windows `.zip` asset — gate it to windows so
+# the unix build (which uses tar.gz) doesn't pull it in. Trim default features to
+# the deflate codec used by the release zips.
+[target.'cfg(windows)'.dependencies]
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
+| `monocle upgrade [--check]` | Update monocle to the latest release (`--check` only reports current vs latest) |
 | `monocle agent [prompt] [--workdir <dir>] [--model <id>] [--max-steps <n>] [--session <name>] [--auto-approve]` | **Experimental.** Headless agent loop with tools (read/write/edit + shell) |
 | `monocle acp` | **Experimental.** Run as an [ACP](https://agentclientprotocol.com) agent over stdio (for editors / desktop / Craft) |
 
@@ -177,6 +178,24 @@ monocle audio speech-azure \
 ```
 
 On failure each command prints the HTTP status and response body to stderr and exits non-zero, which makes it easy to spot bad parameters or backend errors.
+
+## ⬆️ Upgrading
+
+Update to the latest GitHub Release in place — same prebuilt binary as the
+installer, swapped over the running executable:
+
+```bash
+monocle upgrade
+```
+
+Just check whether a newer version exists (no install):
+
+```bash
+monocle upgrade --check
+```
+
+Intel Macs have no prebuilt binary, so `upgrade` reports an error there — build
+from source instead (see Setup).
 
 ## 🤖 Claude Code integration
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod setup;
 pub mod status;
 pub mod token;
 pub mod unset;
+pub mod upgrade;

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,0 +1,255 @@
+//! `monocle upgrade [--check]` — self-update from GitHub Releases.
+//!
+//! Downloads the prebuilt binary for the current platform and swaps it in place
+//! over the running executable. The platform→asset mapping is the same contract
+//! as `install.sh`. All network I/O goes through the `net.rs` facade (the same
+//! `client.get` used everywhere else) — both the GitHub API call and the asset
+//! download — so no second HTTP client sneaks in.
+
+use std::io::Write;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::net::Client;
+
+const REPO: &str = "warmblood-kr/monocle-cli";
+const BINARY: &str = "monocle";
+
+#[derive(Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+}
+
+/// Map (`std::env::consts::OS`, `std::env::consts::ARCH`) → the release asset
+/// platform string, matching `install.sh` exactly. macOS Intel is intentionally
+/// unsupported (no prebuilt binary is shipped).
+fn asset_platform(os: &str, arch: &str) -> Result<&'static str> {
+    match (os, arch) {
+        ("macos", "aarch64") => Ok("macos-arm64"),
+        ("macos", "x86_64") => Err(AppError::new(
+            "macOS Intel is not shipped as a prebuilt binary — build from source",
+        )),
+        ("linux", "x86_64") => Ok("linux-x64"),
+        ("linux", "aarch64") => Ok("linux-arm64"),
+        ("windows", "x86_64") => Ok("windows-x64"),
+        _ => Err(AppError::new(format!("unsupported platform: {os}/{arch}"))),
+    }
+}
+
+/// The release asset filename for a platform: `.tar.gz` on unix, `.zip` on
+/// windows (matches `install.sh`).
+fn asset_filename(platform: &str) -> String {
+    if platform.starts_with("windows") {
+        format!("{BINARY}-{platform}.zip")
+    } else {
+        format!("{BINARY}-{platform}.tar.gz")
+    }
+}
+
+/// The GitHub Releases download URL for `<vTAG>/<asset>`.
+fn download_url(tag: &str, asset: &str) -> String {
+    format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
+}
+
+/// Whether `latest` is a strictly newer semver than `current`. Any unparseable
+/// version is treated as "not newer" (a safe no-op rather than a bad upgrade).
+fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(cur), Ok(lat)) => lat > cur,
+        _ => false,
+    }
+}
+
+/// Extract the `monocle` binary from the downloaded archive into `temp_path`.
+/// cfg-gated: gzip+tar on unix, zip on windows.
+#[cfg(unix)]
+fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
+    use std::io::Read;
+
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let is_target = entry
+            .path()?
+            .file_name()
+            .map(|n| n == BINARY)
+            .unwrap_or(false);
+        if !is_target {
+            continue;
+        }
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf)?;
+        std::fs::write(temp_path, &buf)?;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(temp_path, std::fs::Permissions::from_mode(0o755))?;
+        return Ok(());
+    }
+    Err(AppError::new(format!(
+        "archive did not contain a `{BINARY}` binary"
+    )))
+}
+
+/// Extract the `monocle.exe` binary from the downloaded zip into `temp_path`.
+#[cfg(windows)]
+fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
+    use std::io::Read;
+
+    let reader = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(reader).map_err(|e| AppError::new(e.to_string()))?;
+    let target = format!("{BINARY}.exe");
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| AppError::new(e.to_string()))?;
+        let matches = Path::new(file.name())
+            .file_name()
+            .map(|n| n == target.as_str())
+            .unwrap_or(false);
+        if !matches {
+            continue;
+        }
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+        std::fs::write(temp_path, &buf)?;
+        return Ok(());
+    }
+    Err(AppError::new(format!(
+        "archive did not contain a `{target}` binary"
+    )))
+}
+
+pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
+    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
+    let current = env!("CARGO_PKG_VERSION");
+
+    eprintln!("Checking for updates ({platform})...");
+
+    let resp = client.get(
+        &format!("https://api.github.com/repos/{REPO}/releases/latest"),
+        &[
+            ("User-Agent", "monocle-cli"),
+            ("Accept", "application/vnd.github+json"),
+        ],
+    )?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "GitHub API error {}: {}",
+            resp.status,
+            resp.text()
+        )));
+    }
+    let tag = resp.json::<LatestRelease>()?.tag_name;
+    let latest = tag.strip_prefix('v').unwrap_or(&tag).to_string();
+
+    if check_only {
+        let mut out = std::io::stdout();
+        writeln!(out, "current: v{current} / latest: v{latest}")?;
+        if is_newer(current, &latest) {
+            writeln!(out, "An upgrade is available: run `monocle upgrade`.")?;
+        } else {
+            writeln!(out, "You are on the latest version.")?;
+        }
+        return Ok(());
+    }
+
+    if !is_newer(current, &latest) {
+        println!("Already on the latest version (v{current}).");
+        return Ok(());
+    }
+
+    let asset = asset_filename(platform);
+    let url = download_url(&tag, &asset);
+    eprintln!("Downloading {asset} (v{latest})...");
+
+    let resp = client.get(&url, &[("User-Agent", "monocle-cli")])?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "download failed {}: {}",
+            resp.status, url
+        )));
+    }
+    let bytes = resp.bytes();
+
+    let temp_name = if cfg!(windows) {
+        format!("monocle-upgrade-{}.exe", std::process::id())
+    } else {
+        format!("monocle-upgrade-{}", std::process::id())
+    };
+    let temp_path = std::env::temp_dir().join(temp_name);
+
+    eprintln!("Extracting...");
+    extract_binary(bytes, &temp_path)?;
+
+    eprintln!("Replacing the running binary...");
+    self_replace::self_replace(&temp_path).map_err(|e| AppError::new(e.to_string()))?;
+    let _ = std::fs::remove_file(&temp_path);
+
+    let location = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "the current executable".to_string());
+    println!("Upgraded monocle v{current} → v{latest} ({location}).");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_platform_maps_supported_targets() {
+        assert_eq!(asset_platform("macos", "aarch64").unwrap(), "macos-arm64");
+        assert_eq!(asset_platform("linux", "x86_64").unwrap(), "linux-x64");
+        assert_eq!(asset_platform("linux", "aarch64").unwrap(), "linux-arm64");
+        assert_eq!(asset_platform("windows", "x86_64").unwrap(), "windows-x64");
+    }
+
+    #[test]
+    fn asset_platform_rejects_macos_intel() {
+        let err = asset_platform("macos", "x86_64").unwrap_err();
+        assert!(
+            err.to_string().contains("macOS Intel"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn asset_platform_rejects_unknown() {
+        assert!(asset_platform("linux", "riscv64").is_err());
+        assert!(asset_platform("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn is_newer_compares_semver() {
+        assert!(!is_newer("1.1.0", "1.1.0"));
+        assert!(is_newer("1.1.0", "1.2.0"));
+        assert!(!is_newer("1.1.0", "1.0.9"));
+        assert!(is_newer("1.1.0", "2.0.0"));
+    }
+
+    #[test]
+    fn is_newer_is_false_for_garbage() {
+        assert!(!is_newer("not-a-version", "1.0.0"));
+        assert!(!is_newer("1.0.0", "not-a-version"));
+    }
+
+    #[test]
+    fn asset_filename_matches_install_sh() {
+        assert_eq!(asset_filename("linux-x64"), "monocle-linux-x64.tar.gz");
+        assert_eq!(asset_filename("macos-arm64"), "monocle-macos-arm64.tar.gz");
+        assert_eq!(asset_filename("windows-x64"), "monocle-windows-x64.zip");
+    }
+
+    #[test]
+    fn download_url_uses_v_prefixed_tag() {
+        assert_eq!(
+            download_url("v1.2.0", "monocle-linux-x64.tar.gz"),
+            "https://github.com/warmblood-kr/monocle-cli/releases/download/v1.2.0/monocle-linux-x64.tar.gz"
+        );
+    }
+}

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -203,7 +203,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
                     "current=v{current} latest=v{latest} upgrade_available=unknown"
                 )?;
                 eprintln!(
-                    "⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다."
+                    "⚠ could not parse release tag '{latest}'; unable to determine whether an update is available."
                 );
             }
         }
@@ -214,7 +214,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
         None => {
             // Don't falsely claim up-to-date and don't blindly replace on an
             // unparseable tag — warn and abort.
-            eprintln!("⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다.");
+            eprintln!("⚠ could not parse release tag '{latest}'; unable to determine whether an update is available.");
             return Err(AppError::new(format!(
                 "could not parse release tag '{latest}' as semver"
             )));

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -2,9 +2,10 @@
 //!
 //! Downloads the prebuilt binary for the current platform and swaps it in place
 //! over the running executable. The platform→asset mapping is the same contract
-//! as `install.sh`. All network I/O goes through the `net.rs` facade (the same
-//! `client.get` used everywhere else) — both the GitHub API call and the asset
-//! download — so no second HTTP client sneaks in.
+//! as `install.sh`. All network I/O goes through the `net.rs` facade — the
+//! GitHub API call via `client.get`, and the (potentially large) asset download
+//! via `client.get_download` (a generous-timeout path that won't inherit the
+//! shared API timeout) — so no second HTTP client sneaks in.
 
 use std::io::Write;
 use std::path::Path;
@@ -53,15 +54,17 @@ fn download_url(tag: &str, asset: &str) -> String {
     format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
 }
 
-/// Whether `latest` is a strictly newer semver than `current`. Any unparseable
-/// version is treated as "not newer" (a safe no-op rather than a bad upgrade).
-fn is_newer(current: &str, latest: &str) -> bool {
+/// Compare `current` against `latest` as semver. Returns `None` if EITHER string
+/// fails to parse — so the caller can distinguish "definitely not newer" from
+/// "can't tell" (e.g. a non-semver release tag) instead of silently no-op'ing.
+/// `Ordering::Less` means `current < latest` (an upgrade is available).
+fn compare_versions(current: &str, latest: &str) -> Option<std::cmp::Ordering> {
     match (
         semver::Version::parse(current),
         semver::Version::parse(latest),
     ) {
-        (Ok(cur), Ok(lat)) => lat > cur,
-        _ => false,
+        (Ok(cur), Ok(lat)) => Some(cur.cmp(&lat)),
+        _ => None,
     }
 }
 
@@ -69,23 +72,24 @@ fn is_newer(current: &str, latest: &str) -> bool {
 /// cfg-gated: gzip+tar on unix, zip on windows.
 #[cfg(unix)]
 fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
-    use std::io::Read;
-
     let decoder = flate2::read::GzDecoder::new(bytes);
     let mut archive = tar::Archive::new(decoder);
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let is_target = entry
+        // Accept only a *regular file* named `monocle` — never a directory entry
+        // or other odd layout, which would otherwise yield a 0-byte install.
+        let is_file = entry.header().entry_type().is_file();
+        let is_named = entry
             .path()?
             .file_name()
             .map(|n| n == BINARY)
             .unwrap_or(false);
-        if !is_target {
+        if !(is_file && is_named) {
             continue;
         }
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
-        std::fs::write(temp_path, &buf)?;
+        // Stream the entry straight to disk (no second full-size in-memory copy).
+        let mut out = std::fs::File::create(temp_path)?;
+        std::io::copy(&mut entry, &mut out)?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(temp_path, std::fs::Permissions::from_mode(0o755))?;
         return Ok(());
@@ -98,8 +102,6 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
 /// Extract the `monocle.exe` binary from the downloaded zip into `temp_path`.
 #[cfg(windows)]
 fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
-    use std::io::Read;
-
     let reader = std::io::Cursor::new(bytes);
     let mut archive = zip::ZipArchive::new(reader).map_err(|e| AppError::new(e.to_string()))?;
     let target = format!("{BINARY}.exe");
@@ -107,6 +109,11 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
         let mut file = archive
             .by_index(i)
             .map_err(|e| AppError::new(e.to_string()))?;
+        // Accept only a *file* entry named `monocle.exe` — skip directory entries
+        // so an odd archive layout can't produce a 0-byte install.
+        if file.is_dir() {
+            continue;
+        }
         let matches = Path::new(file.name())
             .file_name()
             .map(|n| n == target.as_str())
@@ -114,9 +121,9 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
         if !matches {
             continue;
         }
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)?;
-        std::fs::write(temp_path, &buf)?;
+        // Stream the entry straight to disk (no second full-size in-memory copy).
+        let mut out = std::fs::File::create(temp_path)?;
+        std::io::copy(&mut file, &mut out)?;
         return Ok(());
     }
     Err(AppError::new(format!(
@@ -124,11 +131,34 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
     )))
 }
 
+/// Map a `self_replace` failure to an actionable message. A permission error
+/// almost always means the binary lives in a root-owned, system-wide install dir
+/// (e.g. install.sh's sudo fallback to `/usr/local/bin`), so tell the user how to
+/// recover instead of surfacing a raw `Permission denied (os error 13)`.
+fn map_self_replace_error(e: std::io::Error) -> AppError {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        let exe = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "the current executable".to_string());
+        AppError::new(format!(
+            "permission denied replacing {exe} — it looks installed system-wide. \
+             Re-run with elevated privileges (e.g. sudo) or reinstall to a \
+             user-writable location. ({e})"
+        ))
+    } else {
+        AppError::new(e.to_string())
+    }
+}
+
 pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
-    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
+    use std::cmp::Ordering;
+
     let current = env!("CARGO_PKG_VERSION");
 
-    eprintln!("Checking for updates ({platform})...");
+    // Checking for updates needs no downloadable asset, so it must work on every
+    // platform (incl. unsupported ones like macOS Intel). `asset_platform()` is
+    // only consulted later, on the actual download path.
+    eprintln!("Checking for updates...");
 
     let resp = client.get(
         &format!("https://api.github.com/repos/{REPO}/releases/latest"),
@@ -147,27 +177,65 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
     let tag = resp.json::<LatestRelease>()?.tag_name;
     let latest = tag.strip_prefix('v').unwrap_or(&tag).to_string();
 
+    let ordering = compare_versions(current, &latest);
+
     if check_only {
+        // Data lines (machine-parseable) go to stdout; prose to stderr.
         let mut out = std::io::stdout();
-        writeln!(out, "current: v{current} / latest: v{latest}")?;
-        if is_newer(current, &latest) {
-            writeln!(out, "An upgrade is available: run `monocle upgrade`.")?;
-        } else {
-            writeln!(out, "You are on the latest version.")?;
+        match ordering {
+            Some(Ordering::Less) => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=true"
+                )?;
+                eprintln!("An upgrade is available: run `monocle upgrade`.");
+            }
+            Some(_) => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=false"
+                )?;
+                eprintln!("You are on the latest version.");
+            }
+            None => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=unknown"
+                )?;
+                eprintln!(
+                    "⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다."
+                );
+            }
         }
         return Ok(());
     }
 
-    if !is_newer(current, &latest) {
-        println!("Already on the latest version (v{current}).");
-        return Ok(());
+    match ordering {
+        None => {
+            // Don't falsely claim up-to-date and don't blindly replace on an
+            // unparseable tag — warn and abort.
+            eprintln!("⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다.");
+            return Err(AppError::new(format!(
+                "could not parse release tag '{latest}' as semver"
+            )));
+        }
+        Some(Ordering::Less) => { /* an upgrade is available — proceed */ }
+        Some(_) => {
+            eprintln!("Already on the latest version (v{current}).");
+            return Ok(());
+        }
     }
 
+    // Only now — on the actual download path — do we need a downloadable asset,
+    // so this is where an unsupported platform legitimately errors out.
+    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
     let asset = asset_filename(platform);
     let url = download_url(&tag, &asset);
     eprintln!("Downloading {asset} (v{latest})...");
 
-    let resp = client.get(&url, &[("User-Agent", "monocle-cli")])?;
+    // Use the dedicated download path: a multi-MB binary on a slow link must not
+    // inherit the shared `send()`'s short total API timeout.
+    let resp = client.get_download(&url, &[("User-Agent", "monocle-cli")])?;
     if !resp.ok() {
         return Err(AppError::new(format!(
             "download failed {}: {}",
@@ -186,14 +254,29 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
     eprintln!("Extracting...");
     extract_binary(bytes, &temp_path)?;
 
+    // Safety gate: never hand self_replace an empty/missing file — that would
+    // brick the CLI (install a 0-byte binary) while printing success.
+    let valid = std::fs::metadata(&temp_path)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false);
+    if !valid {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(AppError::new(
+            "downloaded archive did not contain a valid monocle binary",
+        ));
+    }
+
     eprintln!("Replacing the running binary...");
-    self_replace::self_replace(&temp_path).map_err(|e| AppError::new(e.to_string()))?;
+    if let Err(e) = self_replace::self_replace(&temp_path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(map_self_replace_error(e));
+    }
     let _ = std::fs::remove_file(&temp_path);
 
     let location = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "the current executable".to_string());
-    println!("Upgraded monocle v{current} → v{latest} ({location}).");
+    eprintln!("Upgraded monocle v{current} → v{latest} ({location}).");
     Ok(())
 }
 
@@ -225,17 +308,23 @@ mod tests {
     }
 
     #[test]
-    fn is_newer_compares_semver() {
-        assert!(!is_newer("1.1.0", "1.1.0"));
-        assert!(is_newer("1.1.0", "1.2.0"));
-        assert!(!is_newer("1.1.0", "1.0.9"));
-        assert!(is_newer("1.1.0", "2.0.0"));
+    fn compare_versions_orders_semver() {
+        use std::cmp::Ordering;
+        // Equal.
+        assert_eq!(compare_versions("1.1.0", "1.1.0"), Some(Ordering::Equal));
+        // current < latest → an upgrade is available.
+        assert_eq!(compare_versions("1.1.0", "1.2.0"), Some(Ordering::Less));
+        assert_eq!(compare_versions("1.1.0", "2.0.0"), Some(Ordering::Less));
+        // current > latest → already ahead.
+        assert_eq!(compare_versions("1.1.0", "1.0.9"), Some(Ordering::Greater));
     }
 
     #[test]
-    fn is_newer_is_false_for_garbage() {
-        assert!(!is_newer("not-a-version", "1.0.0"));
-        assert!(!is_newer("1.0.0", "not-a-version"));
+    fn compare_versions_is_none_for_garbage() {
+        // Either side unparseable → None (can't tell), never a silent no-op.
+        assert_eq!(compare_versions("not-a-version", "1.0.0"), None);
+        assert_eq!(compare_versions("1.0.0", "not-a-version"), None);
+        assert_eq!(compare_versions("1.0.0", "latest"), None);
     }
 
     #[test]
@@ -250,6 +339,53 @@ mod tests {
         assert_eq!(
             download_url("v1.2.0", "monocle-linux-x64.tar.gz"),
             "https://github.com/warmblood-kr/monocle-cli/releases/download/v1.2.0/monocle-linux-x64.tar.gz"
+        );
+    }
+
+    #[cfg(unix)]
+    fn make_targz(entries: &[(&str, tar::EntryType, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(&mut out, flate2::Compression::fast());
+            let mut builder = tar::Builder::new(enc);
+            for (name, kind, data) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_size(data.len() as u64);
+                header.set_entry_type(*kind);
+                header.set_mode(0o755);
+                header.set_cksum();
+                builder.append(&header, *data).unwrap();
+            }
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        out
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_binary_writes_regular_file() {
+        let payload = b"#!/bin/sh\necho hi\n";
+        let archive = make_targz(&[("monocle", tar::EntryType::Regular, payload)]);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out");
+        extract_binary(&archive, &out).unwrap();
+        assert_eq!(std::fs::read(&out).unwrap(), payload);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_binary_rejects_directory_named_monocle() {
+        // A directory entry named `monocle` must NOT be accepted (it would yield a
+        // 0-byte install). Extraction must error and write nothing.
+        let archive = make_targz(&[("monocle/", tar::EntryType::Directory, b"")]);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out");
+        let err = extract_binary(&archive, &out).unwrap_err();
+        assert!(err.to_string().contains("did not contain"), "got: {err}");
+        assert!(
+            !out.exists(),
+            "no file must be created for a dir-only archive"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use monocle_cli::commands::setup::setup_command;
 use monocle_cli::commands::status::status_command;
 use monocle_cli::commands::token::token_command;
 use monocle_cli::commands::unset::unset_command;
+use monocle_cli::commands::upgrade::upgrade_command;
 use monocle_cli::credentials::Credentials;
 use monocle_cli::error::Result;
 use monocle_cli::net::Client;
@@ -97,6 +98,12 @@ enum Commands {
     Model {
         #[command(subcommand)]
         command: ModelCommands,
+    },
+    /// Update monocle to the latest release
+    Upgrade {
+        /// Only check for a newer version, don't install
+        #[arg(long)]
+        check: bool,
     },
 }
 
@@ -272,6 +279,7 @@ fn main() {
             },
         ),
         Commands::Audio { command } => run_audio(&client, &creds, command),
+        Commands::Upgrade { check } => upgrade_command(&client, check),
         Commands::Model { command } => {
             match command {
                 ModelCommands::List => {

--- a/src/net.rs
+++ b/src/net.rs
@@ -74,6 +74,33 @@ impl Client {
         send(req)
     }
 
+    /// GET a large file download (e.g. the `monocle upgrade` release binary).
+    ///
+    /// This deliberately does NOT route through the shared `send()`: a multi-MB
+    /// binary on a slow link must not inherit the short total timeout that the
+    /// shared API path may carry (it would abort a legitimately slow transfer).
+    /// Instead it applies its own generous per-request timeout (600s).
+    pub fn get_download(&self, url: &str, headers: &[(&str, &str)]) -> Result<Resp> {
+        let mut req = self
+            .inner
+            .get(url)
+            .timeout(std::time::Duration::from_secs(600));
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        // Inline send (not the shared `send()`) so the 600s timeout above is the
+        // only cap that applies to the download.
+        let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+        let body = resp.bytes().map_err(|e| AppError(e.to_string()))?.to_vec();
+        Ok(Resp {
+            status,
+            status_text,
+            body,
+        })
+    }
+
     /// POST `application/x-www-form-urlencoded` (token / device-code requests).
     pub fn post_form(
         &self,


### PR DESCRIPTION
`monocle upgrade [--check]` — CLI가 스스로 최신 릴리스로 업그레이드.

## 동작
- **`monocle upgrade`**: GitHub 최신 릴리스 태그 확인 → 현재보다 새로우면 플랫폼 바이너리(`monocle-<platform>.tar.gz`/`.zip`) 다운로드 → 추출 → **실행 중인 자기 자신 교체**(self-replace). 최신이면 그대로.
- **`monocle upgrade --check`**: 현재/최신만 보고, 교체 없음.

## 구현
- 플랫폼 매핑은 **install.sh와 동일 계약**(macos-arm64 / linux-x64 / linux-arm64 / windows-x64; Intel Mac 미지원 안내).
- **HTTP는 `net.rs` 파사드 재사용**(GitHub API + 자산 다운로드) — 별도 HTTP 클라이언트/`self_update` 크레이트 안 씀(코드베이스 규약).
- 추출 cfg별: unix `flate2`+`tar`, windows `zip`(windows 전용 dep). 교체는 `self-replace`.
- 진행 로그 → stderr, 결과 → stdout(규약).

## 검증
clippy 클린, 115 테스트(asset_platform/is_newer/URL 단위). **e2e**: `--check` 실제 GitHub API 동작 + 가짜 1.0.0 바이너리 → 실제 v1.1.0 다운로드·추출·자기 교체 → 1.1.0 확인(전 경로). README 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)