### PR TITLE
feat(chat): agent REPL의 rustyline 라인 편집을 chat REPL에도 포팅

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Hello! How can I help you today?
 Bye.
 ```
 
+The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
+and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
+Tab completes `/quit`/`/exit`, and a multi-line paste is inserted as a single input
+(submitted only on Enter, not one turn per line). Command history persists across
+sessions in `~/.monocle/chat_history` (kept separate from `monocle agent`'s history).
+
 One-shot via stdin:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ echo "count the people in this image" | monocle chat --file photo.png --model gp
 - Explicit `--file` flags resolve first (in the order given), then inband
   `file:` references in the order they appear in the text.
 - An attachment-only message (no text) is valid.
-- Attachments are **one-shot only** — not supported in the interactive REPL.
-  Passing `--file` while stdin is a terminal is an error asking you to pipe
-  the instruction instead.
+- The `--file` flag is **one-shot only** — passing it while stdin is a
+  terminal is an error asking you to pipe the instruction instead. Inband
+  `file:<path>` tokens, however, also work when typed directly into the
+  **interactive REPL**: a resolution failure (bad path, unsupported type)
+  prints an error and returns you to the prompt rather than exiting the
+  session.
 
 This makes `monocle chat` a quick harness for an image-handling eval loop —
 run the same image + instruction across models and diff both the answers and

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -78,6 +78,27 @@ fn call_chat(
     Ok(())
 }
 
+/// Resolve inband `file:<path>` refs in a REPL line into images, mirroring the
+/// one-shot path's resolution (`attachment::extract_inband_refs` +
+/// `attachment::resolve`) but returning a failure as `Err(String)` instead of
+/// exiting the process — a bad ref in the REPL is a per-turn error, not a
+/// reason to kill the whole session. Returns the cleaned text (`file:` tokens
+/// stripped, same as the one-shot path) alongside the resolved attachments;
+/// zero refs is the common case and just passes `line` through unchanged.
+fn resolve_repl_attachments(
+    line: &str,
+) -> std::result::Result<(String, Vec<ImageAttachment>), String> {
+    let (cleaned_text, refs) = attachment::extract_inband_refs(line);
+    let mut images: Vec<ImageAttachment> = Vec::new();
+    for r in &refs {
+        match attachment::resolve(r) {
+            Ok(img) => images.push(img),
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    Ok((cleaned_text.trim().to_string(), images))
+}
+
 /// The slash commands the REPL understands — just quitting, for now (chat has
 /// no `/help`/`/model`/`/config`/`/status`, unlike `monocle agent`'s REPL).
 const CHAT_SLASH_COMMANDS: &[&str] = &["/exit", "/quit"];
@@ -286,11 +307,27 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
                 if trimmed.is_empty() {
                     continue;
                 }
+                // History gets the raw typed line (before `file:` tokens are
+                // stripped) — recalling it via ↑ should show what was actually
+                // typed, matching the non-attachment behavior this REPL already
+                // had.
                 let _ = rl.add_history_entry(line.as_str());
                 if trimmed == "/quit" || trimmed == "/exit" {
                     eprintln!("Bye.");
                     break;
                 }
+
+                let (text, images) = match resolve_repl_attachments(trimmed) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Same per-turn recovery as a `call_chat` error below:
+                        // print and go back to the prompt, no `call_chat` call
+                        // for this turn.
+                        eprintln!("Error: {e}");
+                        eprintln!();
+                        continue;
+                    }
+                };
 
                 eprintln!();
                 // Reset before this turn's work runs, so the hint below reflects
@@ -302,9 +339,9 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
                     &provider,
                     &model,
                     system_prompt.as_deref(),
-                    trimmed,
+                    &text,
                     max_tokens,
-                    &[],
+                    &images,
                 ) {
                     Ok(()) => {
                         let mut out = std::io::stdout();
@@ -341,7 +378,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_max_tokens, ChatReplHelper};
+    use super::{resolve_max_tokens, resolve_repl_attachments, ChatReplHelper};
     use rustyline::completion::Completer;
     use rustyline::history::DefaultHistory;
     use rustyline::Context;
@@ -418,5 +455,57 @@ mod tests {
         assert_eq!(resolve_max_tokens(Some("0")), None);
         assert_eq!(resolve_max_tokens(Some("-1")), None);
         assert_eq!(resolve_max_tokens(Some("  -42 ")), None);
+    }
+
+    #[test]
+    fn repl_line_with_no_file_ref_passes_through_unchanged() {
+        let (text, images) = resolve_repl_attachments("hello there").unwrap();
+        assert_eq!(text, "hello there");
+        assert!(images.is_empty());
+    }
+
+    #[test]
+    fn repl_line_with_valid_file_ref_resolves_and_strips_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"bytes").unwrap();
+        let line = format!("what's in file:{} ?", path.to_str().unwrap());
+
+        let (text, images) = resolve_repl_attachments(&line).unwrap();
+        assert!(!text.contains("file:"));
+        assert!(text.contains("what's in"));
+        assert_eq!(images.len(), 1);
+    }
+
+    #[test]
+    fn repl_line_with_image_only_file_ref_yields_empty_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"bytes").unwrap();
+        let line = format!("file:{}", path.to_str().unwrap());
+
+        let (text, images) = resolve_repl_attachments(&line).unwrap();
+        assert!(text.is_empty());
+        assert_eq!(images.len(), 1);
+    }
+
+    #[test]
+    fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
+        let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
+        assert!(err.contains("not found"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn repl_line_with_unsupported_extension_errors_with_typed_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.heic");
+        std::fs::write(&path, b"hello").unwrap();
+        let line = format!("file:{}", path.to_str().unwrap());
+
+        let err = resolve_repl_attachments(&line).unwrap_err();
+        assert!(
+            err.starts_with("unsupported type:"),
+            "unexpected message: {err}"
+        );
     }
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,5 +1,9 @@
 use std::io::{IsTerminal, Write};
 
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::history::DefaultHistory;
+use rustyline::{Config, Context, Editor, Helper, Highlighter, Hinter, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
@@ -13,6 +17,7 @@ use crate::endpoints;
 use crate::error::Result;
 use crate::net::Client;
 use crate::origin::auth_headers;
+use crate::util::home_dir;
 
 pub struct ChatOptions {
     pub model: Option<String>,
@@ -71,6 +76,45 @@ fn call_chat(
         eprintln!("\n⚠ the response was cut short (partial output shown).");
     }
     Ok(())
+}
+
+/// The slash commands the REPL understands — just quitting, for now (chat has
+/// no `/help`/`/model`/`/config`/`/status`, unlike `monocle agent`'s REPL).
+const CHAT_SLASH_COMMANDS: &[&str] = &["/exit", "/quit"];
+
+/// rustyline line helper for `monocle chat`'s REPL: Tab-completes the two
+/// slash commands. Hinting/highlighting/validation are the derived no-op
+/// defaults — multi-line handling comes from `bracketed_paste`, not a custom
+/// `Validator`. Deliberately simpler than `agent.rs`'s `ReplHelper` (no
+/// `/model`-argument fuzzy completion, no model-id list to carry).
+#[derive(Helper, Hinter, Highlighter, Validator)]
+struct ChatReplHelper;
+
+impl Completer for ChatReplHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // Only offer completion for a slash-command being typed at line start.
+        let head = &line[..pos];
+        if !head.starts_with('/') {
+            return Ok((0, Vec::new()));
+        }
+        let candidates = CHAT_SLASH_COMMANDS
+            .iter()
+            .filter(|cmd| cmd.starts_with(head))
+            .map(|cmd| Pair {
+                display: cmd.to_string(),
+                replacement: cmd.to_string(),
+            })
+            .collect();
+        // Replace from column 0 (the whole slash token starts there).
+        Ok((0, candidates))
+    }
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
@@ -211,64 +255,144 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         eprintln!("System prompt loaded ({} chars)", sp.chars().count());
     }
     eprintln!("Type your message. Press Ctrl+D to exit.");
+    eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
     eprintln!("---");
 
-    let stdin = std::io::stdin();
+    // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
+    // Ctrl-A/E/K/Y) with its default Emacs keymap + file history, mirroring
+    // `monocle agent`'s REPL (`src/commands/agent.rs`). `bracketed_paste(true)`
+    // makes a multi-line paste arrive as a single input buffer (submitted only
+    // on Enter) instead of each embedded newline being read as a separate
+    // accept-line → separate turn.
+    let config = Config::builder().bracketed_paste(true).build();
+    let mut rl: Editor<ChatReplHelper, DefaultHistory> =
+        Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
+    rl.set_helper(Some(ChatReplHelper));
+    // Separate history file from `monocle agent`'s — the two REPLs' histories
+    // stay independent.
+    let history_path = home_dir().join(".monocle").join("chat_history");
+    if let Some(parent) = history_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Best-effort history persistence: a missing/unreadable file just means an
+    // empty history this session.
+    let _ = rl.load_history(&history_path);
+
+    let prompt = "> ";
     loop {
-        eprint!("> ");
-        let _ = std::io::stderr().flush();
+        match rl.readline(prompt) {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let _ = rl.add_history_entry(line.as_str());
+                if trimmed == "/quit" || trimmed == "/exit" {
+                    eprintln!("Bye.");
+                    break;
+                }
 
-        let mut line = String::new();
-        let n = stdin.read_line(&mut line)?;
-        if n == 0 {
-            // EOF (Ctrl+D)
-            eprintln!("\nBye.");
-            break;
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("\nBye.");
-            break;
-        }
-
-        eprintln!();
-        // Reset before this turn's work runs, so the hint below reflects only
-        // whether *this* turn logged a network error — not a stale flag left
-        // over from an earlier one (this REPL loops for the life of the process,
-        // same as `monocle agent`'s).
-        crate::diag::reset();
-        match call_chat(
-            &provider,
-            &model,
-            system_prompt.as_deref(),
-            trimmed,
-            max_tokens,
-            &[],
-        ) {
-            Ok(()) => {
-                let mut out = std::io::stdout();
-                out.write_all(b"\n\n")?;
-                out.flush()?;
+                eprintln!();
+                // Reset before this turn's work runs, so the hint below reflects
+                // only whether *this* turn logged a network error — not a stale
+                // flag left over from an earlier one (this REPL loops for the
+                // life of the process, same as `monocle agent`'s).
+                crate::diag::reset();
+                match call_chat(
+                    &provider,
+                    &model,
+                    system_prompt.as_deref(),
+                    trimmed,
+                    max_tokens,
+                    &[],
+                ) {
+                    Ok(()) => {
+                        let mut out = std::io::stdout();
+                        out.write_all(b"\n\n")?;
+                        out.flush()?;
+                    }
+                    Err(e) => {
+                        eprintln!("Error: {e}");
+                        if crate::diag::was_logged() {
+                            eprintln!("  (details logged to {})", crate::diag::display_path());
+                        }
+                        eprintln!();
+                    }
+                }
+            }
+            // Ctrl-C: don't quit — just start a fresh prompt (matches `monocle
+            // agent`'s idle-prompt behavior).
+            Err(ReadlineError::Interrupted) => continue,
+            // Ctrl-D (EOF): quit, matching the previous read_line behavior.
+            Err(ReadlineError::Eof) => {
+                eprintln!("Bye.");
+                break;
             }
             Err(e) => {
                 eprintln!("Error: {e}");
-                if crate::diag::was_logged() {
-                    eprintln!("  (details logged to {})", crate::diag::display_path());
-                }
-                eprintln!();
+                break;
             }
         }
     }
 
