### PR TITLE
Release v1.1.1: devel → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,15 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ascii"
@@ -315,6 +330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +363,17 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -470,10 +505,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -983,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,18 +1068,23 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "flate2",
  "futures-io",
  "open",
  "rand 0.8.6",
  "reqwest",
  "rustyline",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "tiny_http",
  "tokio",
  "tokio-util",
+ "zip",
 ]
 
 [[package]]
@@ -1503,6 +1573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1672,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1682,6 +1769,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2282,6 +2380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,7 +2493,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,20 @@ tokio-util = { version = "0.7", features = ["compat"] }
 # bound (AsyncRead/AsyncWrite), so `acp::serve_over` is generic over the transport
 # — stdio today, socket/WebSocket later (two-way door). No heavy runtime deps.
 futures-io = "0.3"
+# Self-update (`monocle upgrade`). semver compares release tags; self-replace does
+# the running-binary swap on both unix and windows; flate2+tar unpack the unix
+# `.tar.gz` asset. All downloads still go through the net.rs facade (no extra HTTP
+# client) — these only handle version math and archive extraction.
+semver = "1"
+self-replace = "1"
+flate2 = "1"
+tar = "0.4"
+
+# `zip` is only needed to unpack the windows `.zip` asset — gate it to windows so
+# the unix build (which uses tar.gz) doesn't pull it in. Trim default features to
+# the deflate codec used by the release zips.
+[target.'cfg(windows)'.dependencies]
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "monocle-cli"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
-description = "CLI authentication tool for Claude Code with Stark OIDC PKCE integration"
+description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"
 repository = "https://github.com/warmblood-kr/monocle-cli"
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ monocle chat --system-prompt-file ./persona.md --model claude-opus-4-7
 ```
 
 > [!NOTE]
+> The reply **streams** to stdout as it is generated. `--max-tokens` is
+> **omitted by default** so the model/router uses its own (model-appropriate)
+> output limit — pass `--max-tokens <n>` only to cap it.
+
+> [!NOTE]
 > `monocle model chat` / `monocle model list` still work but are deprecated and will be removed in a future release.
 
 ## 🔊 Audio (STT / TTS)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
+| `monocle upgrade [--check]` | Update monocle to the latest release (`--check` only reports current vs latest) |
 | `monocle agent [prompt] [--workdir <dir>] [--model <id>] [--max-steps <n>] [--session <name>] [--auto-approve]` | **Experimental.** Headless agent loop with tools (read/write/edit + shell) |
 | `monocle acp` | **Experimental.** Run as an [ACP](https://agentclientprotocol.com) agent over stdio (for editors / desktop / Craft) |
 
@@ -177,6 +178,24 @@ monocle audio speech-azure \
 ```
 
 On failure each command prints the HTTP status and response body to stderr and exits non-zero, which makes it easy to spot bad parameters or backend errors.
+
+## ⬆️ Upgrading
+
+Update to the latest GitHub Release in place — same prebuilt binary as the
+installer, swapped over the running executable:
+
+```bash
+monocle upgrade
+```
+
+Just check whether a newer version exists (no install):
+
+```bash
+monocle upgrade --check
+```
+
+Intel Macs have no prebuilt binary, so `upgrade` reports an error there — build
+from source instead (see Setup).
 
 ## 🤖 Claude Code integration
 

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -138,6 +138,12 @@ pub struct ChatResponse {
     /// The model the backend actually served (echoed by the API when present).
     pub model: Option<String>,
     pub finish_reason: Option<String>,
+    /// `true` only when the stream dropped **mid-generation** (before the model
+    /// sent a `finish_reason`) and partial text was salvaged — a typed signal so
+    /// callers can flag the output as cut short without pattern-matching on a
+    /// magic `finish_reason` string. A complete-but-then-dropped stream (the
+    /// model already sent `finish_reason`) is NOT truncated.
+    pub truncated: bool,
 }
 
 /// Ensure every assembled tool call has a non-empty `id`, synthesizing a stable
@@ -175,6 +181,7 @@ fn parse_response_value(data: &Value) -> Result<ChatResponse> {
         tool_calls,
         model,
         finish_reason,
+        truncated: false,
     })
 }
 
