### PR TITLE
feat(chat): --file 플래그와 인밴드 file: 토큰으로 이미지 첨부 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | Chat with a model (REPL or stdin) |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]...` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only) |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
@@ -119,6 +119,52 @@ monocle chat --system-prompt-file ./persona.md --model claude-opus-4-7
 
 > [!NOTE]
 > `monocle model chat` / `monocle model list` still work but are deprecated and will be removed in a future release.
+
+### 📎 Attaching files/images
+
+`monocle chat` can attach files (images in v1) to a one-shot (piped) message —
+handy as an eval primitive for comparing how different providers/models handle
+vision input:
+
+```bash
+echo "count the people in this image" | monocle chat --file photo.png --model gpt-4o
+```
+
+- `--file <PATH|URL>` is repeatable. A local path is read, MIME-sniffed by
+  extension, and base64-encoded into a `data:<mime>;base64,...` URI; an
+  `http://`/`https://` value is passed straight through as the remote image
+  URL (no fetch).
+- Only image types are wired to a vision request in v1 (`png`, `jpg`/`jpeg`,
+  `gif`, `webp`). Anything else is a hard error: `unsupported type: <mime>`.
+- You can also reference a file **inband**, inside the piped text itself,
+  with an Org-mode-style `file:<path>` token — **not** a standard `file://`
+  URI (no `//` required, and relative paths are fine):
+
+  ```bash
+  echo "compare file:./a.png and file:./b.png, which is sharper?" | monocle chat --model gpt-4o
+  ```
+
+  The `file:` token is stripped from the text sent to the model. Trailing
+  sentence punctuation (`.,;:!?)'"`) right after the path is trimmed before
+  resolving — a known v1 limitation if your path itself legitimately ends in
+  one of those characters.
+- Explicit `--file` flags resolve first (in the order given), then inband
+  `file:` references in the order they appear in the text.
+- An attachment-only message (no text) is valid.
+- Attachments are **one-shot only** — not supported in the interactive REPL.
+  Passing `--file` while stdin is a terminal is an error asking you to pipe
+  the instruction instead.
+
+This makes `monocle chat` a quick harness for an image-handling eval loop —
+run the same image + instruction across models and diff both the answers and
+the raw provider error messages:
+
+```bash
+for m in gpt-4o claude-sonnet-4-6 gemini-2-flash; do
+  echo "=== $m ==="
+  echo "count the people in this image" | monocle chat --file crowd.jpg --model "$m"
+done
+```
 
 ## 🔊 Audio (STT / TTS)
 

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -128,6 +128,20 @@ pub struct ChatRequest {
     pub messages: Vec<Message>,
     pub max_tokens: Option<i64>,
     pub tools: Vec<ToolDef>,
+    /// Images to attach to the last user message as OpenAI vision parts (see
+    /// `MonocleProvider::build_body`). Carried on the request rather than
+    /// `Message` because `monocle chat` rebuilds `messages` fresh every turn —
+    /// attachments never need to survive into a later turn (monocle-cli
+    /// file-attach plan).
+    pub images: Vec<ImageAttachment>,
+}
+
+/// One resolved image, ready to drop into an OpenAI `image_url` content part —
+/// either a `data:<mime>;base64,...` URI (local file) or a passthrough remote
+/// `http(s)://` URL.
+#[derive(Debug, Clone)]
+pub struct ImageAttachment {
+    pub url: String,
 }
 
 /// The assistant's reply for one turn.
