### PR TITLE
CLI DX 폴리시: 태그라인 갱신 + status 미로그인 힌트

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -24,7 +24,7 @@ pub fn status_command(creds: &Credentials, home: &Path) {
     let creds = match creds.read() {
         Some(c) => c,
         None => {
-            eprintln!("Not logged in.");
+            eprintln!("Not logged in. Run `monocle login --tenant <domain>` first.");
             return;
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use monocle_cli::util;
 #[command(
     name = "monocle",
     version,
-    about = "CLI authentication tool for Claude Code with Stark OIDC integration"
+    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code."
 )]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
`/design-review`(터미널 UX/DX 감사)에서 나온 devel-레벨 수정. 원자 커밋, 되돌리기 쉬움.

## FINDING-001 — 상단 help 태그라인 갱신
`about`이 'CLI authentication tool for Claude Code…'로 옛 monocle을 광고 → chat/agent/acp/audio까지 하는 LLM CLI인데 first-impression 오독. README 정합 한 줄로 교체.

## FINDING-004 — status 미로그인 안내 일관성
`status`가 'Not logged in.'만 찍어 다른 커맨드의 actionable 안내와 불일치 → 'Run `monocle login …` first.' 힌트 추가.

## 관련 (이 PR 밖)
- FINDING-002(런타임 출력 영어 통일)는 한국어 문자열이 있는 #60(chat)·#61(upgrade) 브랜치에 각각 커밋됨.
- FINDING-003(help 커맨드 그룹핑)은 전 커맨드가 모이는 v1.1.1 통합 시점에 커스텀 help 템플릿으로 일괄 처리(지금 하면 #61 Upgrade 추가와 충돌).
- FINDING-005(브랜드 오렌지 256색)는 폴리시로 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)