@@ -191,13 +198,26 @@ struct ToolCallAcc {
 /// `next_line` to pull each raw line and emitting content deltas via `on_delta`.
 ///
 /// Read-error handling — graceful partial-output on a mid-stream drop
-/// (monocle-cli#59): when `next_line` yields `Err`, if anything usable has
-/// already been received (`content` non-empty OR a tool call has been started)
-/// the stream is treated as **truncated-but-usable** — `finish_reason` is set to
-/// `"stream_error"`, any in-progress tool calls are **dropped** (a tool call cut
-/// off mid-stream is unreliable, so the caller gets clean partial text instead of
-/// a malformed call), and the loop ends. Only when nothing has been received is
-/// the error propagated (a genuine connection failure with nothing to salvage).
+/// (monocle-cli#59): when `next_line` yields `Err`, the outcome depends on how
+/// far the stream got:
+/// - **Already complete** (`finish_reason.is_some()`): the model sent its final
+///   chunk before the connection dropped (e.g. before `[DONE]`). Treat the error
+///   as a benign end-of-stream — `break` and keep everything as-is (tool calls
+///   preserved, NOT marked truncated). Dropping a valid tool call here would be a
+///   bug.
+/// - **Mid-generation** (`finish_reason` still `None`, but `content` or a tool
+///   call was started): salvage the partial text — mark `truncated = true`, drop
+///   any in-progress tool calls (a tool call cut off mid-stream is unreliable),
+///   and break.
+/// - **Nothing received**: propagate the error (a genuine connection failure with
+///   nothing to salvage).
+///
+/// No-usable-content guard: if the stream ends having produced nothing usable —
+/// no content, no tool calls, no `finish_reason`, and not truncated — it likely
+/// carried an error-shaped `data:` payload (a 200 with `{"error":...}`) rather
+/// than a real completion, so an error is returned rather than a silent empty
+/// `Ok`. A legitimately-empty-but-complete reply carries `finish_reason` and so
+/// passes.
 fn assemble_sse_stream(
     mut next_line: impl FnMut() -> Result<Option<String>>,
     on_delta: &mut dyn FnMut(&str),
@@ -206,15 +226,22 @@ fn assemble_sse_stream(
     let mut finish_reason: Option<String> = None;
     let mut model: Option<String> = None;
     let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
+    let mut truncated = false;
 
     loop {
         let raw = match next_line() {
             Ok(Some(raw)) => raw,
             Ok(None) => break,
             Err(e) => {
-                // Salvage a truncated-but-usable response if anything arrived.
+                if finish_reason.is_some() {
+                    // The model already completed (final chunk arrived); the drop
+                    // is just a missing `[DONE]`. Keep everything as-is.
+                    break;
+                }
+                // Salvage a truncated-but-usable response if anything arrived
+                // mid-generation; otherwise there is nothing to salvage.
                 if !content.is_empty() || !tool_acc.is_empty() {
-                    finish_reason = Some("stream_error".to_string());
+                    truncated = true;
                     tool_acc.clear();
                     break;
                 }
@@ -284,11 +311,23 @@ fn assemble_sse_stream(
         .collect();
     ensure_tool_call_ids(&mut tool_calls);
 
+    // No-usable-content guard (parity with the non-streaming `parse_response_value`
+    // "no choices" check): a stream that yielded no content, no tool calls, no
+    // finish_reason, and wasn't truncated never saw a valid choice — most likely
+    // an error-shaped 200 (`data:{"error":...}`). Surface it instead of a silent
+    // empty answer.
+    if content.is_empty() && tool_calls.is_empty() && finish_reason.is_none() && !truncated {
+        return Err(AppError::new(
+            "streaming response contained no completion (possible upstream error)",
+        ));
+    }
+
     Ok(ChatResponse {
         content,
         tool_calls,
         model,
         finish_reason,
+        truncated,
     })
 }
 
@@ -433,7 +472,7 @@ mod tests {
         ]);
         let resp = resp.expect("partial content should be salvaged, not error");
         assert_eq!(resp.content, "Hello world");
-        assert_eq!(resp.finish_reason.as_deref(), Some("stream_error"));
+        assert!(resp.truncated);
         assert!(resp.tool_calls.is_empty());
         assert_eq!(deltas, vec!["Hello".to_string(), " world".to_string()]);
     }
@@ -457,7 +496,7 @@ mod tests {
         ]);
         let resp = resp.expect("normal completion should succeed");
         assert_eq!(resp.content, "Hello world");
-        assert_ne!(resp.finish_reason.as_deref(), Some("stream_error"));
+        assert!(!resp.truncated);
         assert!(resp.tool_calls.is_empty());
         assert_eq!(deltas, vec!["Hello".to_string(), " world".to_string()]);
     }
@@ -476,6 +515,49 @@ mod tests {
             resp.tool_calls.is_empty(),
             "an interrupted tool call must be dropped"
         );
-        assert_eq!(resp.finish_reason.as_deref(), Some("stream_error"));
+        assert!(resp.truncated);
+    }
+
+    #[test]
+    fn complete_tool_call_then_drop_is_not_truncated() {
+        // The model sends a COMPLETE tool call plus `finish_reason:"tool_calls"`,
+        // then the connection drops before `[DONE]`. The response is already
+        // complete, so the drop must not truncate it or discard the tool call.
+        let complete_tool_delta = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\
+            \"id\":\"call_abc\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{}\"}}]},\
+            \"finish_reason\":\"tool_calls\"}]}";
+        let (resp, _deltas) = run_stream(vec![
+            Ok(Some(complete_tool_delta.to_string())),
+            Err(AppError::new("error decoding response body")),
+        ]);
+        let resp = resp.expect("a completed response should survive a trailing drop");
+        assert!(
+            !resp.truncated,
+            "a completed response must not be truncated"
+        );
+        assert_eq!(resp.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(
+            resp.tool_calls.len(),
+            1,
+            "a completed tool call must be preserved"
+        );
+        assert_eq!(resp.tool_calls[0].function.name, "read_file");
+    }
+
+    #[test]
+    fn error_shaped_stream_with_no_choices_errors() {
+        // A 200 that carries only an error-shaped payload (no valid choice /
+        // finish_reason) then ends: nothing usable was produced, so surface an
+        // error rather than a silent empty `Ok`.
+        let (resp, _deltas) = run_stream(vec![
+            Ok(Some(
+                "data: {\"error\":{\"message\":\"upstream boom\"}}".to_string(),
+            )),
+            Ok(None),
+        ]);
+        assert!(
+            resp.is_err(),
+            "a stream with no usable completion should error"
+        );
     }
 }

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -187,6 +187,111 @@ struct ToolCallAcc {
     arguments: String,
 }
 
+/// Assemble a `ChatResponse` from an OpenAI-compatible SSE stream, calling
+/// `next_line` to pull each raw line and emitting content deltas via `on_delta`.
+///
+/// Read-error handling — graceful partial-output on a mid-stream drop
+/// (monocle-cli#59): when `next_line` yields `Err`, if anything usable has
+/// already been received (`content` non-empty OR a tool call has been started)
+/// the stream is treated as **truncated-but-usable** — `finish_reason` is set to
+/// `"stream_error"`, any in-progress tool calls are **dropped** (a tool call cut
+/// off mid-stream is unreliable, so the caller gets clean partial text instead of
+/// a malformed call), and the loop ends. Only when nothing has been received is
+/// the error propagated (a genuine connection failure with nothing to salvage).
+fn assemble_sse_stream(
+    mut next_line: impl FnMut() -> Result<Option<String>>,
+    on_delta: &mut dyn FnMut(&str),
+) -> Result<ChatResponse> {
+    let mut content = String::new();
+    let mut finish_reason: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
+
+    loop {
+        let raw = match next_line() {
+            Ok(Some(raw)) => raw,
+            Ok(None) => break,
+            Err(e) => {
+                // Salvage a truncated-but-usable response if anything arrived.
+                if !content.is_empty() || !tool_acc.is_empty() {
+                    finish_reason = Some("stream_error".to_string());
+                    tool_acc.clear();
+                    break;
+                }
+                return Err(e);
+            }
+        };
+        let data = match raw.trim_end().strip_prefix("data:") {
+            Some(d) => d.trim_start().to_string(),
+            None => continue,
+        };
+        if data == "[DONE]" {
+            break;
+        }
+        let v: Value = match serde_json::from_str(&data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if model.is_none() {
+            model = v["model"].as_str().map(String::from);
+        }
+        let choice = &v["choices"][0];
+        if let Some(fr) = choice["finish_reason"].as_str() {
+            finish_reason = Some(fr.to_string());
+        }
+        let delta = &choice["delta"];
+        if let Some(c) = delta["content"].as_str() {
+            if !c.is_empty() {
+                content.push_str(c);
+                on_delta(c);
+            }
+        }
+        if let Some(tcs) = delta["tool_calls"].as_array() {
+            for tc in tcs {
+                let idx = tc["index"].as_u64().unwrap_or(0) as usize;
+                while tool_acc.len() <= idx {
+                    tool_acc.push(ToolCallAcc::default());
+                }
+                let acc = &mut tool_acc[idx];
+                if let Some(id) = tc["id"].as_str() {
+                    if !id.is_empty() {
+                        acc.id = id.to_string();
+                    }
+                }
+                if let Some(name) = tc["function"]["name"].as_str() {
+                    if !name.is_empty() {
+                        acc.name = name.to_string();
+                    }
+                }
+                if let Some(args) = tc["function"]["arguments"].as_str() {
+                    acc.arguments.push_str(args);
+                }
+            }
+        }
+    }
+
+    let mut tool_calls: Vec<ToolCall> = tool_acc
+        .into_iter()
+        .filter(|a| !a.name.is_empty())
+        .map(|a| ToolCall {
+            id: a.id,
+            kind: "function".to_string(),
+            function: FunctionCall {
+                name: a.name,
+                arguments: a.arguments,
+            },
+        })
+        .collect();
+    ensure_tool_call_ids(&mut tool_calls);
+
+    Ok(ChatResponse {
+        content,
+        tool_calls,
+        model,
+        finish_reason,
+    })
+}
+
 /// The seam the agent loop is built on. Any backend (monocle-routed today, a
 /// direct provider tomorrow) implements this; the loop never names a vendor.
 pub trait LlmProvider {
@@ -292,81 +397,85 @@ impl LlmProvider for MonocleProvider {
             return Ok(resp);
         }
 
-        // SSE: assemble content + tool calls from `data:` deltas.
-        let mut content = String::new();
-        let mut finish_reason: Option<String> = None;
-        let mut model: Option<String> = None;
-        let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
+        // SSE: assemble content + tool calls from `data:` deltas. A mid-stream
+        // read error is salvaged into a truncated response (see the fn's docs).
+        assemble_sse_stream(|| stream.next_line(), on_delta)
+    }
+}
 
-        while let Some(raw) = stream.next_line()? {
-            let data = match raw.trim_end().strip_prefix("data:") {
-                Some(d) => d.trim_start().to_string(),
-                None => continue,
-            };
-            if data == "[DONE]" {
-                break;
-            }
-            let v: Value = match serde_json::from_str(&data) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            if model.is_none() {
-                model = v["model"].as_str().map(String::from);
-            }
-            let choice = &v["choices"][0];
-            if let Some(fr) = choice["finish_reason"].as_str() {
-                finish_reason = Some(fr.to_string());
-            }
-            let delta = &choice["delta"];
-            if let Some(c) = delta["content"].as_str() {
-                if !c.is_empty() {
-                    content.push_str(c);
-                    on_delta(c);
-                }
-            }
-            if let Some(tcs) = delta["tool_calls"].as_array() {
-                for tc in tcs {
-                    let idx = tc["index"].as_u64().unwrap_or(0) as usize;
-                    while tool_acc.len() <= idx {
-                        tool_acc.push(ToolCallAcc::default());
-                    }
-                    let acc = &mut tool_acc[idx];
-                    if let Some(id) = tc["id"].as_str() {
-                        if !id.is_empty() {
-                            acc.id = id.to_string();
-                        }
-                    }
-                    if let Some(name) = tc["function"]["name"].as_str() {
-                        if !name.is_empty() {
-                            acc.name = name.to_string();
-                        }
-                    }
-                    if let Some(args) = tc["function"]["arguments"].as_str() {
-                        acc.arguments.push_str(args);
-                    }
-                }
-            }
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let mut tool_calls: Vec<ToolCall> = tool_acc
-            .into_iter()
-            .filter(|a| !a.name.is_empty())
-            .map(|a| ToolCall {
-                id: a.id,
-                kind: "function".to_string(),
-                function: FunctionCall {
-                    name: a.name,
-                    arguments: a.arguments,
-                },
-            })
-            .collect();
-        ensure_tool_call_ids(&mut tool_calls);
+    /// Drive `assemble_sse_stream` from a fixed script of `next_line` outcomes,
+    /// capturing every content delta the callback observed.
+    fn run_stream(script: Vec<Result<Option<String>>>) -> (Result<ChatResponse>, Vec<String>) {
+        let mut it = script.into_iter();
+        let mut deltas: Vec<String> = Vec::new();
+        let resp = assemble_sse_stream(|| it.next().unwrap_or(Ok(None)), &mut |d| {
+            deltas.push(d.to_string())
+        });
+        (resp, deltas)
+    }
 
-        Ok(ChatResponse {
-            content,
-            tool_calls,
-            model,
-            finish_reason,
-        })
+    fn content_line(text: &str) -> Result<Option<String>> {
+        Ok(Some(format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"content\":\"{text}\"}}}}]}}"
+        )))
+    }
+
+    #[test]
+    fn mid_stream_drop_preserves_partial() {
+        let (resp, deltas) = run_stream(vec![
+            content_line("Hello"),
+            content_line(" world"),
+            Err(AppError::new("error decoding response body")),
+        ]);
+        let resp = resp.expect("partial content should be salvaged, not error");
+        assert_eq!(resp.content, "Hello world");
+        assert_eq!(resp.finish_reason.as_deref(), Some("stream_error"));
+        assert!(resp.tool_calls.is_empty());
+        assert_eq!(deltas, vec!["Hello".to_string(), " world".to_string()]);
+    }
+
+    #[test]
+    fn immediate_error_propagates() {
+        let (resp, _deltas) = run_stream(vec![Err(AppError::new("error decoding response body"))]);
+        assert!(
+            resp.is_err(),
+            "an error before any content should propagate"
+        );
+    }
+
+    #[test]
+    fn normal_completion_assembles_content() {
+        let (resp, deltas) = run_stream(vec![
+            content_line("Hello"),
+            content_line(" world"),
+            Ok(Some("data: [DONE]".to_string())),
+            Ok(None),
+        ]);
+        let resp = resp.expect("normal completion should succeed");
+        assert_eq!(resp.content, "Hello world");
+        assert_ne!(resp.finish_reason.as_deref(), Some("stream_error"));
+        assert!(resp.tool_calls.is_empty());
+        assert_eq!(deltas, vec!["Hello".to_string(), " world".to_string()]);
+    }
+
+    #[test]
+    fn truncation_mid_tool_call_drops_the_tool_call() {
+        // A partial tool_call delta (name + start of arguments), then a drop.
+        let tool_delta = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\
+            \"id\":\"call_abc\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"pa\"}}]}}]}";
+        let (resp, _deltas) = run_stream(vec![
+            Ok(Some(tool_delta.to_string())),
+            Err(AppError::new("error decoding response body")),
+        ]);
+        let resp = resp.expect("a started tool call should salvage as partial, not error");
+        assert!(
+            resp.tool_calls.is_empty(),
+            "an interrupted tool call must be dropped"
+        );
+        assert_eq!(resp.finish_reason.as_deref(), Some("stream_error"));
     }
 }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -164,6 +164,15 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 .provider
                 .chat_stream(&req, &mut |delta| observer.on_text_delta(delta))?;
 
