### PR TITLE
fix: 네트워크/스트리밍 에러 진단성 개선 (~/.monocle/cli.log)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ print(resp.choices[0].message.content)
 **Token expired**
 → `monocle token` auto-refreshes when near expiry. If it's been more than 30 days since your last login, run `monocle login` again.
 
+**"Error: error decoding response body" (or another network/streaming error)**
+→ The request/response context (method, URL, underlying error) is appended to
+`~/.monocle/cli.log` whenever this happens; a hint pointing there is printed alongside
+the error. The file is otherwise never written or referenced — check it only when you
+hit an error and need more detail than the one-line message.
+
 For Claude Code and OpenAI SDK specific issues, see the linked guides above.
 
 ## Help

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -455,6 +455,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                         // A transient per-turn error must not tear down the session.
                         if let Err(e) = repl.run_turn(msg.to_string()) {
                             eprintln!("{} {e}", c::red("Error:"));
+                            if crate::diag::was_logged() {
+                                eprintln!(
+                                    "  {}",
+                                    c::dim(&format!(
+                                        "(details logged to {})",
+                                        crate::diag::display_path()
+                                    ))
+                                );
+                            }
                         }
                     }
                 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -452,6 +452,10 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                         eprintln!("unknown command: {cmd} (try /help)");
                     }
                     Command::Turn => {
+                        // Reset before this turn's work runs, so the hint below
+                        // reflects only whether *this* turn logged a network
+                        // error — not a stale flag left over from an earlier one.
+                        crate::diag::reset();
                         // A transient per-turn error must not tear down the session.
                         if let Err(e) = repl.run_turn(msg.to_string()) {
                             eprintln!("{} {e}", c::red("Error:"));

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -183,6 +183,11 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         }
 
         eprintln!();
+        // Reset before this turn's work runs, so the hint below reflects only
+        // whether *this* turn logged a network error — not a stale flag left
+        // over from an earlier one (this REPL loops for the life of the process,
+        // same as `monocle agent`'s).
+        crate::diag::reset();
         match call_chat(
             &provider,
             &model,
@@ -195,7 +200,13 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
                 out.write_all(b"\n\n")?;
                 out.flush()?;
             }
-            Err(e) => eprintln!("Error: {e}\n"),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                if crate::diag::was_logged() {
+                    eprintln!("  (details logged to {})", crate::diag::display_path());
+                }
+                eprintln!();
+            }
         }
     }
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,0 +1,104 @@
+//! A tiny diagnostics log for otherwise-invisible network/streaming failures
+//! (e.g. "error decoding response body" during `monocle agent` streaming).
+//!
+//! This is deliberately NOT a logging framework — no crate, no persistent
+//! logger/subscriber. Just a plain append-only text file at
+//! `~/.monocle/cli.log`, written only at the handful of `net.rs` sites where
+//! an error is about to be collapsed into a generic `AppError(String)` and
+//! the request context (method, URL, underlying error) would otherwise be
+//! lost for good.
+//!
+//! Top-level error-display sites can check [`was_logged`] to add a one-line
+//! hint pointing the user at the log, without every `AppError` needing to
+//! carry structured diagnostic data.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::util::{home_dir, now_ms, to_iso};
+
+/// Set once `log_network_error` has successfully written a line this run, so
+/// top-level error printers know whether pointing the user at the log file is
+/// actually useful.
+static WAS_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// The friendly path shown to users, matching this codebase's existing
+/// `~/.monocle/...` convention (README.md, doc comments) rather than the
+/// fully resolved OS path.
+pub fn display_path() -> &'static str {
+    "~/.monocle/cli.log"
+}
+
+/// The real, resolved log file path: `<home>/.monocle/cli.log`.
+pub fn log_path() -> PathBuf {
+    home_dir().join(".monocle").join("cli.log")
+}
+
+/// Whether a diagnostic line has been written this run.
+pub fn was_logged() -> bool {
+    WAS_LOGGED.load(Ordering::Relaxed)
+}
+
+/// Append one diagnostic line: timestamp, HTTP method + (redacted) URL, and
+/// the raw underlying error text — never the response body or credentials.
+///
+/// Best-effort: this must never mask or replace the original error, so any
+/// failure to write (missing home dir, permissions, disk full, ...) is
+/// silently dropped.
+pub fn log_network_error(method: &str, url: &str, err: &str) {
+    let path = log_path();
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    else {
+        return;
+    };
+    let line = format!(
+        "{} {method} {} — {err}\n",
+        to_iso(now_ms()),
+        redact_url(url)
+    );
+    if file.write_all(line.as_bytes()).is_ok() {
+        WAS_LOGGED.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Strip any query string before logging. Every call site today sends auth
+/// only via the `Authorization` header (never as a URL/query param), so the
+/// bare URL is already safe — this is defense in depth against a future call
+/// site that embeds something sensitive in `?...`.
+fn redact_url(url: &str) -> String {
+    match url.split_once('?') {
+        Some((base, _)) => format!("{base}?<redacted>"),
+        None => url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url;
+
+    #[test]
+    fn redacts_query_string() {
+        assert_eq!(
+            redact_url("https://api.example.com/v1/chat?token=secret"),
+            "https://api.example.com/v1/chat?<redacted>"
+        );
+    }
+
+    #[test]
+    fn leaves_bare_url_unchanged() {
+        assert_eq!(
+            redact_url("https://api.example.com/v1/chat"),
+            "https://api.example.com/v1/chat"
+        );
+    }
+}

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -35,9 +35,20 @@ pub fn log_path() -> PathBuf {
     home_dir().join(".monocle").join("cli.log")
 }
 
-/// Whether a diagnostic line has been written this run.
+/// Whether a diagnostic line has been written since the last [`reset`] (or
+/// since process start, if `reset` was never called).
 pub fn was_logged() -> bool {
     WAS_LOGGED.load(Ordering::Relaxed)
+}
+
+/// Clear the flag. A one-shot command process (e.g. `main.rs`) never needs
+/// this — it exits right after printing its one error. A long-lived REPL
+/// (`monocle agent`, `monocle chat`) must call this at the *start* of each
+/// turn, before that turn's work runs, so a later turn's hint reflects only
+/// whether *that* turn logged a network error — not a stale flag left over
+/// from an earlier turn.
+pub fn reset() {
+    WAS_LOGGED.store(false, Ordering::Relaxed);
 }
 
 /// Append one diagnostic line: timestamp, HTTP method + (redacted) URL, and
@@ -61,6 +72,7 @@ pub fn log_network_error(method: &str, url: &str, err: &str) {
     else {
         return;
     };
+    harden_permissions(&path);
     let line = format!(
         "{} {method} {} — {err}\n",
         to_iso(now_ms()),
@@ -70,6 +82,19 @@ pub fn log_network_error(method: &str, url: &str, err: &str) {
         WAS_LOGGED.store(true, Ordering::Relaxed);
     }
 }
+
+/// Best-effort `chmod 600` on Unix, mirroring `credentials.rs` (no secrets are
+/// logged here, but there's no reason to leave a diagnostics file
+/// world-readable either). A no-op on other platforms; failures are ignored —
+/// same best-effort posture as the rest of this module.
+#[cfg(unix)]
+fn harden_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn harden_permissions(_path: &std::path::Path) {}
 
 /// Strip any query string before logging. Every call site today sends auth
 /// only via the `Authorization` header (never as a URL/query param), so the
@@ -84,7 +109,8 @@ fn redact_url(url: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::redact_url;
+    use super::{redact_url, reset, was_logged, WAS_LOGGED};
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn redacts_query_string() {
@@ -100,5 +126,16 @@ mod tests {
             redact_url("https://api.example.com/v1/chat"),
             "https://api.example.com/v1/chat"
         );
+    }
+
+    #[test]
+    fn reset_clears_the_flag() {
+        // `WAS_LOGGED` is a process-global, so drive it directly rather than
+        // via `log_network_error` (which would touch the real filesystem and
+        // race other tests running in parallel).
+        WAS_LOGGED.store(true, Ordering::Relaxed);
+        assert!(was_logged());
+        reset();
+        assert!(!was_logged());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod colors;
 pub mod commands;
 pub mod credentials;
+pub mod diag;
 pub mod endpoints;
 pub mod error;
 pub mod net;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use monocle_cli::commands::token::token_command;
 use monocle_cli::commands::unset::unset_command;
 use monocle_cli::commands::upgrade::upgrade_command;
 use monocle_cli::credentials::Credentials;
+use monocle_cli::diag;
 use monocle_cli::error::Result;
 use monocle_cli::net::Client;
 use monocle_cli::util;
@@ -337,6 +338,9 @@ fn main() {
 
     if let Err(e) = result {
         eprintln!("Error: {e}");
+        if diag::was_logged() {
+            eprintln!("  (details logged to {})", diag::display_path());
+        }
         std::process::exit(1);
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -81,7 +81,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("GET", url, req)
     }
 
     /// GET a large file download (e.g. the `monocle upgrade` release binary).
@@ -122,7 +122,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `application/json`.
@@ -131,7 +131,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `multipart/form-data` with one binary file part plus text fields.
@@ -154,7 +154,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST a raw body with an explicit `Content-Type` (Azure SSML).
@@ -173,7 +173,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `application/json` and return a streaming line reader over the (SSE)
@@ -200,19 +200,31 @@ impl Client {
             status,
             content_type,
             reader: BufReader::new(resp),
+            request_url: url.to_string(),
         })
     }
 }
 
-fn send(req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
+fn send(method: &str, url: &str, req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
     // Total request timeout — non-streaming only (see `Client::new`). Streaming
     // (`post_json_stream`) builds and sends its own request without this, so a
     // long generation is never cut short.
     let req = req.timeout(std::time::Duration::from_secs(120));
-    let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+    let resp = req.send().map_err(|e| {
+        let msg = e.to_string();
+        crate::diag::log_network_error(method, url, &msg);
+        AppError(msg)
+    })?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
-    let body = resp.bytes().map_err(|e| AppError(e.to_string()))?.to_vec();
+    let body = resp
+        .bytes()
+        .map_err(|e| {
+            let msg = e.to_string();
+            crate::diag::log_network_error(method, url, &msg);
+            AppError(msg)
+        })?
+        .to_vec();
     Ok(Resp {
         status,
         status_text,
@@ -227,6 +239,9 @@ pub struct EventStream {
     pub status: u16,
     pub content_type: String,
     reader: BufReader<reqwest::blocking::Response>,
+    /// The request URL, kept only for diagnostic logging on a mid-stream read
+    /// failure (see `next_line`).
+    request_url: String,
 }
 
 impl EventStream {
@@ -242,10 +257,11 @@ impl EventStream {
     /// Next line (including the trailing newline), or `None` at end of stream.
     pub fn next_line(&mut self) -> Result<Option<String>> {
         let mut line = String::new();
-        let n = self
-            .reader
-            .read_line(&mut line)
-            .map_err(|e| AppError(e.to_string()))?;
+        let n = self.reader.read_line(&mut line).map_err(|e| {
+            let msg = e.to_string();
+            crate::diag::log_network_error("POST", &self.request_url, &msg);
+            AppError(msg)
+        })?;
         Ok(if n == 0 { None } else { Some(line) })
     }
 


### PR DESCRIPTION
## 배경

네트워크/스트리밍 에러가 "error decoding response body" 같은 문자열로만 뭉개져서
원인 파악이 불가능했습니다. 지금까지는 이런 에러를 진단할 방법이 전혀 없었고
(로그 자체가 없이 stderr에 한 줄 찍히고 사라지는 게 전부), 정수님이 CLI를 직접
쓰다가 겪은 문제에서 출발했습니다.

## 변경 사항

- `~/.monocle/cli.log`를 새로 도입해, `src/net.rs`의 세 실패 지점(요청 전송,
  응답 바디 읽기, SSE 스트림 라인 읽기)에서 타임스탬프·HTTP 메서드·URL(쿼리스트링은
  redact)·원본 에러 텍스트를 append합니다.
- `monocle agent`와 `monocle chat` 양쪽 REPL에서, 에러가 출력된 직후 실제로 그
  턴에서 로그가 기록된 경우에만 `(details logged to ~/.monocle/cli.log)` 힌트를
  한 줄 덧붙입니다.
- 코드 리뷰 과정에서 실제 버그를 하나 발견해 같이 고쳤습니다: 초기 구현은 단순
  전역 플래그(`WAS_LOGGED`)를 썼는데, 한 번 `true`가 되면 리셋되지 않아 REPL의
  다음 턴에서 나온 무관한(네트워크와 무관한) 로컬 에러에도 힌트가 잘못 붙는
  문제가 있었습니다. `diag::reset()`을 추가해 각 턴 시작 시점(작업 실행 전)에
  호출하도록 고쳤고, `diag::tests::reset_clears_the_flag` 테스트로 회귀를
  막았습니다.
- 부가로 `cli.log` 파일에 `credentials.json`과 같은 취지로 유닉스에서
  `chmod 600`을 적용해 권한을 강화했습니다.
- 새 크레이트 추가 없이 std + 기존 chrono/util 헬퍼만 사용합니다.

## 커밋

- `cb23e0b` fix: 네트워크/스트리밍 에러 진단성 개선 — `~/.monocle/cli.log` 추가
- `829477b` fix: diag 플래그가 REPL 턴 간에 새는 문제 수정 + chat REPL에도 힌트 적용

## 테스트

- [x] `cargo build`
- [x] `cargo test` (신규 `diag::tests::reset_clears_the_flag` 포함 전체 통과)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] 기존 `providers.rs`의 mid-stream drop salvage 테스트들 영향 없음 확인