@@ -374,9 +388,30 @@ impl MonocleProvider {
     }
 
     fn build_body(&self, req: &ChatRequest, stream: bool) -> Value {
+        let mut messages = json!(req.messages);
+        // Vision requests (monocle-cli file-attach plan): rewrite the last
+        // `user` message's `content` from a plain string into the OpenAI
+        // multi-part shape (`[{type:text}, {type:image_url}, ...]`). With no
+        // images the messages serialize exactly as before — this branch is
+        // the only place behavior can diverge.
+        if !req.images.is_empty() {
+            if let Some(arr) = messages.as_array_mut() {
+                if let Some(last_user) = arr.iter_mut().rev().find(|m| m["role"] == "user") {
+                    let mut parts: Vec<Value> = Vec::new();
+                    let text = last_user["content"].as_str().unwrap_or("");
+                    if !text.is_empty() {
+                        parts.push(json!({"type": "text", "text": text}));
+                    }
+                    for img in &req.images {
+                        parts.push(json!({"type": "image_url", "image_url": {"url": img.url}}));
+                    }
+                    last_user["content"] = json!(parts);
+                }
+            }
+        }
         let mut body = json!({
             "model": req.model,
-            "messages": req.messages,
+            "messages": messages,
             "stream": stream,
         });
         if let Some(max_tokens) = req.max_tokens {
@@ -559,5 +594,83 @@ mod tests {
             resp.is_err(),
             "a stream with no usable completion should error"
         );
+    }
+
+    fn dummy_provider() -> MonocleProvider {
+        MonocleProvider::new("token", "https://router.example")
+    }
+
+    #[test]
+    fn build_body_with_no_images_is_unchanged() {
+        // The critical regression oracle: an empty `images` vec must produce
+        // exactly the same body as before attachments existed — a plain
+        // string `content`, not an array.
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::system("be terse"), Message::user("hello")],
+            max_tokens: Some(100),
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+        assert_eq!(body["messages"][0]["content"], json!("be terse"));
+        assert_eq!(body["messages"][1]["content"], json!("hello"));
+        assert!(body["messages"][1]["content"].is_string());
+        assert_eq!(body["max_tokens"], json!(100));
+    }
+
+    #[test]
+    fn build_body_with_images_rewrites_last_user_message_as_parts() {
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::system("be terse"), Message::user("count them")],
+            images: vec![
+                ImageAttachment {
+                    url: "data:image/png;base64,AAAA".to_string(),
+                },
+                ImageAttachment {
+                    url: "https://example.com/b.png".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+
+        // System message untouched.
+        assert_eq!(body["messages"][0]["content"], json!("be terse"));
+
+        // Last user message becomes a parts array: text part then image parts,
+        // in the order the images were given.
+        let parts = body["messages"][1]["content"]
+            .as_array()
+            .expect("user content should be rewritten into an array");
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], json!({"type": "text", "text": "count them"}));
+        assert_eq!(
+            parts[1],
+            json!({"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}})
+        );
+        assert_eq!(
+            parts[2],
+            json!({"type": "image_url", "image_url": {"url": "https://example.com/b.png"}})
+        );
+    }
+
+    #[test]
+    fn build_body_with_images_and_empty_text_omits_text_part() {
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::user("")],
+            images: vec![ImageAttachment {
+                url: "https://example.com/a.png".to_string(),
+            }],
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+        let parts = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], json!("image_url"));
     }
 }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -158,6 +158,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 messages: conversation.clone(),
                 max_tokens: self.config.max_tokens,
                 tools: defs.clone(),
