### PR TITLE
feat(agent): /model 인자 fuzzy-completion 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1079,7 @@ dependencies = [
  "ctrlc",
  "flate2",
  "futures-io",
+ "fuzzy-matcher",
  "open",
  "rand 0.8.6",
  "reqwest",
@@ -1813,6 +1823,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ ctrlc = "3"
 # Default features bring the Emacs keymap + FileHistory; used solely on the
 # interactive TTY path (see src/commands/agent.rs) — never in headless/ACP.
 rustyline = { version = "14", features = ["derive"] }
+# Fuzzy-matching for the REPL's `/model <TAB>` completion (skim's algorithm).
+# Small, dependency-light (adds only `thread_local`); default features only.
+fuzzy-matcher = "0.3.7"
 # ACP server-agent surface (Phase 3). async stays confined to src/acp.rs; the
 # core loop is sync. Pin 0.9 (trait-based `impl Agent`); 1.0 is a builder rewrite.
 agent-client-protocol = "0.9"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ In the interactive REPL, lines starting with `/` are local management commands (
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,
 `/model` shows the current model (or `/model <id>` switches it for later turns), and
-`/exit` (or `/quit`, Ctrl-D) quits.
+`/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the model ids
+available to your account (fetched once at startup) — e.g. `/model cla<TAB>` narrows to
+matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
+list can't be fetched, completion just offers nothing (typing a full id still works).
 
 ```bash
 monocle agent "summarize the TODOs in this repo" --workdir .

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -6,7 +6,10 @@
 
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
+use std::rc::Rc;
 
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
@@ -21,6 +24,7 @@ use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
+use crate::commands::model_list::fetch_model_ids;
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -72,10 +76,20 @@ impl Observer for CliObserver {
 /// what `dispatch_command` / `parse_model_command` actually handle.
 const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
 
-/// rustyline line helper: Tab-completes slash commands. Hinting/highlighting/
-/// validation are the derived no-op defaults — we only customize completion.
+/// rustyline line helper: Tab-completes slash commands, and (for `/model`)
+/// fuzzy-completes the argument against a model id list fetched once at REPL
+/// startup. Hinting/highlighting/validation are the derived no-op defaults —
+/// we only customize completion.
 #[derive(Helper, Hinter, Highlighter, Validator)]
-struct ReplHelper;
+struct ReplHelper {
+    /// Model ids fetched once before the loop starts (see `agent_command`).
+    /// Empty when not logged in / the fetch failed — `/model` completion then
+    /// just offers no candidates, same defensive posture as the rest of the
+    /// interactive path. `Rc` because `Editor::set_helper` takes ownership and
+    /// the list is read-only for the session's lifetime (no need for a `Vec`
+    /// clone per keystroke).
+    models: Rc<Vec<String>>,
+}
 
 impl Completer for ReplHelper {
     type Candidate = Pair;
@@ -91,6 +105,16 @@ impl Completer for ReplHelper {
         if !head.starts_with('/') {
             return Ok((0, Vec::new()));
         }
+        // `/model <partial>` — fuzzy-match the argument against the cached model
+        // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
+        // to matching ids and a bare `/model <TAB>` shows the full dropdown.
+        // Replace only from just after "/model " (not column 0, unlike the
+        // command-name path below) — we're completing the argument, not the
+        // command word.
+        if let Some(query) = head.strip_prefix("/model ") {
+            let start = head.len() - query.len();
+            return Ok((start, fuzzy_model_candidates(&self.models, query)));
+        }
         let candidates = SLASH_COMMANDS
             .iter()
             .filter(|cmd| cmd.starts_with(head))
@@ -102,6 +126,31 @@ impl Completer for ReplHelper {
         // Replace from column 0 (the whole slash token starts there).
         Ok((0, candidates))
     }
+}
+
+/// Fuzzy-match `query` against cached model ids for `/model` tab-completion.
+/// An empty query returns the full list unranked (the "show me what's
+/// available" dropdown); otherwise ids are scored with `fuzzy-matcher`'s skim
+/// algorithm (subsequence match, case-smart), kept only if they match at all,
+/// and sorted best match first.
+fn fuzzy_model_candidates(models: &[String], query: &str) -> Vec<Pair> {
+    let to_pair = |id: &String| Pair {
+        display: id.clone(),
+        replacement: id.clone(),
+    };
+    if query.is_empty() {
+        return models.iter().map(to_pair).collect();
+    }
+    // `ignore_case` (not the default smart-case) so typing in any case still
+    // narrows the (lowercase-by-convention) model ids — smart-case would make
+    // an all-caps query like "CLAUDE" match nothing.
+    let matcher = SkimMatcherV2::default().ignore_case();
+    let mut scored: Vec<(i64, &String)> = models
+        .iter()
+        .filter_map(|id| matcher.fuzzy_match(id, query).map(|score| (score, id)))
+        .collect();
+    scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+    scored.into_iter().map(|(_, id)| to_pair(id)).collect()
 }
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
@@ -365,6 +414,16 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         )
     );
 
+    // Prime `/model` tab-completion with the real model id list — fetched once,
+    // up front, never inside the completer itself (a blocking HTTP call on every
+    // Tab press would make typing laggy). Best-effort: not logged in, an
+    // unreachable router, or any other fetch error just leaves the list empty
+    // rather than blocking startup or crashing the REPL — the same defensive
+    // posture `login_view` uses for `/status` in a not-logged-in session. The
+    // `client`'s own connect/total timeouts (`src/net.rs`) already bound how
+    // long this can hang.
+    let model_ids = fetch_model_ids(client, creds).unwrap_or_default();
+
     // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
     // Ctrl-A/E/K/Y) with its default Emacs keymap + file history. It is used
     // ONLY here, on the interactive TTY path — the headless / piped / ACP paths
@@ -383,7 +442,9 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     let config = Config::builder().bracketed_paste(true).build();
     let mut rl: Editor<ReplHelper, DefaultHistory> =
         Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
-    rl.set_helper(Some(ReplHelper));
+    rl.set_helper(Some(ReplHelper {
+        models: Rc::new(model_ids),
+    }));
     let history_path = home_dir().join(".monocle").join("agent_history");
     if let Some(parent) = history_path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -557,6 +618,110 @@ mod tests {
         assert_eq!(
             parse_model_command("/model  claude-x  "),
             Some(Some("claude-x".to_string()))
+        );
+    }
+
+    fn model_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_empty_query_returns_full_list_unranked() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, models);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_narrows_by_subsequence() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "cla")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, vec!["claude-sonnet-4-6", "claude-opus-4"]);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_ranks_tighter_match_first() {
+        // "gpt4o" as a subsequence appears in both, but a contiguous match in
+        // "gpt-4o" should outrank the more scattered match in "gpt-4-omni".
+        let models = model_ids(&["gpt-4-omni", "gpt-4o"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "gpt4o")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got.first().map(String::as_str), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_excludes_non_matches() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o"]);
+        let got = fuzzy_model_candidates(&models, "zzz");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_case_insensitive() {
+        let models = model_ids(&["claude-sonnet-4-6"]);
+        let got = fuzzy_model_candidates(&models, "CLAUDE");
+        assert_eq!(got.len(), 1);
+    }
+
+    /// The completion `start` offset is what rustyline uses to splice the
+    /// chosen candidate back into the line — get it wrong and accepting a
+    /// completion corrupts the line. For `/model <partial>` it must point
+    /// just past `"/model "`, not column 0 (unlike the command-name path),
+    /// so accepting a candidate replaces only the partial id.
+    #[test]
+    fn complete_model_argument_uses_offset_after_prefix() {
+        let helper = ReplHelper {
+            models: Rc::new(model_ids(&["claude-sonnet-4-6", "gpt-4o"])),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model cla";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
+        );
+
+        // Bare "/model " (empty partial) offers the full dropdown, still
+        // anchored right after the prefix.
+        let line = "/model ";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(candidates.len(), 2);
+    }
+
+    /// Command-name completion (`/mo<TAB>` → `/model`) must be unaffected by
+    /// the new `/model` argument branch.
+    #[test]
+    fn complete_command_name_unaffected_by_model_argument_branch() {
+        let helper = ReplHelper {
+            models: Rc::new(model_ids(&["claude-sonnet-4-6"])),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/mo";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/model".to_string()]
         );
     }
 }

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use serde::Deserialize;
 