+    let _ = rl.save_history(&history_path);
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_max_tokens;
+    use super::{resolve_max_tokens, ChatReplHelper};
+    use rustyline::completion::Completer;
+    use rustyline::history::DefaultHistory;
+    use rustyline::Context;
+
+    #[test]
+    fn complete_slash_command_narrows_to_matching_prefix() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/qu";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/quit".to_string()]
+        );
+    }
+
+    #[test]
+    fn complete_bare_slash_offers_both_commands() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/exit".to_string(), "/quit".to_string()]
+        );
+    }
+
+    #[test]
+    fn complete_non_slash_text_offers_nothing() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "hello";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert!(candidates.is_empty());
+    }
 
     #[test]
     fn absent_flag_omits() {


### PR DESCRIPTION
## 배경

정수님이 직접 사용하다가 `monocle chat`의 인터랙티브 REPL이 `monocle agent`와 달리 readline(방향키 히스토리, 라인 편집)을 지원하지 않는다는 걸 발견해서 요청한 기능 patch입니다 — agent 모드에 추가됐던 REPL UX 개선이 chat 모드에는 적용 안 되고 있었던 격차.

## 변경 내용

`monocle agent`의 rustyline 기반 REPL(`Editor` + bracketed-paste 설정 + 세션 간 유지되는 히스토리 파일 + Tab 완성)을 `monocle chat`의 인터랙티브 REPL에도 포팅했습니다.

의도적으로 범위를 좁혀서:

- chat 전용의 새 `ChatReplHelper`(agent의 `ReplHelper`보다 단순 — `/model` 인자 fuzzy 완성이나 모델 목록 프리페치 없음)로 기존 슬래시 커맨드(`/quit`, `/exit`)만 Tab 완성 지원.
- 히스토리는 `~/.monocle/chat_history`에 별도 저장(agent의 `~/.monocle/agent_history`와 독립).
- rustyline의 에러 처리(Ctrl-C=현재 턴만 취소하지 않고 계속 진행 / Ctrl-D=종료)는 `agent.rs`와 동일한 패턴을 따름.

**의도적으로 범위 밖으로 둔 것:**

- chat에 `/model`/`/help`/`/config`/`/status` 같은 새 슬래시 커맨드 추가
- agent에 있는 "Ctrl-C가 현재 턴만 취소"하는 동작(별도의 시그널/취소 처리 인프라가 필요해 이번 범위 밖)
- `agent.rs` 자체 변경
- chat의 대화/요청 로직이나 파이프/원샷 입력 경로(최근 머지된 `--file`/인밴드 `file:` 첨부 기능 포함) 변경 — 이번 diff는 인터랙티브 REPL 분기만 건드림

## 검증

- cargo build/test/clippy `-D warnings`/fmt 전부 green (신규 `Completer` 유닛 테스트 3개 포함)
- 실제 PTY 기반 인터랙티브 스모크 테스트 수행:
  - bracketed paste 활성화
  - 빈 Enter 무시
  - Tab 완성(`/qu` → `/quit`)
  - `/exit` 정상 종료
  - Ctrl-C는 종료 안 하고 새 프롬프트만
  - Ctrl-D는 정상 종료
  - `~/.monocle/chat_history` 파일이 `agent_history`와 별도로 생성/기록됨을 확인
- 독립적인 코드리뷰(9개 항목 전수)도 통과 — 특히 최근 머지된 파일 첨부 기능이 있는 원샷/파이프 경로가 이번 변경으로 전혀 건드려지지 않았음을 별도 확인함

## 변경 파일

- `README.md` (+6)
- `src/commands/chat.rs` (+172/-42)