+                ..Default::default()
             };
             // Stream assistant text to the observer as it arrives.
             let resp = self

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,0 +1,187 @@
+//! File/image attachment resolution for `monocle chat` (vision eval
+//! primitive). Mirrors `audio_io.rs`'s patterns for file/MIME/error handling,
+//! but is kept separate since its MIME table is image-only (audio_io's is
+//! audio-only) — see the file/image-attachments plan.
+
+use std::path::Path;
+
+use base64::Engine;
+
+use crate::agent::providers::ImageAttachment;
+use crate::error::{AppError, Result};
+
+/// Sentence punctuation trimmed off the trailing end of a captured `file:`
+/// token before it is treated as a path (e.g. `file:./a.png.` in "...a.png.").
+const TRAILING_PUNCT: [char; 9] = ['.', ',', ';', ':', '!', '?', ')', '\'', '"'];
+
+fn mime_by_ext(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+/// Resolve a `--file` value or an inband `file:<path>` reference into an
+/// [`ImageAttachment`].
+///
+/// - `http://` / `https://` → passed through verbatim as a remote
+///   `image_url.url` (no fetch, no base64).
+/// - Anything else is treated as a local path: read the bytes, guess MIME by
+///   extension, and if it's `image/*` encode as a `data:<mime>;base64,...`
+///   URI. A missing file or a non-image MIME is a hard, typed error (matches
+///   the file-not-found style in `audio_io::resolve_audio_input`).
+pub fn resolve(value: &str) -> Result<ImageAttachment> {
+    if value.starts_with("http://") || value.starts_with("https://") {
+        return Ok(ImageAttachment {
+            url: value.to_string(),
+        });
+    }
+
+    let path = Path::new(value);
+    if !path.exists() {
+        return Err(AppError::new(format!("file not found: {value}")));
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+    let mime = mime_by_ext(&ext).unwrap_or("application/octet-stream");
+    if !mime.starts_with("image/") {
+        return Err(AppError::new(format!("unsupported type: {mime}")));
+    }
+
+    let data = std::fs::read(path)?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+    Ok(ImageAttachment {
+        url: format!("data:{mime};base64,{b64}"),
+    })
+}
+
+/// Scan `text` for inband `file:<path>` tokens (Org-mode-style — NOT a strict
+/// `file://` URI; no `//` required, relative paths welcome), returning the
+/// text with each matched token removed and the ordered list of raw path
+/// strings found (trailing sentence punctuation trimmed off each).
+///
+/// All whitespace other than the removed tokens themselves is preserved
+/// verbatim, so text with no `file:` tokens comes back byte-identical — this
+/// is the regression oracle for the common (no-attachment) path.
+pub fn extract_inband_refs(text: &str) -> (String, Vec<String>) {
+    let mut refs = Vec::new();
+    let mut result = String::with_capacity(text.len());
+    let mut rest = text;
+
+    loop {
+        let word_start = match rest.find(|c: char| !c.is_whitespace()) {
+            Some(idx) => idx,
+            None => {
+                result.push_str(rest);
+                break;
+            }
+        };
+        // Whitespace before the next word — keep verbatim.
+        result.push_str(&rest[..word_start]);
+        let after_ws = &rest[word_start..];
+        let word_end = after_ws
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(after_ws.len());
+        let word = &after_ws[..word_end];
+
+        match word.strip_prefix("file:") {
+            Some(path) => {
+                let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
+                if trimmed.is_empty() {
+                    // "file:" with nothing usable after it — not a real token.
+                    result.push_str(word);
+                } else {
+                    refs.push(trimmed.to_string());
+                    // Token is stripped from the outgoing text entirely.
+                }
+            }
+            None => result.push_str(word),
+        }
+
+        rest = &after_ws[word_end..];
+    }
+
+    (result, refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn resolves_local_png_to_data_uri() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"not a real png but bytes are enough").unwrap();
+
+        let img = resolve(path.to_str().unwrap()).expect("should resolve");
+        let expected_b64 = base64::engine::general_purpose::STANDARD
+            .encode(b"not a real png but bytes are enough");
+        assert_eq!(img.url, format!("data:image/png;base64,{expected_b64}"));
+    }
+
+    #[test]
+    fn http_url_passes_through_unencoded() {
+        let img = resolve("https://example.com/a.png").expect("should pass through");
+        assert_eq!(img.url, "https://example.com/a.png");
+
+        let img = resolve("http://example.com/a.png").expect("should pass through");
+        assert_eq!(img.url, "http://example.com/a.png");
+    }
+
+    #[test]
+    fn nonexistent_path_errors() {
+        let err = resolve("/no/such/path/ever.png").unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn non_image_extension_errors_with_typed_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"hello").unwrap();
+
+        let err = resolve(path.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().starts_with("unsupported type:"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_inband_refs_strips_tokens_and_trims_trailing_punct() {
+        let (cleaned, refs) = extract_inband_refs("compare file:./a.png and file:./b.png.");
+        assert_eq!(refs, vec!["./a.png".to_string(), "./b.png".to_string()]);
+        // Tokens removed; surrounding words/whitespace otherwise untouched.
+        assert!(!cleaned.contains("file:"));
+        assert!(cleaned.contains("compare"));
+        assert!(cleaned.contains("and"));
+    }
+
+    #[test]
+    fn bare_https_substring_is_left_untouched() {
+        let (cleaned, refs) = extract_inband_refs("see https://example.com/x.png please");
+        assert!(refs.is_empty());
+        assert_eq!(cleaned, "see https://example.com/x.png please");
+    }
+
+    #[test]
+    fn no_tokens_is_byte_identical() {
+        let text = "line one\nline two   with   spaces\tand a tab";
+        let (cleaned, refs) = extract_inband_refs(text);
+        assert!(refs.is_empty());
+        assert_eq!(cleaned, text);
+    }
+}

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -52,7 +52,9 @@ pub fn resolve(value: &str) -> Result<ImageAttachment> {
         .unwrap_or_default();
     let mime = mime_by_ext(&ext).unwrap_or("application/octet-stream");
     if !mime.starts_with("image/") {
-        return Err(AppError::new(format!("unsupported type: {mime}")));
+        return Err(AppError::new(format!(
+            "unsupported type: {mime} (from extension \"{ext}\" of {value})"
+        )));
     }
 
     let data = std::fs::read(path)?;
@@ -91,18 +93,28 @@ pub fn extract_inband_refs(text: &str) -> (String, Vec<String>) {
             .unwrap_or(after_ws.len());
         let word = &after_ws[..word_end];
 
-        match word.strip_prefix("file:") {
-            Some(path) => {
-                let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
-                if trimmed.is_empty() {
-                    // "file:" with nothing usable after it — not a real token.
-                    result.push_str(word);
-                } else {
-                    refs.push(trimmed.to_string());
-                    // Token is stripped from the outgoing text entirely.
-                }
+        // Marker match is case-insensitive (`File:`, `FILE:`, ... all count —
+        // mobile autocapitalize / sentence-case habit shouldn't silently drop
+        // an attachment), but only the 5-byte marker itself is case-folded for
+        // the comparison; the path remainder is used verbatim since filesystem
+        // paths are case-sensitive on Linux/macOS.
+        let is_file_marker = word
+            .get(..5)
+            .map(|prefix| prefix.eq_ignore_ascii_case("file:"))
+            .unwrap_or(false);
+
+        if is_file_marker {
+            let path = &word[5..];
+            let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
+            if trimmed.is_empty() {
+                // "file:" with nothing usable after it — not a real token.
+                result.push_str(word);
+            } else {
+                refs.push(trimmed.to_string());
+                // Token is stripped from the outgoing text entirely.
             }
-            None => result.push_str(word),
+        } else {
+            result.push_str(word);
         }
 
         rest = &after_ws[word_end..];
@@ -149,14 +161,27 @@ mod tests {
     #[test]
     fn non_image_extension_errors_with_typed_message() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("notes.txt");
+        let path = dir.path().join("notes.heic");
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(b"hello").unwrap();
 
         let err = resolve(path.to_str().unwrap()).unwrap_err();
+        let msg = err.to_string();
         assert!(
-            err.to_string().starts_with("unsupported type:"),
-            "unexpected message: {err}"
+            msg.starts_with("unsupported type:"),
+            "unexpected message: {msg}"
+        );
+        // Regression: the rejected extension (and the offending path) must be
+        // named in the error — otherwise the user has no way to diagnose
+        // "what happened with this file/format" (the whole point of the
+        // feature).
+        assert!(
+            msg.contains("heic"),
+            "error should name the rejected extension: {msg}"
+        );
+        assert!(
+            msg.contains(path.to_str().unwrap()),
+            "error should name the offending path: {msg}"
         );
     }
 
@@ -168,6 +193,23 @@ mod tests {
         assert!(!cleaned.contains("file:"));
         assert!(cleaned.contains("compare"));
         assert!(cleaned.contains("and"));
+    }
+
+    #[test]
+    fn inband_marker_is_case_insensitive_but_path_case_is_preserved() {
+        let (cleaned, refs) = extract_inband_refs("look at File:./Photo.png please");
+        assert_eq!(refs, vec!["./Photo.png".to_string()]);
+        assert!(!cleaned.to_lowercase().contains("file:"));
+        assert!(cleaned.contains("look"));
+        assert!(cleaned.contains("please"));
+
+        let (cleaned2, refs2) = extract_inband_refs("FILE:./B.PNG");
+        assert_eq!(refs2, vec!["./B.PNG".to_string()]);
+        assert!(cleaned2.trim().is_empty());
+
+        // Lowercase marker still works unchanged (regression).
+        let (_, refs3) = extract_inband_refs("file:./a.png");
+        assert_eq!(refs3, vec!["./a.png".to_string()]);
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -101,9 +101,18 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         std::process::exit(1);
     }
 
-    // Read stdin + resolve any attachments up front — cheap, local-only work
-    // that should fail fast (bad path, unsupported MIME) before we ever touch
-    // the network for auth/model validation below.
+    // Auth FIRST — before any local-input validation. Otherwise an expired/
+    // missing-credentials error can be masked by a local failure that happens
+    // to come first (e.g. empty piped stdin reporting "No input provided via
+    // stdin." while the real problem is "Not logged in").
+    let session = get_access_token(client, creds);
+    let token = session.token;
+    let router_url = session.router_url;
+    let bearer = format!("Bearer {token}");
+
+    // Read stdin + resolve any attachments — cheap, local-only work that
+    // should fail fast (bad path, unsupported MIME) before the second network
+    // call (model-ID validation) below, but after the auth check above.
     let one_shot_input: Option<(String, Vec<ImageAttachment>)> = if !stdin_is_tty {
         let mut input = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
@@ -146,11 +155,6 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     } else {
         options.system_prompt.clone()
     };
-
-    let session = get_access_token(client, creds);
-    let token = session.token;
-    let router_url = session.router_url;
-    let bearer = format!("Bearer {token}");
 
     // Validate the model ID against the available models (non-fatal on failure).
     if let Ok(resp) = client.get(

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -2,8 +2,11 @@ use std::io::{IsTerminal, Write};
 
 use serde_json::Value;
 
-use crate::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
+use crate::agent::providers::{
+    ChatRequest, ImageAttachment, LlmProvider, Message, MonocleProvider,
+};
 use crate::agent::DEFAULT_MODEL;
+use crate::attachment;
 use crate::auth::get_access_token;
 use crate::credentials::Credentials;
 use crate::endpoints;
@@ -16,6 +19,8 @@ pub struct ChatOptions {
     pub system_prompt: Option<String>,
     pub system_prompt_file: Option<String>,
     pub max_tokens: Option<String>,
+    /// `--file <PATH|URL>` values (repeatable), one-shot only.
+    pub files: Vec<String>,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -37,6 +42,7 @@ fn call_chat(
     system_prompt: Option<&str>,
     user_message: &str,
     max_tokens: Option<i64>,
+    images: &[ImageAttachment],
 ) -> Result<()> {
     let mut messages = Vec::new();
     if let Some(sp) = system_prompt {
@@ -48,6 +54,7 @@ fn call_chat(
         model: model.to_string(),
         messages,
         max_tokens,
+        images: images.to_vec(),
         ..Default::default()
     };
     // Acquire the stdout lock once for the whole stream rather than per token —
@@ -82,6 +89,52 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             eprintln!("⚠ ignoring --max-tokens '{raw}' (a positive integer is required)");
         }
     }
+
+    let stdin_is_tty = std::io::stdin().is_terminal();
+
+    // Attachments (`--file` / inband `file:<path>`) are one-shot only (piped
+    // stdin), never the interactive REPL.
+    if !options.files.is_empty() && stdin_is_tty {
+        eprintln!(
+            "--file requires piped input. Pipe your instruction, e.g.:\n  echo \"describe this image\" | monocle chat --file photo.png"
+        );
+        std::process::exit(1);
+    }
+
+    // Read stdin + resolve any attachments up front — cheap, local-only work
+    // that should fail fast (bad path, unsupported MIME) before we ever touch
+    // the network for auth/model validation below.
+    let one_shot_input: Option<(String, Vec<ImageAttachment>)> = if !stdin_is_tty {
+        let mut input = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
+        let (cleaned_text, inband_refs) = attachment::extract_inband_refs(input.trim());
+
+        let mut refs: Vec<String> = options.files.clone();
+        refs.extend(inband_refs);
+
+        let mut images: Vec<ImageAttachment> = Vec::new();
+        for r in &refs {
+            match attachment::resolve(r) {
+                Ok(img) => images.push(img),
+                Err(e) => {
+                    eprintln!("{e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        let cleaned_text = cleaned_text.trim().to_string();
+        // Image-only messages are valid — only bail when BOTH the text and the
+        // attachments are empty.
+        if cleaned_text.is_empty() && images.is_empty() {
+            eprintln!("No input provided via stdin.");
+            std::process::exit(1);
+        }
+
+        Some((cleaned_text, images))
+    } else {
+        None
+    };
 
     // Resolve system prompt.
     let system_prompt: Option<String> = if let Some(path) = &options.system_prompt_file {
@@ -129,22 +182,17 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
 
     let provider = MonocleProvider::new(token, router_url.clone());
 
-    // Non-interactive: stdin is piped.
-    if !std::io::stdin().is_terminal() {
-        let mut input = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
-        if input.trim().is_empty() {
-            eprintln!("No input provided via stdin.");
-            std::process::exit(1);
-        }
+    // Non-interactive: stdin was piped (input + attachments already resolved above).
+    if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
         call_chat(
             &provider,
             &model,
             system_prompt.as_deref(),
-            input.trim(),
+            &text,
             max_tokens,
+            &images,
         )?;
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
@@ -189,6 +237,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             system_prompt.as_deref(),
             trimmed,
             max_tokens,
+            &[],
         ) {
             Ok(()) => {
                 let mut out = std::io::stdout();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod acp;
 pub mod agent;
+pub mod attachment;
 pub mod audio_io;
 pub mod auth;
 pub mod colors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,10 @@ struct ChatArgs {
     /// Maximum output tokens (omitted by default → model/router uses its own)
     #[arg(long = "max-tokens")]
     max_tokens: Option<String>,
+    /// Attach a file/image (repeatable); local path or http(s) URL. One-shot
+    /// (piped stdin) only — see also inband `file:<path>` tokens in the text.
+    #[arg(long = "file")]
+    file: Vec<String>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -169,6 +173,7 @@ impl From<ChatArgs> for ChatOptions {
             system_prompt: a.system_prompt,
             system_prompt_file: a.system_prompt_file,
             max_tokens: a.max_tokens,
+            files: a.file,
         }
     }
 }
@@ -424,5 +429,21 @@ fn run_audio(client: &Client, creds: &Credentials, command: AudioCommands) -> Re
             ssml.as_deref(),
             AudioSpeechAzureOptions { format, output },
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_file_flag_repeats_into_vec() {
+        let cli = Cli::parse_from(["monocle", "chat", "--file", "a.png", "--file", "b.png"]);
+        match cli.command {
+            Commands::Chat(args) => {
+                assert_eq!(args.file, vec!["a.png".to_string(), "b.png".to_string()]);
+            }
+            _ => panic!("expected Chat command"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`monocle chat`에 파일/이미지 첨부 기능 추가 — 여러 LLM 프로바이더가 이미지를 어떻게 처리하는지(포맷/사이즈별) 평가하는 용도. 두 가지 입력 방식: 반복 가능한 `--file <경로|URL>` 플래그, 그리고 파이프로 들어온 지시문 텍스트 안의 인밴드 `file:<경로>` 토큰(Org-mode 스타일 — RFC 8089 `file://` URI가 아님, `//` 불필요, 상대경로 지원). 로컬 파일은 MIME 감지 후 `image/*`만 OpenAI vision 파트로 변환(그 외 확장자는 `unsupported type: <mime>` 에러로 명시적 실패 — "이미지"가 아니라 "파일" 개념으로 일반화해 나중에 PDF 등 확장 시 플래그/토큰 이름을 바꿀 필요 없음), `http(s)://` 값은 그대로 image_url로 패스스루. 첨부는 `ChatRequest`에만 실려 있고 `Message`/세션 JSONL/agent runner/ACP는 전혀 건드리지 않음(설계 근거: `monocle chat`은 대화 히스토리를 유지하지 않으므로).

## Test plan / 검증

- cargo build/test/clippy -D warnings/fmt 모두 green
- 신규 유닛 테스트: `attachment.rs`의 MIME/base64/인밴드 파싱 테스트, `providers.rs`의 build_body 회귀 테스트 3종 — 이미지 없을 때 기존과 byte-identical 확인 포함, `main.rs`의 `--file` 반복 플래그 테스트
- 독립적인 코드 리뷰 통과(10개 항목 전수 확인 — 회귀 오라클, base64 엔진, 인밴드 토큰 파싱 엣지케이스, 해석 순서/하드에러, TTY 가드, README 정확성 등)
- 실제 로그인된 환경에서 라이브 스모크 테스트도 수행됨: 실제 Azure OpenAI에 더미 PNG 전송 시 진짜 `image_parse_error`가 stderr에 그대로 노출되는 것 확인 — 이게 바로 이 기능의 핵심 목표(각 프로바이더의 이미지 처리/에러 관찰)

## 리뷰에서 나온 사소한 참고사항 (블로킹 아님, follow-up 후보)

1. 인밴드 `file:` 토큰을 텍스트에서 제거할 때 앞뒤 공백이 그대로 남아 더블스페이스가 생길 수 있음(LLM에는 무해).
2. `chat_command`가 이제 로컬 stdin/파일 해석을 네트워크 호출(로그인 확인, 모델 검증)보다 먼저 수행하도록 순서가 바뀜 — "로컬에서 먼저 실패"가 의도된 설계이지만, `--system-prompt-file`이 없고 stdin도 비어있는 아주 드문 동시 실패 케이스에서 에러 메시지 우선순위가 바뀜(기능적 회귀 아님, cosmetic).
3. `build_body`에 이미지가 있는데 user 메시지가 하나도 없는 경우(현재 코드 경로상 도달 불가) 조용히 no-op — 방어적 주석을 달아두면 좋음.

## Scope

v1은 `monocle chat`의 one-shot(파이프) 경로만 지원. Agent/ACP 첨부, 인터랙티브 REPL 첨부, `Message.content` 확장, 비이미지 파일 실제 지원, `--image-content-type`/`detail` 플래그 등은 의도적으로 범위 밖.