-use crate::auth::get_access_token;
+use crate::auth::{get_access_token, try_access_token, AuthSession};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::{AppError, Result};
@@ -33,8 +33,13 @@ fn pad(s: &str, width: usize) -> String {
     }
 }
 
-pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
-    let session = get_access_token(client, creds);
+/// Fetch the full model listing from the router (`GET /v1/models`) given an
+/// already-resolved session, with no printing — the pure data path shared by
+/// `monocle models` and the `agent` REPL's tab-completion (which needs the id
+/// list, not a rendered table). Takes the session rather than resolving it
+/// itself so callers can choose exiting (`get_access_token`) vs. graceful
+/// (`try_access_token`) auth resolution.
+fn fetch_models_with_session(client: &Client, session: &AuthSession) -> Result<Vec<ModelInfo>> {
     let bearer = format!("Bearer {}", session.token);
 
     let resp = client.get(
@@ -50,7 +55,25 @@ pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
         )));
     }
 
-    let models = resp.json::<ModelsResponse>()?.data;
+    Ok(resp.json::<ModelsResponse>()?.data)
+}
+
+/// Fetch just the model ids — what the `agent` REPL's `/model` completer needs.
+/// Uses the non-exiting [`try_access_token`] (not [`get_access_token`]) so a
+/// missing login or a network hiccup returns an `Err` instead of killing the
+/// process; `agent.rs` treats that as "no candidates" and starts the REPL
+/// anyway rather than propagating.
+pub fn fetch_model_ids(client: &Client, creds: &Credentials) -> Result<Vec<String>> {
+    let session = try_access_token(client, creds)?;
+    Ok(fetch_models_with_session(client, &session)?
+        .into_iter()
+        .map(|m| m.id)
+        .collect())
+}
+
+pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
+    let session = get_access_token(client, creds);
+    let models = fetch_models_with_session(client, &session)?;
 
     if models.is_empty() {
         eprintln!("No models available.");


### PR DESCRIPTION
## 배경

지금까지는 슬래시 명령어 *이름*만 탭 완성이 됐고(예: `/mo<TAB>` → `/model`),
`/model` 뒤에 실제로 어떤 모델 id를 넣어야 하는지는 알아낼 방법이 전혀 없었습니다.
정수님이 CLI를 직접 쓰다가 겪은 불편에서 출발했습니다.

## 변경 사항

- REPL 시작 시 한 번 `fetch_model_ids`로 실제 모델 목록을 fetch해 `ReplHelper`에
  캐싱합니다. `fetch_model_ids`는 기존 `monocle models` 명령에서 쓰던 fetch 로직을
  `fetch_models_with_session` / `fetch_model_ids`로 분리해 재사용한 것입니다.
- 로그인이 안 되어 있거나 네트워크 실패가 나도 죽거나 멈추지 않고 빈 목록으로
  degrade하도록, exit하지 않는 형태의 인증 체크를 사용합니다.
- `/model <partial><TAB>`에서 `fuzzy-matcher` 크레이트(`SkimMatcherV2`, skim
  알고리즘)로 후보를 스코어링/narrowing해서 보여줍니다.
- 비대화형/파이프 입력 경로에서는 이 fetch/completion이 동작하지 않습니다.
- 기존 `/mo<TAB>` 같은 슬래시 명령 이름 완성 경로와 `parse_model_command`의
  자유 입력 허용 동작은 그대로 유지됩니다.

## 커밋

- `f4a15fa` feat(agent): `/model` 인자에 모델 목록 fuzzy-completion 추가

## 테스트

- [x] `cargo build`
- [x] `cargo test` (completion 로직을 검증하는 신규 유닛 테스트 7개 포함 전체 통과)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] 기존 `monocle models` 명령 동작 변화 없음 확인
