### PR TITLE
release: v1.1.1 — help 그룹핑(Finding-3) + 버전 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "monocle-cli"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
-description = "CLI authentication tool for Claude Code with Stark OIDC PKCE integration"
+description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"
 repository = "https://github.com/warmblood-kr/monocle-cli"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,50 @@ use monocle_cli::error::Result;
 use monocle_cli::net::Client;
 use monocle_cli::util;
 
+// clap 4 has no native way to group subcommands under section headings, so the
+// root command uses a custom help_template that drops the flat auto-generated
+// command list ({options} still renders flags) and prints a hand-grouped list
+// via {after-help}. Only the root sets this template, so subcommand `--help`
+// screens keep clap's default layout.
+const ROOT_HELP_TEMPLATE: &str = "\
+{about-with-newline}
+{usage-heading} {usage}{after-help}
+
+Options:
+{options}";
+
+const ROOT_HELP_COMMANDS: &str = "\
+Commands:
+  Auth & setup:
+    login    Authenticate with Stark OIDC provider
+    token    Output access token to stdout (for apiKeyHelper)
+    setup    Configure Claude Code to use Monocle authentication
+    unset    Remove Monocle configuration from Claude Code
+    status   Show authentication and configuration status
+    claude   Launch Claude Code with Monocle authentication
+
+  Chat & models:
+    chat     Chat with LLM via Monocle router (interactive REPL or pipe from stdin)
+    models   List available models from the Monocle router
+
+  Agent:
+    agent    [Experimental] Headless agent loop with tools (read/write/edit + shell)
+    acp      [Experimental] Run as an ACP agent over stdio (editors / desktop / Craft)
+
+  Audio:
+    audio    Call audio (STT / TTS) endpoints directly for debugging
+
+  Maintenance:
+    upgrade  Update monocle to the latest release
+    help     Print this message or the help of the given subcommand(s)";
+
 #[derive(Parser)]
 #[command(
     name = "monocle",
     version,
-    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code."
+    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code.",
+    help_template = ROOT_HELP_TEMPLATE,
+    after_help = ROOT_HELP_COMMANDS
 )]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
v1.1.1 통합 폴리시 (릴리스 런북 §4 step 2–3).

- **Finding-3 (help grouping):** 루트 `--help`의 flat 명령 목록을 논리 그룹으로 재구성 (Auth & setup / Chat & models / Agent / Audio / Maintenance). clap 4는 subcommand 섹션 헤딩을 네이티브 지원하지 않으므로 루트에만 커스텀 `help_template` + `after_help`로 렌더 — 서브커맨드 `--help`는 clap 기본 레이아웃 유지. 모든 variant(`Upgrade` 포함)가 존재하는 통합 시점에 수행.
- **버전 bump:** `Cargo.toml` 1.1.0 → 1.1.1 (릴리스 태그 `v1.1.1`과 일치, release.yml verify-version 게이트 통과용).
- **description 정렬:** stale한 "CLI authentication tool…" → 새 태그라인.

검증: `cargo test`(전부 통과) · `clippy`/`fmt` 클린 · 스모크(--help 그룹핑 · `upgrade --check` · chat 스트리밍 · 로그아웃 힌트).