### PR TITLE
release: v1.2.0 — 버전 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
## 요약

v1.1.1 이후 devel에 쌓인 기능들을 v1.2.0으로 릴리스.

- chat: `--file` 플래그와 인밴드 `file:` 토큰으로 이미지 첨부 지원 (#67)
- agent: `/model` 인자에 모델 목록 fuzzy-completion 추가 (#66)
- 네트워크/스트리밍 에러 진단성 개선 — `~/.monocle/cli.log` 추가, diag 플래그
  REPL 턴 간 누수 수정 (#65)
- chat REPL에 agent REPL의 rustyline 라인 편집 포팅 (#68)

Cargo.toml/Cargo.lock: `1.1.1` → `1.2.0`.

**제외**: mcp 서브커맨드(#70)는 아직 리뷰 전이고, 실 staging/prod에서
stark#1058/#1061에 막혀 동작하지 않아 이번 릴리스 스코프 밖.

## Test plan

- [x] `cargo check` 통과, Cargo.lock 버전 동기화 확인
- [ ] CI green 확인 후 merge