+            // A mid-stream drop was salvaged into a truncated response
+            // (monocle-cli#59): tool_calls are already dropped, so this falls
+            // into the EndTurn path below — just surface a notice. The partial
+            // `resp.content` is appended there like any final answer, so a
+            // `--session` resume keeps it (no separate append needed).
+            if resp.finish_reason.as_deref() == Some("stream_error") {
+                observer.on_notice("[generation was cut short — showing partial output]");
+            }
+
             // No tool calls → this is the final answer (already streamed to the
             // observer; appended to the conversation for multi-turn callers).
             if resp.tool_calls.is_empty() {

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -169,7 +169,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             // into the EndTurn path below — just surface a notice. The partial
             // `resp.content` is appended there like any final answer, so a
             // `--session` resume keeps it (no separate append needed).
-            if resp.finish_reason.as_deref() == Some("stream_error") {
+            if resp.truncated {
                 observer.on_notice("[generation was cut short — showing partial output]");
             }
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -47,11 +47,16 @@ fn call_chat(
         max_tokens,
         ..Default::default()
     };
-    provider.chat_stream(&req, &mut |delta| {
+    let resp = provider.chat_stream(&req, &mut |delta| {
         let mut out = std::io::stdout();
         let _ = out.write_all(delta.as_bytes());
         let _ = out.flush();
     })?;
+    // A mid-stream drop was salvaged into partial output (monocle-cli#59): stdout
+    // already holds the partial text, so the notice goes to stderr.
+    if resp.finish_reason.as_deref() == Some("stream_error") {
+        eprintln!("\n⚠ 응답이 중간에 끊겼습니다 (부분 출력).");
+    }
     Ok(())
 }
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -11,8 +11,6 @@ use crate::error::Result;
 use crate::net::Client;
 use crate::origin::auth_headers;
 
-const DEFAULT_MAX_TOKENS: i64 = 4096;
-
 pub struct ChatOptions {
     pub model: Option<String>,
     pub system_prompt: Option<String>,
@@ -20,27 +18,41 @@ pub struct ChatOptions {
     pub max_tokens: Option<String>,
 }
 
-/// One non-streaming chat turn via the shared provider (chat-proxy routing).
+/// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
+/// only when the flag was passed AND parses as an integer; otherwise `None`, so
+/// the request omits `max_tokens` and the router/model uses its own (higher,
+/// model-appropriate) default.
+fn resolve_max_tokens(flag: Option<&str>) -> Option<i64> {
+    flag.and_then(|s| s.trim().parse::<i64>().ok())
+}
+
+/// One streaming chat turn via the shared provider (chat-proxy routing): assistant
+/// text deltas are written to stdout (and flushed) as they arrive.
 fn call_chat(
     provider: &MonocleProvider,
     model: &str,
     system_prompt: Option<&str>,
     user_message: &str,
-    max_tokens: i64,
-) -> Result<String> {
+    max_tokens: Option<i64>,
+) -> Result<()> {
     let mut messages = Vec::new();
     if let Some(sp) = system_prompt {
         messages.push(Message::system(sp));
     }
     messages.push(Message::user(user_message));
 
-    let resp = provider.chat(&ChatRequest {
+    let req = ChatRequest {
         model: model.to_string(),
         messages,
-        max_tokens: Some(max_tokens),
+        max_tokens,
         ..Default::default()
+    };
+    provider.chat_stream(&req, &mut |delta| {
+        let mut out = std::io::stdout();
+        let _ = out.write_all(delta.as_bytes());
+        let _ = out.flush();
     })?;
-    Ok(resp.content)
+    Ok(())
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
@@ -49,11 +61,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         .as_deref()
         .unwrap_or(DEFAULT_MODEL)
         .to_string();
-    let max_tokens = options
-        .max_tokens
-        .as_deref()
-        .and_then(|s| s.trim().parse::<i64>().ok())
-        .unwrap_or(DEFAULT_MAX_TOKENS);
+    let max_tokens = resolve_max_tokens(options.max_tokens.as_deref());
 
     // Resolve system prompt.
     let system_prompt: Option<String> = if let Some(path) = &options.system_prompt_file {
@@ -111,7 +119,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         }
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
-        let result = call_chat(
+        call_chat(
             &provider,
             &model,
             system_prompt.as_deref(),
@@ -119,8 +127,8 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             max_tokens,
         )?;
         let mut out = std::io::stdout();
-        out.write_all(result.as_bytes())?;
         out.write_all(b"\n")?;
+        out.flush()?;
         return Ok(());
     }
 
@@ -162,9 +170,8 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             trimmed,
             max_tokens,
         ) {
-            Ok(result) => {
+            Ok(()) => {
                 let mut out = std::io::stdout();
-                out.write_all(result.as_bytes())?;
                 out.write_all(b"\n\n")?;
                 out.flush()?;
             }
@@ -173,4 +180,27 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_max_tokens;
+
+    #[test]
+    fn absent_flag_omits() {
+        assert_eq!(resolve_max_tokens(None), None);
+    }
+
+    #[test]
+    fn valid_integer_is_used() {
+        assert_eq!(resolve_max_tokens(Some("8000")), Some(8000));
+        // Surrounding whitespace is tolerated.
+        assert_eq!(resolve_max_tokens(Some("  4096 ")), Some(4096));
+    }
+
+    #[test]
+    fn unparseable_flag_omits() {
+        assert_eq!(resolve_max_tokens(Some("x")), None);
+        assert_eq!(resolve_max_tokens(Some("")), None);
+    }
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -19,11 +19,14 @@ pub struct ChatOptions {
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
-/// only when the flag was passed AND parses as an integer; otherwise `None`, so
-/// the request omits `max_tokens` and the router/model uses its own (higher,
-/// model-appropriate) default.
+/// only when the flag was passed AND parses as a **positive** integer; otherwise
+/// `None`, so the request omits `max_tokens` and the router/model uses its own
+/// (higher, model-appropriate) default. Pure: a present-but-invalid flag is
+/// detectable by the caller as `flag.is_some() && resolve_max_tokens(flag) ==
+/// None`, which is where the user-facing warning is emitted.
 fn resolve_max_tokens(flag: Option<&str>) -> Option<i64> {
     flag.and_then(|s| s.trim().parse::<i64>().ok())
+        .filter(|&n| n > 0)
 }
 
 /// One streaming chat turn via the shared provider (chat-proxy routing): assistant
@@ -47,14 +50,17 @@ fn call_chat(
         max_tokens,
         ..Default::default()
     };
+    // Acquire the stdout lock once for the whole stream rather than per token —
+    // the closure writes+flushes to this single handle (per-delta flush keeps the
+    // output live).
+    let mut out = std::io::stdout().lock();
     let resp = provider.chat_stream(&req, &mut |delta| {
-        let mut out = std::io::stdout();
         let _ = out.write_all(delta.as_bytes());
         let _ = out.flush();
     })?;
     // A mid-stream drop was salvaged into partial output (monocle-cli#59): stdout
     // already holds the partial text, so the notice goes to stderr.
-    if resp.finish_reason.as_deref() == Some("stream_error") {
+    if resp.truncated {
         eprintln!("\n⚠ 응답이 중간에 끊겼습니다 (부분 출력).");
     }
     Ok(())
@@ -66,7 +72,16 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         .as_deref()
         .unwrap_or(DEFAULT_MODEL)
         .to_string();
-    let max_tokens = resolve_max_tokens(options.max_tokens.as_deref());
+    let max_tokens_flag = options.max_tokens.as_deref();
+    let max_tokens = resolve_max_tokens(max_tokens_flag);
+    // The flag was given but didn't resolve to a positive integer — warn (to
+    // stderr) rather than silently omitting it, so a typo isn't mistaken for the
+    // model's default limit.
+    if let Some(raw) = max_tokens_flag {
+        if max_tokens.is_none() {
+            eprintln!("⚠ --max-tokens '{raw}' 무시됨 (양의 정수 필요)");
+        }
+    }
 
     // Resolve system prompt.
     let system_prompt: Option<String> = if let Some(path) = &options.system_prompt_file {
@@ -207,5 +222,13 @@ mod tests {
     fn unparseable_flag_omits() {
         assert_eq!(resolve_max_tokens(Some("x")), None);
         assert_eq!(resolve_max_tokens(Some("")), None);
+    }
+
+    #[test]
+    fn non_positive_flag_omits() {
+        // Present but not a positive integer → None (caller warns).
+        assert_eq!(resolve_max_tokens(Some("0")), None);
+        assert_eq!(resolve_max_tokens(Some("-1")), None);
+        assert_eq!(resolve_max_tokens(Some("  -42 ")), None);
     }
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -61,7 +61,7 @@ fn call_chat(
     // A mid-stream drop was salvaged into partial output (monocle-cli#59): stdout
     // already holds the partial text, so the notice goes to stderr.
     if resp.truncated {
-        eprintln!("\n⚠ 응답이 중간에 끊겼습니다 (부분 출력).");
+        eprintln!("\n⚠ the response was cut short (partial output shown).");
     }
     Ok(())
 }
@@ -79,7 +79,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     // model's default limit.
     if let Some(raw) = max_tokens_flag {
         if max_tokens.is_none() {
-            eprintln!("⚠ --max-tokens '{raw}' 무시됨 (양의 정수 필요)");
+            eprintln!("⚠ ignoring --max-tokens '{raw}' (a positive integer is required)");
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod setup;
 pub mod status;
 pub mod token;
 pub mod unset;
+pub mod upgrade;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -24,7 +24,7 @@ pub fn status_command(creds: &Credentials, home: &Path) {
     let creds = match creds.read() {
         Some(c) => c,
         None => {
-            eprintln!("Not logged in.");
+            eprintln!("Not logged in. Run `monocle login --tenant <domain>` first.");
             return;
         }
     };

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,0 +1,255 @@
+//! `monocle upgrade [--check]` — self-update from GitHub Releases.
+//!
+//! Downloads the prebuilt binary for the current platform and swaps it in place
+//! over the running executable. The platform→asset mapping is the same contract
+//! as `install.sh`. All network I/O goes through the `net.rs` facade (the same
+//! `client.get` used everywhere else) — both the GitHub API call and the asset
+//! download — so no second HTTP client sneaks in.
+
+use std::io::Write;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::net::Client;
+
+const REPO: &str = "warmblood-kr/monocle-cli";
+const BINARY: &str = "monocle";
+
+#[derive(Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+}
+
+/// Map (`std::env::consts::OS`, `std::env::consts::ARCH`) → the release asset
+/// platform string, matching `install.sh` exactly. macOS Intel is intentionally
+/// unsupported (no prebuilt binary is shipped).
+fn asset_platform(os: &str, arch: &str) -> Result<&'static str> {
+    match (os, arch) {
+        ("macos", "aarch64") => Ok("macos-arm64"),
+        ("macos", "x86_64") => Err(AppError::new(
+            "macOS Intel is not shipped as a prebuilt binary — build from source",
+        )),
+        ("linux", "x86_64") => Ok("linux-x64"),
+        ("linux", "aarch64") => Ok("linux-arm64"),
+        ("windows", "x86_64") => Ok("windows-x64"),
+        _ => Err(AppError::new(format!("unsupported platform: {os}/{arch}"))),
+    }
+}
+
+/// The release asset filename for a platform: `.tar.gz` on unix, `.zip` on
+/// windows (matches `install.sh`).
+fn asset_filename(platform: &str) -> String {
+    if platform.starts_with("windows") {
+        format!("{BINARY}-{platform}.zip")
+    } else {
+        format!("{BINARY}-{platform}.tar.gz")
+    }
+}
+
+/// The GitHub Releases download URL for `<vTAG>/<asset>`.
+fn download_url(tag: &str, asset: &str) -> String {
+    format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
+}
+
+/// Whether `latest` is a strictly newer semver than `current`. Any unparseable
+/// version is treated as "not newer" (a safe no-op rather than a bad upgrade).
+fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(cur), Ok(lat)) => lat > cur,
+        _ => false,
+    }
+}
+
+/// Extract the `monocle` binary from the downloaded archive into `temp_path`.
+/// cfg-gated: gzip+tar on unix, zip on windows.
+#[cfg(unix)]
+fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
+    use std::io::Read;
+
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let is_target = entry
+            .path()?
+            .file_name()
+            .map(|n| n == BINARY)
+            .unwrap_or(false);
+        if !is_target {
+            continue;
+        }
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf)?;
+        std::fs::write(temp_path, &buf)?;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(temp_path, std::fs::Permissions::from_mode(0o755))?;
+        return Ok(());
+    }
+    Err(AppError::new(format!(
+        "archive did not contain a `{BINARY}` binary"
+    )))
+}
+
+/// Extract the `monocle.exe` binary from the downloaded zip into `temp_path`.
+#[cfg(windows)]
+fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
+    use std::io::Read;
+
+    let reader = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(reader).map_err(|e| AppError::new(e.to_string()))?;
+    let target = format!("{BINARY}.exe");
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| AppError::new(e.to_string()))?;
+        let matches = Path::new(file.name())
+            .file_name()
+            .map(|n| n == target.as_str())
+            .unwrap_or(false);
+        if !matches {
+            continue;
+        }
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+        std::fs::write(temp_path, &buf)?;
+        return Ok(());
+    }
+    Err(AppError::new(format!(
+        "archive did not contain a `{target}` binary"
+    )))
+}
+
+pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
+    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
+    let current = env!("CARGO_PKG_VERSION");
+
+    eprintln!("Checking for updates ({platform})...");
+
+    let resp = client.get(
+        &format!("https://api.github.com/repos/{REPO}/releases/latest"),
+        &[
+            ("User-Agent", "monocle-cli"),
+            ("Accept", "application/vnd.github+json"),
+        ],
+    )?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "GitHub API error {}: {}",
+            resp.status,
+            resp.text()
+        )));
+    }
+    let tag = resp.json::<LatestRelease>()?.tag_name;
+    let latest = tag.strip_prefix('v').unwrap_or(&tag).to_string();
+
+    if check_only {
+        let mut out = std::io::stdout();
+        writeln!(out, "current: v{current} / latest: v{latest}")?;
+        if is_newer(current, &latest) {
+            writeln!(out, "An upgrade is available: run `monocle upgrade`.")?;
+        } else {
+            writeln!(out, "You are on the latest version.")?;
+        }
+        return Ok(());
+    }
+
+    if !is_newer(current, &latest) {
+        println!("Already on the latest version (v{current}).");
+        return Ok(());
+    }
+
+    let asset = asset_filename(platform);
+    let url = download_url(&tag, &asset);
+    eprintln!("Downloading {asset} (v{latest})...");
+
+    let resp = client.get(&url, &[("User-Agent", "monocle-cli")])?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "download failed {}: {}",
+            resp.status, url
+        )));
+    }
+    let bytes = resp.bytes();
+
+    let temp_name = if cfg!(windows) {
+        format!("monocle-upgrade-{}.exe", std::process::id())
+    } else {
+        format!("monocle-upgrade-{}", std::process::id())
+    };
+    let temp_path = std::env::temp_dir().join(temp_name);
+
+    eprintln!("Extracting...");
+    extract_binary(bytes, &temp_path)?;
+
+    eprintln!("Replacing the running binary...");
+    self_replace::self_replace(&temp_path).map_err(|e| AppError::new(e.to_string()))?;
+    let _ = std::fs::remove_file(&temp_path);
+
+    let location = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "the current executable".to_string());
+    println!("Upgraded monocle v{current} → v{latest} ({location}).");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_platform_maps_supported_targets() {
+        assert_eq!(asset_platform("macos", "aarch64").unwrap(), "macos-arm64");
+        assert_eq!(asset_platform("linux", "x86_64").unwrap(), "linux-x64");
+        assert_eq!(asset_platform("linux", "aarch64").unwrap(), "linux-arm64");
+        assert_eq!(asset_platform("windows", "x86_64").unwrap(), "windows-x64");
+    }
+
+    #[test]
+    fn asset_platform_rejects_macos_intel() {
+        let err = asset_platform("macos", "x86_64").unwrap_err();
+        assert!(
+            err.to_string().contains("macOS Intel"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn asset_platform_rejects_unknown() {
+        assert!(asset_platform("linux", "riscv64").is_err());
+        assert!(asset_platform("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn is_newer_compares_semver() {
+        assert!(!is_newer("1.1.0", "1.1.0"));
+        assert!(is_newer("1.1.0", "1.2.0"));
+        assert!(!is_newer("1.1.0", "1.0.9"));
+        assert!(is_newer("1.1.0", "2.0.0"));
+    }
+
+    #[test]
+    fn is_newer_is_false_for_garbage() {
+        assert!(!is_newer("not-a-version", "1.0.0"));
+        assert!(!is_newer("1.0.0", "not-a-version"));
+    }
+
+    #[test]
+    fn asset_filename_matches_install_sh() {
+        assert_eq!(asset_filename("linux-x64"), "monocle-linux-x64.tar.gz");
+        assert_eq!(asset_filename("macos-arm64"), "monocle-macos-arm64.tar.gz");
+        assert_eq!(asset_filename("windows-x64"), "monocle-windows-x64.zip");
+    }
+
+    #[test]
+    fn download_url_uses_v_prefixed_tag() {
+        assert_eq!(
+            download_url("v1.2.0", "monocle-linux-x64.tar.gz"),
+            "https://github.com/warmblood-kr/monocle-cli/releases/download/v1.2.0/monocle-linux-x64.tar.gz"
+        );
+    }
+}

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -203,7 +203,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
                     "current=v{current} latest=v{latest} upgrade_available=unknown"
                 )?;
                 eprintln!(
-                    "⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다."
+                    "⚠ could not parse release tag '{latest}'; unable to determine whether an update is available."
                 );
             }
         }
@@ -214,7 +214,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
         None => {
             // Don't falsely claim up-to-date and don't blindly replace on an
             // unparseable tag — warn and abort.
-            eprintln!("⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다.");
+            eprintln!("⚠ could not parse release tag '{latest}'; unable to determine whether an update is available.");
             return Err(AppError::new(format!(
                 "could not parse release tag '{latest}' as semver"
             )));

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -2,9 +2,10 @@
 //!
 //! Downloads the prebuilt binary for the current platform and swaps it in place
 //! over the running executable. The platform→asset mapping is the same contract
-//! as `install.sh`. All network I/O goes through the `net.rs` facade (the same
-//! `client.get` used everywhere else) — both the GitHub API call and the asset
-//! download — so no second HTTP client sneaks in.
+//! as `install.sh`. All network I/O goes through the `net.rs` facade — the
+//! GitHub API call via `client.get`, and the (potentially large) asset download
+//! via `client.get_download` (a generous-timeout path that won't inherit the
+//! shared API timeout) — so no second HTTP client sneaks in.
 
 use std::io::Write;
 use std::path::Path;
@@ -53,15 +54,17 @@ fn download_url(tag: &str, asset: &str) -> String {
     format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
 }
 
-/// Whether `latest` is a strictly newer semver than `current`. Any unparseable
-/// version is treated as "not newer" (a safe no-op rather than a bad upgrade).
-fn is_newer(current: &str, latest: &str) -> bool {
+/// Compare `current` against `latest` as semver. Returns `None` if EITHER string
+/// fails to parse — so the caller can distinguish "definitely not newer" from
+/// "can't tell" (e.g. a non-semver release tag) instead of silently no-op'ing.
+/// `Ordering::Less` means `current < latest` (an upgrade is available).
+fn compare_versions(current: &str, latest: &str) -> Option<std::cmp::Ordering> {
     match (
         semver::Version::parse(current),
         semver::Version::parse(latest),
     ) {
-        (Ok(cur), Ok(lat)) => lat > cur,
-        _ => false,
+        (Ok(cur), Ok(lat)) => Some(cur.cmp(&lat)),
+        _ => None,
     }
 }
 
@@ -69,23 +72,24 @@ fn is_newer(current: &str, latest: &str) -> bool {
 /// cfg-gated: gzip+tar on unix, zip on windows.
 #[cfg(unix)]
 fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
-    use std::io::Read;
-
     let decoder = flate2::read::GzDecoder::new(bytes);
     let mut archive = tar::Archive::new(decoder);
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let is_target = entry
+        // Accept only a *regular file* named `monocle` — never a directory entry
+        // or other odd layout, which would otherwise yield a 0-byte install.
+        let is_file = entry.header().entry_type().is_file();
+        let is_named = entry
             .path()?
             .file_name()
             .map(|n| n == BINARY)
             .unwrap_or(false);
-        if !is_target {
+        if !(is_file && is_named) {
             continue;
         }
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
-        std::fs::write(temp_path, &buf)?;
+        // Stream the entry straight to disk (no second full-size in-memory copy).
+        let mut out = std::fs::File::create(temp_path)?;
+        std::io::copy(&mut entry, &mut out)?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(temp_path, std::fs::Permissions::from_mode(0o755))?;
         return Ok(());
@@ -98,8 +102,6 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
 /// Extract the `monocle.exe` binary from the downloaded zip into `temp_path`.
 #[cfg(windows)]
 fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
-    use std::io::Read;
-
     let reader = std::io::Cursor::new(bytes);
     let mut archive = zip::ZipArchive::new(reader).map_err(|e| AppError::new(e.to_string()))?;
     let target = format!("{BINARY}.exe");
@@ -107,6 +109,11 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
         let mut file = archive
             .by_index(i)
             .map_err(|e| AppError::new(e.to_string()))?;
+        // Accept only a *file* entry named `monocle.exe` — skip directory entries
+        // so an odd archive layout can't produce a 0-byte install.
+        if file.is_dir() {
+            continue;
+        }
         let matches = Path::new(file.name())
             .file_name()
             .map(|n| n == target.as_str())
@@ -114,9 +121,9 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
         if !matches {
             continue;
         }
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)?;
-        std::fs::write(temp_path, &buf)?;
+        // Stream the entry straight to disk (no second full-size in-memory copy).
+        let mut out = std::fs::File::create(temp_path)?;
+        std::io::copy(&mut file, &mut out)?;
         return Ok(());
     }
     Err(AppError::new(format!(
@@ -124,11 +131,34 @@ fn extract_binary(bytes: &[u8], temp_path: &Path) -> Result<()> {
     )))
 }
 
+/// Map a `self_replace` failure to an actionable message. A permission error
+/// almost always means the binary lives in a root-owned, system-wide install dir
+/// (e.g. install.sh's sudo fallback to `/usr/local/bin`), so tell the user how to
+/// recover instead of surfacing a raw `Permission denied (os error 13)`.
+fn map_self_replace_error(e: std::io::Error) -> AppError {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        let exe = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "the current executable".to_string());
+        AppError::new(format!(
+            "permission denied replacing {exe} — it looks installed system-wide. \
+             Re-run with elevated privileges (e.g. sudo) or reinstall to a \
+             user-writable location. ({e})"
+        ))
+    } else {
+        AppError::new(e.to_string())
+    }
+}
+
 pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
-    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
+    use std::cmp::Ordering;
+
     let current = env!("CARGO_PKG_VERSION");
 
-    eprintln!("Checking for updates ({platform})...");
+    // Checking for updates needs no downloadable asset, so it must work on every
+    // platform (incl. unsupported ones like macOS Intel). `asset_platform()` is
+    // only consulted later, on the actual download path.
+    eprintln!("Checking for updates...");
 
     let resp = client.get(
         &format!("https://api.github.com/repos/{REPO}/releases/latest"),
@@ -147,27 +177,65 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
     let tag = resp.json::<LatestRelease>()?.tag_name;
     let latest = tag.strip_prefix('v').unwrap_or(&tag).to_string();
 
+    let ordering = compare_versions(current, &latest);
+
     if check_only {
+        // Data lines (machine-parseable) go to stdout; prose to stderr.
         let mut out = std::io::stdout();
-        writeln!(out, "current: v{current} / latest: v{latest}")?;
-        if is_newer(current, &latest) {
-            writeln!(out, "An upgrade is available: run `monocle upgrade`.")?;
-        } else {
-            writeln!(out, "You are on the latest version.")?;
+        match ordering {
+            Some(Ordering::Less) => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=true"
+                )?;
+                eprintln!("An upgrade is available: run `monocle upgrade`.");
+            }
+            Some(_) => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=false"
+                )?;
+                eprintln!("You are on the latest version.");
+            }
+            None => {
+                writeln!(
+                    out,
+                    "current=v{current} latest=v{latest} upgrade_available=unknown"
+                )?;
+                eprintln!(
+                    "⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다."
+                );
+            }
         }
         return Ok(());
     }
 
-    if !is_newer(current, &latest) {
-        println!("Already on the latest version (v{current}).");
-        return Ok(());
+    match ordering {
+        None => {
+            // Don't falsely claim up-to-date and don't blindly replace on an
+            // unparseable tag — warn and abort.
+            eprintln!("⚠ 릴리스 태그 '{latest}'를 해석할 수 없어 최신 여부를 판단할 수 없습니다.");
+            return Err(AppError::new(format!(
+                "could not parse release tag '{latest}' as semver"
+            )));
+        }
+        Some(Ordering::Less) => { /* an upgrade is available — proceed */ }
+        Some(_) => {
+            eprintln!("Already on the latest version (v{current}).");
+            return Ok(());
+        }
     }
 
+    // Only now — on the actual download path — do we need a downloadable asset,
+    // so this is where an unsupported platform legitimately errors out.
+    let platform = asset_platform(std::env::consts::OS, std::env::consts::ARCH)?;
     let asset = asset_filename(platform);
     let url = download_url(&tag, &asset);
     eprintln!("Downloading {asset} (v{latest})...");
 
-    let resp = client.get(&url, &[("User-Agent", "monocle-cli")])?;
+    // Use the dedicated download path: a multi-MB binary on a slow link must not
+    // inherit the shared `send()`'s short total API timeout.
+    let resp = client.get_download(&url, &[("User-Agent", "monocle-cli")])?;
     if !resp.ok() {
         return Err(AppError::new(format!(
             "download failed {}: {}",
@@ -186,14 +254,29 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
     eprintln!("Extracting...");
     extract_binary(bytes, &temp_path)?;
 
+    // Safety gate: never hand self_replace an empty/missing file — that would
+    // brick the CLI (install a 0-byte binary) while printing success.
+    let valid = std::fs::metadata(&temp_path)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false);
+    if !valid {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(AppError::new(
+            "downloaded archive did not contain a valid monocle binary",
+        ));
+    }
+
     eprintln!("Replacing the running binary...");
-    self_replace::self_replace(&temp_path).map_err(|e| AppError::new(e.to_string()))?;
+    if let Err(e) = self_replace::self_replace(&temp_path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(map_self_replace_error(e));
+    }
     let _ = std::fs::remove_file(&temp_path);
 
     let location = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "the current executable".to_string());
-    println!("Upgraded monocle v{current} → v{latest} ({location}).");
+    eprintln!("Upgraded monocle v{current} → v{latest} ({location}).");
     Ok(())
 }
 
@@ -225,17 +308,23 @@ mod tests {
     }
 
     #[test]
-    fn is_newer_compares_semver() {
-        assert!(!is_newer("1.1.0", "1.1.0"));
-        assert!(is_newer("1.1.0", "1.2.0"));
-        assert!(!is_newer("1.1.0", "1.0.9"));
-        assert!(is_newer("1.1.0", "2.0.0"));
+    fn compare_versions_orders_semver() {
+        use std::cmp::Ordering;
+        // Equal.
+        assert_eq!(compare_versions("1.1.0", "1.1.0"), Some(Ordering::Equal));
+        // current < latest → an upgrade is available.
+        assert_eq!(compare_versions("1.1.0", "1.2.0"), Some(Ordering::Less));
+        assert_eq!(compare_versions("1.1.0", "2.0.0"), Some(Ordering::Less));
+        // current > latest → already ahead.
+        assert_eq!(compare_versions("1.1.0", "1.0.9"), Some(Ordering::Greater));
     }
 
     #[test]
-    fn is_newer_is_false_for_garbage() {
-        assert!(!is_newer("not-a-version", "1.0.0"));
-        assert!(!is_newer("1.0.0", "not-a-version"));
+    fn compare_versions_is_none_for_garbage() {
+        // Either side unparseable → None (can't tell), never a silent no-op.
+        assert_eq!(compare_versions("not-a-version", "1.0.0"), None);
+        assert_eq!(compare_versions("1.0.0", "not-a-version"), None);
+        assert_eq!(compare_versions("1.0.0", "latest"), None);
     }
 
     #[test]
@@ -250,6 +339,53 @@ mod tests {
         assert_eq!(
             download_url("v1.2.0", "monocle-linux-x64.tar.gz"),
             "https://github.com/warmblood-kr/monocle-cli/releases/download/v1.2.0/monocle-linux-x64.tar.gz"
+        );
+    }
+
+    #[cfg(unix)]
+    fn make_targz(entries: &[(&str, tar::EntryType, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(&mut out, flate2::Compression::fast());
+            let mut builder = tar::Builder::new(enc);
+            for (name, kind, data) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_size(data.len() as u64);
+                header.set_entry_type(*kind);
+                header.set_mode(0o755);
+                header.set_cksum();
+                builder.append(&header, *data).unwrap();
+            }
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        out
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_binary_writes_regular_file() {
+        let payload = b"#!/bin/sh\necho hi\n";
+        let archive = make_targz(&[("monocle", tar::EntryType::Regular, payload)]);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out");
+        extract_binary(&archive, &out).unwrap();
+        assert_eq!(std::fs::read(&out).unwrap(), payload);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_binary_rejects_directory_named_monocle() {
+        // A directory entry named `monocle` must NOT be accepted (it would yield a
+        // 0-byte install). Extraction must error and write nothing.
+        let archive = make_targz(&[("monocle/", tar::EntryType::Directory, b"")]);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out");
+        let err = extract_binary(&archive, &out).unwrap_err();
+        assert!(err.to_string().contains("did not contain"), "got: {err}");
+        assert!(
+            !out.exists(),
+            "no file must be created for a dir-only archive"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,9 @@ struct ChatArgs {
     /// Load system prompt from file
     #[arg(long = "system-prompt-file")]
     system_prompt_file: Option<String>,
-    /// Maximum output tokens
-    #[arg(long = "max-tokens", default_value = "4096")]
-    max_tokens: String,
+    /// Maximum output tokens (omitted by default → model/router uses its own)
+    #[arg(long = "max-tokens")]
+    max_tokens: Option<String>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -122,7 +122,7 @@ impl From<ChatArgs> for ChatOptions {
             model: Some(a.model),
             system_prompt: a.system_prompt,
             system_prompt_file: a.system_prompt_file,
-            max_tokens: Some(a.max_tokens),
+            max_tokens: a.max_tokens,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use monocle_cli::util;
 #[command(
     name = "monocle",
     version,
-    about = "CLI authentication tool for Claude Code with Stark OIDC integration"
+    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code."
 )]
 struct Cli {
     #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use monocle_cli::commands::setup::setup_command;
 use monocle_cli::commands::status::status_command;
 use monocle_cli::commands::token::token_command;
 use monocle_cli::commands::unset::unset_command;
+use monocle_cli::commands::upgrade::upgrade_command;
 use monocle_cli::credentials::Credentials;
 use monocle_cli::error::Result;
 use monocle_cli::net::Client;
@@ -97,6 +98,12 @@ enum Commands {
     Model {
         #[command(subcommand)]
         command: ModelCommands,
+    },
+    /// Update monocle to the latest release
+    Upgrade {
+        /// Only check for a newer version, don't install
+        #[arg(long)]
+        check: bool,
     },
 }
 
@@ -272,6 +279,7 @@ fn main() {
             },
         ),
         Commands::Audio { command } => run_audio(&client, &creds, command),
+        Commands::Upgrade { check } => upgrade_command(&client, check),
         Commands::Model { command } => {
             match command {
                 ModelCommands::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,50 @@ use monocle_cli::error::Result;
 use monocle_cli::net::Client;
 use monocle_cli::util;
 
+// clap 4 has no native way to group subcommands under section headings, so the
+// root command uses a custom help_template that drops the flat auto-generated
+// command list ({options} still renders flags) and prints a hand-grouped list
+// via {after-help}. Only the root sets this template, so subcommand `--help`
+// screens keep clap's default layout.
+const ROOT_HELP_TEMPLATE: &str = "\
+{about-with-newline}
+{usage-heading} {usage}{after-help}
+
+Options:
+{options}";
+
+const ROOT_HELP_COMMANDS: &str = "\
+Commands:
+  Auth & setup:
+    login    Authenticate with Stark OIDC provider
+    token    Output access token to stdout (for apiKeyHelper)
+    setup    Configure Claude Code to use Monocle authentication
+    unset    Remove Monocle configuration from Claude Code
+    status   Show authentication and configuration status
+    claude   Launch Claude Code with Monocle authentication
+
+  Chat & models:
+    chat     Chat with LLM via Monocle router (interactive REPL or pipe from stdin)
+    models   List available models from the Monocle router
+
+  Agent:
+    agent    [Experimental] Headless agent loop with tools (read/write/edit + shell)
+    acp      [Experimental] Run as an ACP agent over stdio (editors / desktop / Craft)
+
+  Audio:
+    audio    Call audio (STT / TTS) endpoints directly for debugging
+
+  Maintenance:
+    upgrade  Update monocle to the latest release
+    help     Print this message or the help of the given subcommand(s)";
+
 #[derive(Parser)]
 #[command(
     name = "monocle",
     version,
-    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code."
+    about = "Control and use Monocle AI from your terminal: log in once, then chat with models, run the agent, or integrate Claude Code.",
+    help_template = ROOT_HELP_TEMPLATE,
+    after_help = ROOT_HELP_COMMANDS
 )]
 struct Cli {
     #[command(subcommand)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -68,6 +68,9 @@ impl Client {
         // total timeout, since one would cut a long generation mid-stream.
         let inner = reqwest::blocking::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(30))
+            // TCP keepalive lets the OS surface a dead peer on the streaming path
+            // (which has no total timeout) without capping a healthy long stream.
+            .tcp_keepalive(std::time::Duration::from_secs(60))
             .build()
             .expect("failed to build HTTP client");
         Self { inner }

--- a/src/net.rs
+++ b/src/net.rs
@@ -74,6 +74,33 @@ impl Client {
         send(req)
     }
 
+    /// GET a large file download (e.g. the `monocle upgrade` release binary).
+    ///
+    /// This deliberately does NOT route through the shared `send()`: a multi-MB
+    /// binary on a slow link must not inherit the short total timeout that the
+    /// shared API path may carry (it would abort a legitimately slow transfer).
+    /// Instead it applies its own generous per-request timeout (600s).
+    pub fn get_download(&self, url: &str, headers: &[(&str, &str)]) -> Result<Resp> {
+        let mut req = self
+            .inner
+            .get(url)
+            .timeout(std::time::Duration::from_secs(600));
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        // Inline send (not the shared `send()`) so the 600s timeout above is the
+        // only cap that applies to the download.
+        let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+        let body = resp.bytes().map_err(|e| AppError(e.to_string()))?.to_vec();
+        Ok(Resp {
+            status,
+            status_text,
+            body,
+        })
+    }
+
     /// POST `application/x-www-form-urlencoded` (token / device-code requests).
     pub fn post_form(
         &self,

--- a/src/net.rs
+++ b/src/net.rs
@@ -60,7 +60,14 @@ impl Default for Client {
 
 impl Client {
     pub fn new() -> Self {
+        // Timeout split: `connect_timeout` bounds only connection establishment,
+        // so a hung/unreachable endpoint fails fast — but it does NOT limit body
+        // read time, which keeps it safe for long streaming generations. The total
+        // per-request `.timeout()` is applied only to non-streaming calls in
+        // `send()`; the streaming path (`post_json_stream`) deliberately gets no
+        // total timeout, since one would cut a long generation mid-stream.
         let inner = reqwest::blocking::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("failed to build HTTP client");
         Self { inner }
@@ -168,6 +175,10 @@ impl Client {
 }
 
 fn send(req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
+    // Total request timeout — non-streaming only (see `Client::new`). Streaming
+    // (`post_json_stream`) builds and sends its own request without this, so a
+    // long generation is never cut short.
+    let req = req.timeout(std::time::Duration::from_secs(120));
     let resp = req.send().map_err(|e| AppError(e.to_string()))?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -53,6 +53,7 @@ pub fn text_response(content: &str) -> ChatResponse {
         tool_calls: vec![],
         model: None,
         finish_reason: Some("stop".to_string()),
+        truncated: false,
     }
 }
 
@@ -76,6 +77,7 @@ pub fn tool_call_response_raw(id: &str, name: &str, arguments: &str) -> ChatResp
         }],
         model: None,
         finish_reason: Some("tool_calls".to_string()),
+        truncated: false,
     }
 }
 


### PR DESCRIPTION
v1.1.1 프로모션 (devel → main, 직행 — Rust 컷오버 정책).

포함 내용:
- **#60** net 타임아웃 + `chat` 스트리밍 + max_tokens 가변 + graceful-partial (#59)
- **#61** `monocle upgrade` 셀프 업그레이드 커맨드
- **#62** CLI DX 폴리시 — 태그라인 갱신 + status 미로그인 힌트
- **#63** Finding-3 help 그룹핑 + 버전 1.1.0→1.1.1 + description 정렬

diff는 위 의도된 변경만 포함(예상 밖 파일 없음). `cargo test` 전부 통과 · clippy/fmt 클린 · 스모크(그룹핑 --help · upgrade --check · chat 스트리밍 · 로그아웃 힌트) 확인.

머지 후: 태그 `v1.1.1` push → release.yml 4바이너리 퍼블리시 (별도 owner 게이트).