### PR TITLE
Release v1.2.0: devel → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1079,7 @@ dependencies = [
  "ctrlc",
  "flate2",
  "futures-io",
+ "fuzzy-matcher",
  "open",
  "rand 0.8.6",
  "reqwest",
@@ -1813,6 +1823,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ ctrlc = "3"
 # Default features bring the Emacs keymap + FileHistory; used solely on the
 # interactive TTY path (see src/commands/agent.rs) — never in headless/ACP.
 rustyline = { version = "14", features = ["derive"] }
+# Fuzzy-matching for the REPL's `/model <TAB>` completion (skim's algorithm).
+# Small, dependency-light (adds only `thread_local`); default features only.
+fuzzy-matcher = "0.3.7"
 # ACP server-agent surface (Phase 3). async stays confined to src/acp.rs; the
 # core loop is sync. Pin 0.9 (trait-based `impl Agent`); 1.0 is a builder rewrite.
 agent-client-protocol = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ print(resp.choices[0].message.content)
 **Token expired**
 → `monocle token` auto-refreshes when near expiry. If it's been more than 30 days since your last login, run `monocle login` again.
 
+**"Error: error decoding response body" (or another network/streaming error)**
+→ The request/response context (method, URL, underlying error) is appended to
+`~/.monocle/cli.log` whenever this happens; a hint pointing there is printed alongside
+the error. The file is otherwise never written or referenced — check it only when you
+hit an error and need more detail than the one-line message.
+
 For Claude Code and OpenAI SDK specific issues, see the linked guides above.
 
 ## Help

--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ In the interactive REPL, lines starting with `/` are local management commands (
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,
 `/model` shows the current model (or `/model <id>` switches it for later turns), and
-`/exit` (or `/quit`, Ctrl-D) quits.
+`/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the model ids
+available to your account (fetched once at startup) — e.g. `/model cla<TAB>` narrows to
+matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
+list can't be fetched, completion just offers nothing (typing a full id still works).
 
 ```bash
 monocle agent "summarize the TODOs in this repo" --workdir .

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>]` | Chat with a model (REPL or stdin) |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]...` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only) |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
@@ -119,6 +119,52 @@ monocle chat --system-prompt-file ./persona.md --model claude-opus-4-7
 
 > [!NOTE]
 > `monocle model chat` / `monocle model list` still work but are deprecated and will be removed in a future release.
+
+### 📎 Attaching files/images
+
+`monocle chat` can attach files (images in v1) to a one-shot (piped) message —
+handy as an eval primitive for comparing how different providers/models handle
+vision input:
+
+```bash
+echo "count the people in this image" | monocle chat --file photo.png --model gpt-4o
+```
+
+- `--file <PATH|URL>` is repeatable. A local path is read, MIME-sniffed by
+  extension, and base64-encoded into a `data:<mime>;base64,...` URI; an
+  `http://`/`https://` value is passed straight through as the remote image
+  URL (no fetch).
+- Only image types are wired to a vision request in v1 (`png`, `jpg`/`jpeg`,
+  `gif`, `webp`). Anything else is a hard error: `unsupported type: <mime>`.
+- You can also reference a file **inband**, inside the piped text itself,
+  with an Org-mode-style `file:<path>` token — **not** a standard `file://`
+  URI (no `//` required, and relative paths are fine):
+
+  ```bash
+  echo "compare file:./a.png and file:./b.png, which is sharper?" | monocle chat --model gpt-4o
+  ```
+
+  The `file:` token is stripped from the text sent to the model. Trailing
+  sentence punctuation (`.,;:!?)'"`) right after the path is trimmed before
+  resolving — a known v1 limitation if your path itself legitimately ends in
+  one of those characters.
+- Explicit `--file` flags resolve first (in the order given), then inband
+  `file:` references in the order they appear in the text.
+- An attachment-only message (no text) is valid.
+- Attachments are **one-shot only** — not supported in the interactive REPL.
+  Passing `--file` while stdin is a terminal is an error asking you to pipe
+  the instruction instead.
+
+This makes `monocle chat` a quick harness for an image-handling eval loop —
+run the same image + instruction across models and diff both the answers and
+the raw provider error messages:
+
+```bash
+for m in gpt-4o claude-sonnet-4-6 gemini-2-flash; do
+  echo "=== $m ==="
+  echo "count the people in this image" | monocle chat --file crowd.jpg --model "$m"
+done
+```
 
 ## 🔊 Audio (STT / TTS)
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Hello! How can I help you today?
 Bye.
 ```
 
+The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
+and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
+Tab completes `/quit`/`/exit`, and a multi-line paste is inserted as a single input
+(submitted only on Enter, not one turn per line). Command history persists across
+sessions in `~/.monocle/chat_history` (kept separate from `monocle agent`'s history).
+
 One-shot via stdin:
 
 ```console
@@ -151,9 +157,12 @@ echo "count the people in this image" | monocle chat --file photo.png --model gp
 - Explicit `--file` flags resolve first (in the order given), then inband
   `file:` references in the order they appear in the text.
 - An attachment-only message (no text) is valid.
-- Attachments are **one-shot only** — not supported in the interactive REPL.
-  Passing `--file` while stdin is a terminal is an error asking you to pipe
-  the instruction instead.
+- The `--file` flag is **one-shot only** — passing it while stdin is a
+  terminal is an error asking you to pipe the instruction instead. Inband
+  `file:<path>` tokens, however, also work when typed directly into the
+  **interactive REPL**: a resolution failure (bad path, unsupported type)
+  prints an error and returns you to the prompt rather than exiting the
+  session.
 
 This makes `monocle chat` a quick harness for an image-handling eval loop —
 run the same image + instruction across models and diff both the answers and

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -128,6 +128,20 @@ pub struct ChatRequest {
     pub messages: Vec<Message>,
     pub max_tokens: Option<i64>,
     pub tools: Vec<ToolDef>,
+    /// Images to attach to the last user message as OpenAI vision parts (see
+    /// `MonocleProvider::build_body`). Carried on the request rather than
+    /// `Message` because `monocle chat` rebuilds `messages` fresh every turn —
+    /// attachments never need to survive into a later turn (monocle-cli
+    /// file-attach plan).
+    pub images: Vec<ImageAttachment>,
+}
+
+/// One resolved image, ready to drop into an OpenAI `image_url` content part —
+/// either a `data:<mime>;base64,...` URI (local file) or a passthrough remote
+/// `http(s)://` URL.
+#[derive(Debug, Clone)]
+pub struct ImageAttachment {
+    pub url: String,
 }
 
 /// The assistant's reply for one turn.
@@ -374,9 +388,30 @@ impl MonocleProvider {
     }
 
     fn build_body(&self, req: &ChatRequest, stream: bool) -> Value {
+        let mut messages = json!(req.messages);
+        // Vision requests (monocle-cli file-attach plan): rewrite the last
+        // `user` message's `content` from a plain string into the OpenAI
+        // multi-part shape (`[{type:text}, {type:image_url}, ...]`). With no
+        // images the messages serialize exactly as before — this branch is
+        // the only place behavior can diverge.
+        if !req.images.is_empty() {
+            if let Some(arr) = messages.as_array_mut() {
+                if let Some(last_user) = arr.iter_mut().rev().find(|m| m["role"] == "user") {
+                    let mut parts: Vec<Value> = Vec::new();
+                    let text = last_user["content"].as_str().unwrap_or("");
+                    if !text.is_empty() {
+                        parts.push(json!({"type": "text", "text": text}));
+                    }
+                    for img in &req.images {
+                        parts.push(json!({"type": "image_url", "image_url": {"url": img.url}}));
+                    }
+                    last_user["content"] = json!(parts);
+                }
+            }
+        }
         let mut body = json!({
             "model": req.model,
-            "messages": req.messages,
+            "messages": messages,
             "stream": stream,
         });
         if let Some(max_tokens) = req.max_tokens {
@@ -559,5 +594,83 @@ mod tests {
             resp.is_err(),
             "a stream with no usable completion should error"
         );
+    }
+
+    fn dummy_provider() -> MonocleProvider {
+        MonocleProvider::new("token", "https://router.example")
+    }
+
+    #[test]
+    fn build_body_with_no_images_is_unchanged() {
+        // The critical regression oracle: an empty `images` vec must produce
+        // exactly the same body as before attachments existed — a plain
+        // string `content`, not an array.
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::system("be terse"), Message::user("hello")],
+            max_tokens: Some(100),
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+        assert_eq!(body["messages"][0]["content"], json!("be terse"));
+        assert_eq!(body["messages"][1]["content"], json!("hello"));
+        assert!(body["messages"][1]["content"].is_string());
+        assert_eq!(body["max_tokens"], json!(100));
+    }
+
+    #[test]
+    fn build_body_with_images_rewrites_last_user_message_as_parts() {
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::system("be terse"), Message::user("count them")],
+            images: vec![
+                ImageAttachment {
+                    url: "data:image/png;base64,AAAA".to_string(),
+                },
+                ImageAttachment {
+                    url: "https://example.com/b.png".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+
+        // System message untouched.
+        assert_eq!(body["messages"][0]["content"], json!("be terse"));
+
+        // Last user message becomes a parts array: text part then image parts,
+        // in the order the images were given.
+        let parts = body["messages"][1]["content"]
+            .as_array()
+            .expect("user content should be rewritten into an array");
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], json!({"type": "text", "text": "count them"}));
+        assert_eq!(
+            parts[1],
+            json!({"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}})
+        );
+        assert_eq!(
+            parts[2],
+            json!({"type": "image_url", "image_url": {"url": "https://example.com/b.png"}})
+        );
+    }
+
+    #[test]
+    fn build_body_with_images_and_empty_text_omits_text_part() {
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::user("")],
+            images: vec![ImageAttachment {
+                url: "https://example.com/a.png".to_string(),
+            }],
+            ..Default::default()
+        };
+        let body = provider.build_body(&req, false);
+        let parts = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], json!("image_url"));
     }
 }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -158,6 +158,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
                 messages: conversation.clone(),
                 max_tokens: self.config.max_tokens,
                 tools: defs.clone(),
+                ..Default::default()
             };
             // Stream assistant text to the observer as it arrives.
             let resp = self

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,0 +1,187 @@
+//! File/image attachment resolution for `monocle chat` (vision eval
+//! primitive). Mirrors `audio_io.rs`'s patterns for file/MIME/error handling,
+//! but is kept separate since its MIME table is image-only (audio_io's is
+//! audio-only) — see the file/image-attachments plan.
+
+use std::path::Path;
+
+use base64::Engine;
+
+use crate::agent::providers::ImageAttachment;
+use crate::error::{AppError, Result};
+
+/// Sentence punctuation trimmed off the trailing end of a captured `file:`
+/// token before it is treated as a path (e.g. `file:./a.png.` in "...a.png.").
+const TRAILING_PUNCT: [char; 9] = ['.', ',', ';', ':', '!', '?', ')', '\'', '"'];
+
+fn mime_by_ext(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+/// Resolve a `--file` value or an inband `file:<path>` reference into an
+/// [`ImageAttachment`].
+///
+/// - `http://` / `https://` → passed through verbatim as a remote
+///   `image_url.url` (no fetch, no base64).
+/// - Anything else is treated as a local path: read the bytes, guess MIME by
+///   extension, and if it's `image/*` encode as a `data:<mime>;base64,...`
+///   URI. A missing file or a non-image MIME is a hard, typed error (matches
+///   the file-not-found style in `audio_io::resolve_audio_input`).
+pub fn resolve(value: &str) -> Result<ImageAttachment> {
+    if value.starts_with("http://") || value.starts_with("https://") {
+        return Ok(ImageAttachment {
+            url: value.to_string(),
+        });
+    }
+
+    let path = Path::new(value);
+    if !path.exists() {
+        return Err(AppError::new(format!("file not found: {value}")));
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+    let mime = mime_by_ext(&ext).unwrap_or("application/octet-stream");
+    if !mime.starts_with("image/") {
+        return Err(AppError::new(format!("unsupported type: {mime}")));
+    }
+
+    let data = std::fs::read(path)?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+    Ok(ImageAttachment {
+        url: format!("data:{mime};base64,{b64}"),
+    })
+}
+
+/// Scan `text` for inband `file:<path>` tokens (Org-mode-style — NOT a strict
+/// `file://` URI; no `//` required, relative paths welcome), returning the
+/// text with each matched token removed and the ordered list of raw path
+/// strings found (trailing sentence punctuation trimmed off each).
+///
+/// All whitespace other than the removed tokens themselves is preserved
+/// verbatim, so text with no `file:` tokens comes back byte-identical — this
+/// is the regression oracle for the common (no-attachment) path.
+pub fn extract_inband_refs(text: &str) -> (String, Vec<String>) {
+    let mut refs = Vec::new();
+    let mut result = String::with_capacity(text.len());
+    let mut rest = text;
+
+    loop {
+        let word_start = match rest.find(|c: char| !c.is_whitespace()) {
+            Some(idx) => idx,
+            None => {
+                result.push_str(rest);
+                break;
+            }
+        };
+        // Whitespace before the next word — keep verbatim.
+        result.push_str(&rest[..word_start]);
+        let after_ws = &rest[word_start..];
+        let word_end = after_ws
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(after_ws.len());
+        let word = &after_ws[..word_end];
+
+        match word.strip_prefix("file:") {
+            Some(path) => {
+                let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
+                if trimmed.is_empty() {
+                    // "file:" with nothing usable after it — not a real token.
+                    result.push_str(word);
+                } else {
+                    refs.push(trimmed.to_string());
+                    // Token is stripped from the outgoing text entirely.
+                }
+            }
+            None => result.push_str(word),
+        }
+
+        rest = &after_ws[word_end..];
+    }
+
+    (result, refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn resolves_local_png_to_data_uri() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"not a real png but bytes are enough").unwrap();
+
+        let img = resolve(path.to_str().unwrap()).expect("should resolve");
+        let expected_b64 = base64::engine::general_purpose::STANDARD
+            .encode(b"not a real png but bytes are enough");
+        assert_eq!(img.url, format!("data:image/png;base64,{expected_b64}"));
+    }
+
+    #[test]
+    fn http_url_passes_through_unencoded() {
+        let img = resolve("https://example.com/a.png").expect("should pass through");
+        assert_eq!(img.url, "https://example.com/a.png");
+
+        let img = resolve("http://example.com/a.png").expect("should pass through");
+        assert_eq!(img.url, "http://example.com/a.png");
+    }
+
+    #[test]
+    fn nonexistent_path_errors() {
+        let err = resolve("/no/such/path/ever.png").unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn non_image_extension_errors_with_typed_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"hello").unwrap();
+
+        let err = resolve(path.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().starts_with("unsupported type:"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_inband_refs_strips_tokens_and_trims_trailing_punct() {
+        let (cleaned, refs) = extract_inband_refs("compare file:./a.png and file:./b.png.");
+        assert_eq!(refs, vec!["./a.png".to_string(), "./b.png".to_string()]);
+        // Tokens removed; surrounding words/whitespace otherwise untouched.
+        assert!(!cleaned.contains("file:"));
+        assert!(cleaned.contains("compare"));
+        assert!(cleaned.contains("and"));
+    }
+
+    #[test]
+    fn bare_https_substring_is_left_untouched() {
+        let (cleaned, refs) = extract_inband_refs("see https://example.com/x.png please");
+        assert!(refs.is_empty());
+        assert_eq!(cleaned, "see https://example.com/x.png please");
+    }
+
+    #[test]
+    fn no_tokens_is_byte_identical() {
+        let text = "line one\nline two   with   spaces\tand a tab";
+        let (cleaned, refs) = extract_inband_refs(text);
+        assert!(refs.is_empty());
+        assert_eq!(cleaned, text);
+    }
+}

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -52,7 +52,9 @@ pub fn resolve(value: &str) -> Result<ImageAttachment> {
         .unwrap_or_default();
     let mime = mime_by_ext(&ext).unwrap_or("application/octet-stream");
     if !mime.starts_with("image/") {
-        return Err(AppError::new(format!("unsupported type: {mime}")));
+        return Err(AppError::new(format!(
+            "unsupported type: {mime} (from extension \"{ext}\" of {value})"
+        )));
     }
 
     let data = std::fs::read(path)?;
@@ -91,18 +93,28 @@ pub fn extract_inband_refs(text: &str) -> (String, Vec<String>) {
             .unwrap_or(after_ws.len());
         let word = &after_ws[..word_end];
 
-        match word.strip_prefix("file:") {
-            Some(path) => {
-                let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
-                if trimmed.is_empty() {
-                    // "file:" with nothing usable after it — not a real token.
-                    result.push_str(word);
-                } else {
-                    refs.push(trimmed.to_string());
-                    // Token is stripped from the outgoing text entirely.
-                }
+        // Marker match is case-insensitive (`File:`, `FILE:`, ... all count —
+        // mobile autocapitalize / sentence-case habit shouldn't silently drop
+        // an attachment), but only the 5-byte marker itself is case-folded for
+        // the comparison; the path remainder is used verbatim since filesystem
+        // paths are case-sensitive on Linux/macOS.
+        let is_file_marker = word
+            .get(..5)
+            .map(|prefix| prefix.eq_ignore_ascii_case("file:"))
+            .unwrap_or(false);
+
+        if is_file_marker {
+            let path = &word[5..];
+            let trimmed = path.trim_end_matches(TRAILING_PUNCT.as_slice());
+            if trimmed.is_empty() {
+                // "file:" with nothing usable after it — not a real token.
+                result.push_str(word);
+            } else {
+                refs.push(trimmed.to_string());
+                // Token is stripped from the outgoing text entirely.
             }
-            None => result.push_str(word),
+        } else {
+            result.push_str(word);
         }
 
         rest = &after_ws[word_end..];
@@ -149,14 +161,27 @@ mod tests {
     #[test]
     fn non_image_extension_errors_with_typed_message() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("notes.txt");
+        let path = dir.path().join("notes.heic");
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(b"hello").unwrap();
 
         let err = resolve(path.to_str().unwrap()).unwrap_err();
+        let msg = err.to_string();
         assert!(
-            err.to_string().starts_with("unsupported type:"),
-            "unexpected message: {err}"
+            msg.starts_with("unsupported type:"),
+            "unexpected message: {msg}"
+        );
+        // Regression: the rejected extension (and the offending path) must be
+        // named in the error — otherwise the user has no way to diagnose
+        // "what happened with this file/format" (the whole point of the
+        // feature).
+        assert!(
+            msg.contains("heic"),
+            "error should name the rejected extension: {msg}"
+        );
+        assert!(
+            msg.contains(path.to_str().unwrap()),
+            "error should name the offending path: {msg}"
         );
     }
 
@@ -168,6 +193,23 @@ mod tests {
         assert!(!cleaned.contains("file:"));
         assert!(cleaned.contains("compare"));
         assert!(cleaned.contains("and"));
+    }
+
+    #[test]
+    fn inband_marker_is_case_insensitive_but_path_case_is_preserved() {
+        let (cleaned, refs) = extract_inband_refs("look at File:./Photo.png please");
+        assert_eq!(refs, vec!["./Photo.png".to_string()]);
+        assert!(!cleaned.to_lowercase().contains("file:"));
+        assert!(cleaned.contains("look"));
+        assert!(cleaned.contains("please"));
+
+        let (cleaned2, refs2) = extract_inband_refs("FILE:./B.PNG");
+        assert_eq!(refs2, vec!["./B.PNG".to_string()]);
+        assert!(cleaned2.trim().is_empty());
+
+        // Lowercase marker still works unchanged (regression).
+        let (_, refs3) = extract_inband_refs("file:./a.png");
+        assert_eq!(refs3, vec!["./a.png".to_string()]);
     }
 
     #[test]

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -6,7 +6,10 @@
 
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
+use std::rc::Rc;
 
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
@@ -21,6 +24,7 @@ use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
+use crate::commands::model_list::fetch_model_ids;
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -72,10 +76,20 @@ impl Observer for CliObserver {
 /// what `dispatch_command` / `parse_model_command` actually handle.
 const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
 
-/// rustyline line helper: Tab-completes slash commands. Hinting/highlighting/
-/// validation are the derived no-op defaults — we only customize completion.
+/// rustyline line helper: Tab-completes slash commands, and (for `/model`)
+/// fuzzy-completes the argument against a model id list fetched once at REPL
+/// startup. Hinting/highlighting/validation are the derived no-op defaults —
+/// we only customize completion.
 #[derive(Helper, Hinter, Highlighter, Validator)]
-struct ReplHelper;
+struct ReplHelper {
+    /// Model ids fetched once before the loop starts (see `agent_command`).
+    /// Empty when not logged in / the fetch failed — `/model` completion then
+    /// just offers no candidates, same defensive posture as the rest of the
+    /// interactive path. `Rc` because `Editor::set_helper` takes ownership and
+    /// the list is read-only for the session's lifetime (no need for a `Vec`
+    /// clone per keystroke).
+    models: Rc<Vec<String>>,
+}
 
 impl Completer for ReplHelper {
     type Candidate = Pair;
@@ -91,6 +105,16 @@ impl Completer for ReplHelper {
         if !head.starts_with('/') {
             return Ok((0, Vec::new()));
         }
+        // `/model <partial>` — fuzzy-match the argument against the cached model
+        // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
+        // to matching ids and a bare `/model <TAB>` shows the full dropdown.
+        // Replace only from just after "/model " (not column 0, unlike the
+        // command-name path below) — we're completing the argument, not the
+        // command word.
+        if let Some(query) = head.strip_prefix("/model ") {
+            let start = head.len() - query.len();
+            return Ok((start, fuzzy_model_candidates(&self.models, query)));
+        }
         let candidates = SLASH_COMMANDS
             .iter()
             .filter(|cmd| cmd.starts_with(head))
@@ -102,6 +126,31 @@ impl Completer for ReplHelper {
         // Replace from column 0 (the whole slash token starts there).
         Ok((0, candidates))
     }
+}
+
+/// Fuzzy-match `query` against cached model ids for `/model` tab-completion.
+/// An empty query returns the full list unranked (the "show me what's
+/// available" dropdown); otherwise ids are scored with `fuzzy-matcher`'s skim
+/// algorithm (subsequence match, case-smart), kept only if they match at all,
+/// and sorted best match first.
+fn fuzzy_model_candidates(models: &[String], query: &str) -> Vec<Pair> {
+    let to_pair = |id: &String| Pair {
+        display: id.clone(),
+        replacement: id.clone(),
+    };
+    if query.is_empty() {
+        return models.iter().map(to_pair).collect();
+    }
+    // `ignore_case` (not the default smart-case) so typing in any case still
+    // narrows the (lowercase-by-convention) model ids — smart-case would make
+    // an all-caps query like "CLAUDE" match nothing.
+    let matcher = SkimMatcherV2::default().ignore_case();
+    let mut scored: Vec<(i64, &String)> = models
+        .iter()
+        .filter_map(|id| matcher.fuzzy_match(id, query).map(|score| (score, id)))
+        .collect();
+    scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+    scored.into_iter().map(|(_, id)| to_pair(id)).collect()
 }
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
@@ -365,6 +414,16 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         )
     );
 
+    // Prime `/model` tab-completion with the real model id list — fetched once,
+    // up front, never inside the completer itself (a blocking HTTP call on every
+    // Tab press would make typing laggy). Best-effort: not logged in, an
+    // unreachable router, or any other fetch error just leaves the list empty
+    // rather than blocking startup or crashing the REPL — the same defensive
+    // posture `login_view` uses for `/status` in a not-logged-in session. The
+    // `client`'s own connect/total timeouts (`src/net.rs`) already bound how
+    // long this can hang.
+    let model_ids = fetch_model_ids(client, creds).unwrap_or_default();
+
     // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
     // Ctrl-A/E/K/Y) with its default Emacs keymap + file history. It is used
     // ONLY here, on the interactive TTY path — the headless / piped / ACP paths
@@ -383,7 +442,9 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     let config = Config::builder().bracketed_paste(true).build();
     let mut rl: Editor<ReplHelper, DefaultHistory> =
         Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
-    rl.set_helper(Some(ReplHelper));
+    rl.set_helper(Some(ReplHelper {
+        models: Rc::new(model_ids),
+    }));
     let history_path = home_dir().join(".monocle").join("agent_history");
     if let Some(parent) = history_path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -557,6 +618,110 @@ mod tests {
         assert_eq!(
             parse_model_command("/model  claude-x  "),
             Some(Some("claude-x".to_string()))
+        );
+    }
+
+    fn model_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_empty_query_returns_full_list_unranked() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, models);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_narrows_by_subsequence() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "cla")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, vec!["claude-sonnet-4-6", "claude-opus-4"]);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_ranks_tighter_match_first() {
+        // "gpt4o" as a subsequence appears in both, but a contiguous match in
+        // "gpt-4o" should outrank the more scattered match in "gpt-4-omni".
+        let models = model_ids(&["gpt-4-omni", "gpt-4o"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "gpt4o")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got.first().map(String::as_str), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_excludes_non_matches() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o"]);
+        let got = fuzzy_model_candidates(&models, "zzz");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_case_insensitive() {
+        let models = model_ids(&["claude-sonnet-4-6"]);
+        let got = fuzzy_model_candidates(&models, "CLAUDE");
+        assert_eq!(got.len(), 1);
+    }
+
+    /// The completion `start` offset is what rustyline uses to splice the
+    /// chosen candidate back into the line — get it wrong and accepting a
+    /// completion corrupts the line. For `/model <partial>` it must point
+    /// just past `"/model "`, not column 0 (unlike the command-name path),
+    /// so accepting a candidate replaces only the partial id.
+    #[test]
+    fn complete_model_argument_uses_offset_after_prefix() {
+        let helper = ReplHelper {
+            models: Rc::new(model_ids(&["claude-sonnet-4-6", "gpt-4o"])),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model cla";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
+        );
+
+        // Bare "/model " (empty partial) offers the full dropdown, still
+        // anchored right after the prefix.
+        let line = "/model ";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(candidates.len(), 2);
+    }
+
+    /// Command-name completion (`/mo<TAB>` → `/model`) must be unaffected by
+    /// the new `/model` argument branch.
+    #[test]
+    fn complete_command_name_unaffected_by_model_argument_branch() {
+        let helper = ReplHelper {
+            models: Rc::new(model_ids(&["claude-sonnet-4-6"])),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/mo";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/model".to_string()]
         );
     }
 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -455,6 +455,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                         // A transient per-turn error must not tear down the session.
                         if let Err(e) = repl.run_turn(msg.to_string()) {
                             eprintln!("{} {e}", c::red("Error:"));
+                            if crate::diag::was_logged() {
+                                eprintln!(
+                                    "  {}",
+                                    c::dim(&format!(
+                                        "(details logged to {})",
+                                        crate::diag::display_path()
+                                    ))
+                                );
+                            }
                         }
                     }
                 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -452,6 +452,10 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                         eprintln!("unknown command: {cmd} (try /help)");
                     }
                     Command::Turn => {
+                        // Reset before this turn's work runs, so the hint below
+                        // reflects only whether *this* turn logged a network
+                        // error — not a stale flag left over from an earlier one.
+                        crate::diag::reset();
                         // A transient per-turn error must not tear down the session.
                         if let Err(e) = repl.run_turn(msg.to_string()) {
                             eprintln!("{} {e}", c::red("Error:"));

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -101,9 +101,18 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         std::process::exit(1);
     }
 
-    // Read stdin + resolve any attachments up front — cheap, local-only work
-    // that should fail fast (bad path, unsupported MIME) before we ever touch
-    // the network for auth/model validation below.
+    // Auth FIRST — before any local-input validation. Otherwise an expired/
+    // missing-credentials error can be masked by a local failure that happens
+    // to come first (e.g. empty piped stdin reporting "No input provided via
+    // stdin." while the real problem is "Not logged in").
+    let session = get_access_token(client, creds);
+    let token = session.token;
+    let router_url = session.router_url;
+    let bearer = format!("Bearer {token}");
+
+    // Read stdin + resolve any attachments — cheap, local-only work that
+    // should fail fast (bad path, unsupported MIME) before the second network
+    // call (model-ID validation) below, but after the auth check above.
     let one_shot_input: Option<(String, Vec<ImageAttachment>)> = if !stdin_is_tty {
         let mut input = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
@@ -146,11 +155,6 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     } else {
         options.system_prompt.clone()
     };
-
-    let session = get_access_token(client, creds);
-    let token = session.token;
-    let router_url = session.router_url;
-    let bearer = format!("Bearer {token}");
 
     // Validate the model ID against the available models (non-fatal on failure).
     if let Ok(resp) = client.get(

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -2,8 +2,11 @@ use std::io::{IsTerminal, Write};
 
 use serde_json::Value;
 
-use crate::agent::providers::{ChatRequest, LlmProvider, Message, MonocleProvider};
+use crate::agent::providers::{
+    ChatRequest, ImageAttachment, LlmProvider, Message, MonocleProvider,
+};
 use crate::agent::DEFAULT_MODEL;
+use crate::attachment;
 use crate::auth::get_access_token;
 use crate::credentials::Credentials;
 use crate::endpoints;
@@ -16,6 +19,8 @@ pub struct ChatOptions {
     pub system_prompt: Option<String>,
     pub system_prompt_file: Option<String>,
     pub max_tokens: Option<String>,
+    /// `--file <PATH|URL>` values (repeatable), one-shot only.
+    pub files: Vec<String>,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -37,6 +42,7 @@ fn call_chat(
     system_prompt: Option<&str>,
     user_message: &str,
     max_tokens: Option<i64>,
+    images: &[ImageAttachment],
 ) -> Result<()> {
     let mut messages = Vec::new();
     if let Some(sp) = system_prompt {
@@ -48,6 +54,7 @@ fn call_chat(
         model: model.to_string(),
         messages,
         max_tokens,
+        images: images.to_vec(),
         ..Default::default()
     };
     // Acquire the stdout lock once for the whole stream rather than per token —
@@ -82,6 +89,52 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             eprintln!("⚠ ignoring --max-tokens '{raw}' (a positive integer is required)");
         }
     }
+
+    let stdin_is_tty = std::io::stdin().is_terminal();
+
+    // Attachments (`--file` / inband `file:<path>`) are one-shot only (piped
+    // stdin), never the interactive REPL.
+    if !options.files.is_empty() && stdin_is_tty {
+        eprintln!(
+            "--file requires piped input. Pipe your instruction, e.g.:\n  echo \"describe this image\" | monocle chat --file photo.png"
+        );
+        std::process::exit(1);
+    }
+
+    // Read stdin + resolve any attachments up front — cheap, local-only work
+    // that should fail fast (bad path, unsupported MIME) before we ever touch
+    // the network for auth/model validation below.
+    let one_shot_input: Option<(String, Vec<ImageAttachment>)> = if !stdin_is_tty {
+        let mut input = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
+        let (cleaned_text, inband_refs) = attachment::extract_inband_refs(input.trim());
+
+        let mut refs: Vec<String> = options.files.clone();
+        refs.extend(inband_refs);
+
+        let mut images: Vec<ImageAttachment> = Vec::new();
+        for r in &refs {
+            match attachment::resolve(r) {
+                Ok(img) => images.push(img),
+                Err(e) => {
+                    eprintln!("{e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        let cleaned_text = cleaned_text.trim().to_string();
+        // Image-only messages are valid — only bail when BOTH the text and the
+        // attachments are empty.
+        if cleaned_text.is_empty() && images.is_empty() {
+            eprintln!("No input provided via stdin.");
+            std::process::exit(1);
+        }
+
+        Some((cleaned_text, images))
+    } else {
+        None
+    };
 
     // Resolve system prompt.
     let system_prompt: Option<String> = if let Some(path) = &options.system_prompt_file {
@@ -129,22 +182,17 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
 
     let provider = MonocleProvider::new(token, router_url.clone());
 
-    // Non-interactive: stdin is piped.
-    if !std::io::stdin().is_terminal() {
-        let mut input = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
-        if input.trim().is_empty() {
-            eprintln!("No input provided via stdin.");
-            std::process::exit(1);
-        }
+    // Non-interactive: stdin was piped (input + attachments already resolved above).
+    if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
         call_chat(
             &provider,
             &model,
             system_prompt.as_deref(),
-            input.trim(),
+            &text,
             max_tokens,
+            &images,
         )?;
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
@@ -189,6 +237,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
             system_prompt.as_deref(),
             trimmed,
             max_tokens,
+            &[],
         ) {
             Ok(()) => {
                 let mut out = std::io::stdout();

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -183,6 +183,11 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         }
 
         eprintln!();
+        // Reset before this turn's work runs, so the hint below reflects only
+        // whether *this* turn logged a network error — not a stale flag left
+        // over from an earlier one (this REPL loops for the life of the process,
+        // same as `monocle agent`'s).
+        crate::diag::reset();
         match call_chat(
             &provider,
             &model,
@@ -195,7 +200,13 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
                 out.write_all(b"\n\n")?;
                 out.flush()?;
             }
-            Err(e) => eprintln!("Error: {e}\n"),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                if crate::diag::was_logged() {
+                    eprintln!("  (details logged to {})", crate::diag::display_path());
+                }
+                eprintln!();
+            }
         }
     }
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,5 +1,9 @@
 use std::io::{IsTerminal, Write};
 
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::history::DefaultHistory;
+use rustyline::{Config, Context, Editor, Helper, Highlighter, Hinter, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
@@ -13,6 +17,7 @@ use crate::endpoints;
 use crate::error::Result;
 use crate::net::Client;
 use crate::origin::auth_headers;
+use crate::util::home_dir;
 
 pub struct ChatOptions {
     pub model: Option<String>,
@@ -71,6 +76,66 @@ fn call_chat(
         eprintln!("\n⚠ the response was cut short (partial output shown).");
     }
     Ok(())
+}
+
+/// Resolve inband `file:<path>` refs in a REPL line into images, mirroring the
+/// one-shot path's resolution (`attachment::extract_inband_refs` +
+/// `attachment::resolve`) but returning a failure as `Err(String)` instead of
+/// exiting the process — a bad ref in the REPL is a per-turn error, not a
+/// reason to kill the whole session. Returns the cleaned text (`file:` tokens
+/// stripped, same as the one-shot path) alongside the resolved attachments;
+/// zero refs is the common case and just passes `line` through unchanged.
+fn resolve_repl_attachments(
+    line: &str,
+) -> std::result::Result<(String, Vec<ImageAttachment>), String> {
+    let (cleaned_text, refs) = attachment::extract_inband_refs(line);
+    let mut images: Vec<ImageAttachment> = Vec::new();
+    for r in &refs {
+        match attachment::resolve(r) {
+            Ok(img) => images.push(img),
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    Ok((cleaned_text.trim().to_string(), images))
+}
+
+/// The slash commands the REPL understands — just quitting, for now (chat has
+/// no `/help`/`/model`/`/config`/`/status`, unlike `monocle agent`'s REPL).
+const CHAT_SLASH_COMMANDS: &[&str] = &["/exit", "/quit"];
+
+/// rustyline line helper for `monocle chat`'s REPL: Tab-completes the two
+/// slash commands. Hinting/highlighting/validation are the derived no-op
+/// defaults — multi-line handling comes from `bracketed_paste`, not a custom
+/// `Validator`. Deliberately simpler than `agent.rs`'s `ReplHelper` (no
+/// `/model`-argument fuzzy completion, no model-id list to carry).
+#[derive(Helper, Hinter, Highlighter, Validator)]
+struct ChatReplHelper;
+
+impl Completer for ChatReplHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // Only offer completion for a slash-command being typed at line start.
+        let head = &line[..pos];
+        if !head.starts_with('/') {
+            return Ok((0, Vec::new()));
+        }
+        let candidates = CHAT_SLASH_COMMANDS
+            .iter()
+            .filter(|cmd| cmd.starts_with(head))
+            .map(|cmd| Pair {
+                display: cmd.to_string(),
+                replacement: cmd.to_string(),
+            })
+            .collect();
+        // Replace from column 0 (the whole slash token starts there).
+        Ok((0, candidates))
+    }
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
@@ -211,64 +276,160 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         eprintln!("System prompt loaded ({} chars)", sp.chars().count());
     }
     eprintln!("Type your message. Press Ctrl+D to exit.");
+    eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
     eprintln!("---");
 
-    let stdin = std::io::stdin();
+    // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
+    // Ctrl-A/E/K/Y) with its default Emacs keymap + file history, mirroring
+    // `monocle agent`'s REPL (`src/commands/agent.rs`). `bracketed_paste(true)`
+    // makes a multi-line paste arrive as a single input buffer (submitted only
+    // on Enter) instead of each embedded newline being read as a separate
+    // accept-line → separate turn.
+    let config = Config::builder().bracketed_paste(true).build();
+    let mut rl: Editor<ChatReplHelper, DefaultHistory> =
+        Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
+    rl.set_helper(Some(ChatReplHelper));
+    // Separate history file from `monocle agent`'s — the two REPLs' histories
+    // stay independent.
+    let history_path = home_dir().join(".monocle").join("chat_history");
+    if let Some(parent) = history_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Best-effort history persistence: a missing/unreadable file just means an
+    // empty history this session.
+    let _ = rl.load_history(&history_path);
+
+    let prompt = "> ";
     loop {
-        eprint!("> ");
-        let _ = std::io::stderr().flush();
+        match rl.readline(prompt) {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                // History gets the raw typed line (before `file:` tokens are
+                // stripped) — recalling it via ↑ should show what was actually
+                // typed, matching the non-attachment behavior this REPL already
+                // had.
+                let _ = rl.add_history_entry(line.as_str());
+                if trimmed == "/quit" || trimmed == "/exit" {
+                    eprintln!("Bye.");
+                    break;
+                }
 
-        let mut line = String::new();
-        let n = stdin.read_line(&mut line)?;
-        if n == 0 {
-            // EOF (Ctrl+D)
-            eprintln!("\nBye.");
-            break;
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("\nBye.");
-            break;
-        }
+                let (text, images) = match resolve_repl_attachments(trimmed) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Same per-turn recovery as a `call_chat` error below:
+                        // print and go back to the prompt, no `call_chat` call
+                        // for this turn.
+                        eprintln!("Error: {e}");
+                        eprintln!();
+                        continue;
+                    }
+                };
 
-        eprintln!();
-        // Reset before this turn's work runs, so the hint below reflects only
-        // whether *this* turn logged a network error — not a stale flag left
-        // over from an earlier one (this REPL loops for the life of the process,
-        // same as `monocle agent`'s).
-        crate::diag::reset();
-        match call_chat(
-            &provider,
-            &model,
-            system_prompt.as_deref(),
-            trimmed,
-            max_tokens,
-            &[],
-        ) {
-            Ok(()) => {
-                let mut out = std::io::stdout();
-                out.write_all(b"\n\n")?;
-                out.flush()?;
+                eprintln!();
+                // Reset before this turn's work runs, so the hint below reflects
+                // only whether *this* turn logged a network error — not a stale
+                // flag left over from an earlier one (this REPL loops for the
+                // life of the process, same as `monocle agent`'s).
+                crate::diag::reset();
+                match call_chat(
+                    &provider,
+                    &model,
+                    system_prompt.as_deref(),
+                    &text,
+                    max_tokens,
+                    &images,
+                ) {
+                    Ok(()) => {
+                        let mut out = std::io::stdout();
+                        out.write_all(b"\n\n")?;
+                        out.flush()?;
+                    }
+                    Err(e) => {
+                        eprintln!("Error: {e}");
+                        if crate::diag::was_logged() {
+                            eprintln!("  (details logged to {})", crate::diag::display_path());
+                        }
+                        eprintln!();
+                    }
+                }
+            }
+            // Ctrl-C: don't quit — just start a fresh prompt (matches `monocle
+            // agent`'s idle-prompt behavior).
+            Err(ReadlineError::Interrupted) => continue,
+            // Ctrl-D (EOF): quit, matching the previous read_line behavior.
+            Err(ReadlineError::Eof) => {
+                eprintln!("Bye.");
+                break;
             }
             Err(e) => {
                 eprintln!("Error: {e}");
-                if crate::diag::was_logged() {
-                    eprintln!("  (details logged to {})", crate::diag::display_path());
-                }
-                eprintln!();
+                break;
             }
         }
     }
 
+    let _ = rl.save_history(&history_path);
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_max_tokens;
+    use super::{resolve_max_tokens, resolve_repl_attachments, ChatReplHelper};
+    use rustyline::completion::Completer;
+    use rustyline::history::DefaultHistory;
+    use rustyline::Context;
+
+    #[test]
+    fn complete_slash_command_narrows_to_matching_prefix() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/qu";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/quit".to_string()]
+        );
+    }
+
+    #[test]
+    fn complete_bare_slash_offers_both_commands() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/exit".to_string(), "/quit".to_string()]
+        );
+    }
+
+    #[test]
+    fn complete_non_slash_text_offers_nothing() {
+        let helper = ChatReplHelper;
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "hello";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert!(candidates.is_empty());
+    }
 
     #[test]
     fn absent_flag_omits() {
@@ -294,5 +455,57 @@ mod tests {
         assert_eq!(resolve_max_tokens(Some("0")), None);
         assert_eq!(resolve_max_tokens(Some("-1")), None);
         assert_eq!(resolve_max_tokens(Some("  -42 ")), None);
+    }
+
+    #[test]
+    fn repl_line_with_no_file_ref_passes_through_unchanged() {
+        let (text, images) = resolve_repl_attachments("hello there").unwrap();
+        assert_eq!(text, "hello there");
+        assert!(images.is_empty());
+    }
+
+    #[test]
+    fn repl_line_with_valid_file_ref_resolves_and_strips_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"bytes").unwrap();
+        let line = format!("what's in file:{} ?", path.to_str().unwrap());
+
+        let (text, images) = resolve_repl_attachments(&line).unwrap();
+        assert!(!text.contains("file:"));
+        assert!(text.contains("what's in"));
+        assert_eq!(images.len(), 1);
+    }
+
+    #[test]
+    fn repl_line_with_image_only_file_ref_yields_empty_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        std::fs::write(&path, b"bytes").unwrap();
+        let line = format!("file:{}", path.to_str().unwrap());
+
+        let (text, images) = resolve_repl_attachments(&line).unwrap();
+        assert!(text.is_empty());
+        assert_eq!(images.len(), 1);
+    }
+
+    #[test]
+    fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
+        let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
+        assert!(err.contains("not found"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn repl_line_with_unsupported_extension_errors_with_typed_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.heic");
+        std::fs::write(&path, b"hello").unwrap();
+        let line = format!("file:{}", path.to_str().unwrap());
+
+        let err = resolve_repl_attachments(&line).unwrap_err();
+        assert!(
+            err.starts_with("unsupported type:"),
+            "unexpected message: {err}"
+        );
     }
 }

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use serde::Deserialize;
 
-use crate::auth::get_access_token;
+use crate::auth::{get_access_token, try_access_token, AuthSession};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::{AppError, Result};
@@ -33,8 +33,13 @@ fn pad(s: &str, width: usize) -> String {
     }
 }
 
-pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
-    let session = get_access_token(client, creds);
+/// Fetch the full model listing from the router (`GET /v1/models`) given an
+/// already-resolved session, with no printing — the pure data path shared by
+/// `monocle models` and the `agent` REPL's tab-completion (which needs the id
+/// list, not a rendered table). Takes the session rather than resolving it
+/// itself so callers can choose exiting (`get_access_token`) vs. graceful
+/// (`try_access_token`) auth resolution.
+fn fetch_models_with_session(client: &Client, session: &AuthSession) -> Result<Vec<ModelInfo>> {
     let bearer = format!("Bearer {}", session.token);
 
     let resp = client.get(
@@ -50,7 +55,25 @@ pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
         )));
     }
 
-    let models = resp.json::<ModelsResponse>()?.data;
+    Ok(resp.json::<ModelsResponse>()?.data)
+}
+
+/// Fetch just the model ids — what the `agent` REPL's `/model` completer needs.
+/// Uses the non-exiting [`try_access_token`] (not [`get_access_token`]) so a
+/// missing login or a network hiccup returns an `Err` instead of killing the
+/// process; `agent.rs` treats that as "no candidates" and starts the REPL
+/// anyway rather than propagating.
+pub fn fetch_model_ids(client: &Client, creds: &Credentials) -> Result<Vec<String>> {
+    let session = try_access_token(client, creds)?;
+    Ok(fetch_models_with_session(client, &session)?
+        .into_iter()
+        .map(|m| m.id)
+        .collect())
+}
+
+pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
+    let session = get_access_token(client, creds);
+    let models = fetch_models_with_session(client, &session)?;
 
     if models.is_empty() {
         eprintln!("No models available.");

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,0 +1,104 @@
+//! A tiny diagnostics log for otherwise-invisible network/streaming failures
+//! (e.g. "error decoding response body" during `monocle agent` streaming).
+//!
+//! This is deliberately NOT a logging framework — no crate, no persistent
+//! logger/subscriber. Just a plain append-only text file at
+//! `~/.monocle/cli.log`, written only at the handful of `net.rs` sites where
+//! an error is about to be collapsed into a generic `AppError(String)` and
+//! the request context (method, URL, underlying error) would otherwise be
+//! lost for good.
+//!
+//! Top-level error-display sites can check [`was_logged`] to add a one-line
+//! hint pointing the user at the log, without every `AppError` needing to
+//! carry structured diagnostic data.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::util::{home_dir, now_ms, to_iso};
+
+/// Set once `log_network_error` has successfully written a line this run, so
+/// top-level error printers know whether pointing the user at the log file is
+/// actually useful.
+static WAS_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// The friendly path shown to users, matching this codebase's existing
+/// `~/.monocle/...` convention (README.md, doc comments) rather than the
+/// fully resolved OS path.
+pub fn display_path() -> &'static str {
+    "~/.monocle/cli.log"
+}
+
+/// The real, resolved log file path: `<home>/.monocle/cli.log`.
+pub fn log_path() -> PathBuf {
+    home_dir().join(".monocle").join("cli.log")
+}
+
+/// Whether a diagnostic line has been written this run.
+pub fn was_logged() -> bool {
+    WAS_LOGGED.load(Ordering::Relaxed)
+}
+
+/// Append one diagnostic line: timestamp, HTTP method + (redacted) URL, and
+/// the raw underlying error text — never the response body or credentials.
+///
+/// Best-effort: this must never mask or replace the original error, so any
+/// failure to write (missing home dir, permissions, disk full, ...) is
+/// silently dropped.
+pub fn log_network_error(method: &str, url: &str, err: &str) {
+    let path = log_path();
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    else {
+        return;
+    };
+    let line = format!(
+        "{} {method} {} — {err}\n",
+        to_iso(now_ms()),
+        redact_url(url)
+    );
+    if file.write_all(line.as_bytes()).is_ok() {
+        WAS_LOGGED.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Strip any query string before logging. Every call site today sends auth
+/// only via the `Authorization` header (never as a URL/query param), so the
+/// bare URL is already safe — this is defense in depth against a future call
+/// site that embeds something sensitive in `?...`.
+fn redact_url(url: &str) -> String {
+    match url.split_once('?') {
+        Some((base, _)) => format!("{base}?<redacted>"),
+        None => url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url;
+
+    #[test]
+    fn redacts_query_string() {
+        assert_eq!(
+            redact_url("https://api.example.com/v1/chat?token=secret"),
+            "https://api.example.com/v1/chat?<redacted>"
+        );
+    }
+
+    #[test]
+    fn leaves_bare_url_unchanged() {
+        assert_eq!(
+            redact_url("https://api.example.com/v1/chat"),
+            "https://api.example.com/v1/chat"
+        );
+    }
+}

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -35,9 +35,20 @@ pub fn log_path() -> PathBuf {
     home_dir().join(".monocle").join("cli.log")
 }
 
-/// Whether a diagnostic line has been written this run.
+/// Whether a diagnostic line has been written since the last [`reset`] (or
+/// since process start, if `reset` was never called).
 pub fn was_logged() -> bool {
     WAS_LOGGED.load(Ordering::Relaxed)
+}
+
+/// Clear the flag. A one-shot command process (e.g. `main.rs`) never needs
+/// this — it exits right after printing its one error. A long-lived REPL
+/// (`monocle agent`, `monocle chat`) must call this at the *start* of each
+/// turn, before that turn's work runs, so a later turn's hint reflects only
+/// whether *that* turn logged a network error — not a stale flag left over
+/// from an earlier turn.
+pub fn reset() {
+    WAS_LOGGED.store(false, Ordering::Relaxed);
 }
 
 /// Append one diagnostic line: timestamp, HTTP method + (redacted) URL, and
@@ -61,6 +72,7 @@ pub fn log_network_error(method: &str, url: &str, err: &str) {
     else {
         return;
     };
+    harden_permissions(&path);
     let line = format!(
         "{} {method} {} — {err}\n",
         to_iso(now_ms()),
@@ -70,6 +82,19 @@ pub fn log_network_error(method: &str, url: &str, err: &str) {
         WAS_LOGGED.store(true, Ordering::Relaxed);
     }
 }
+
+/// Best-effort `chmod 600` on Unix, mirroring `credentials.rs` (no secrets are
+/// logged here, but there's no reason to leave a diagnostics file
+/// world-readable either). A no-op on other platforms; failures are ignored —
+/// same best-effort posture as the rest of this module.
+#[cfg(unix)]
+fn harden_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn harden_permissions(_path: &std::path::Path) {}
 
 /// Strip any query string before logging. Every call site today sends auth
 /// only via the `Authorization` header (never as a URL/query param), so the
@@ -84,7 +109,8 @@ fn redact_url(url: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::redact_url;
+    use super::{redact_url, reset, was_logged, WAS_LOGGED};
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn redacts_query_string() {
@@ -100,5 +126,16 @@ mod tests {
             redact_url("https://api.example.com/v1/chat"),
             "https://api.example.com/v1/chat"
         );
+    }
+
+    #[test]
+    fn reset_clears_the_flag() {
+        // `WAS_LOGGED` is a process-global, so drive it directly rather than
+        // via `log_network_error` (which would touch the real filesystem and
+        // race other tests running in parallel).
+        WAS_LOGGED.store(true, Ordering::Relaxed);
+        assert!(was_logged());
+        reset();
+        assert!(!was_logged());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod acp;
 pub mod agent;
+pub mod attachment;
 pub mod audio_io;
 pub mod auth;
 pub mod colors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod colors;
 pub mod commands;
 pub mod credentials;
+pub mod diag;
 pub mod endpoints;
 pub mod error;
 pub mod net;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,10 @@ struct ChatArgs {
     /// Maximum output tokens (omitted by default → model/router uses its own)
     #[arg(long = "max-tokens")]
     max_tokens: Option<String>,
+    /// Attach a file/image (repeatable); local path or http(s) URL. One-shot
+    /// (piped stdin) only — see also inband `file:<path>` tokens in the text.
+    #[arg(long = "file")]
+    file: Vec<String>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -169,6 +173,7 @@ impl From<ChatArgs> for ChatOptions {
             system_prompt: a.system_prompt,
             system_prompt_file: a.system_prompt_file,
             max_tokens: a.max_tokens,
+            files: a.file,
         }
     }
 }
@@ -424,5 +429,21 @@ fn run_audio(client: &Client, creds: &Credentials, command: AudioCommands) -> Re
             ssml.as_deref(),
             AudioSpeechAzureOptions { format, output },
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_file_flag_repeats_into_vec() {
+        let cli = Cli::parse_from(["monocle", "chat", "--file", "a.png", "--file", "b.png"]);
+        match cli.command {
+            Commands::Chat(args) => {
+                assert_eq!(args.file, vec!["a.png".to_string(), "b.png".to_string()]);
+            }
+            _ => panic!("expected Chat command"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use monocle_cli::commands::token::token_command;
 use monocle_cli::commands::unset::unset_command;
 use monocle_cli::commands::upgrade::upgrade_command;
 use monocle_cli::credentials::Credentials;
+use monocle_cli::diag;
 use monocle_cli::error::Result;
 use monocle_cli::net::Client;
 use monocle_cli::util;
@@ -337,6 +338,9 @@ fn main() {
 
     if let Err(e) = result {
         eprintln!("Error: {e}");
+        if diag::was_logged() {
+            eprintln!("  (details logged to {})", diag::display_path());
+        }
         std::process::exit(1);
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -81,7 +81,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("GET", url, req)
     }
 
     /// GET a large file download (e.g. the `monocle upgrade` release binary).
@@ -122,7 +122,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `application/json`.
@@ -131,7 +131,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `multipart/form-data` with one binary file part plus text fields.
@@ -154,7 +154,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST a raw body with an explicit `Content-Type` (Azure SSML).
@@ -173,7 +173,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        send(req)
+        send("POST", url, req)
     }
 
     /// POST `application/json` and return a streaming line reader over the (SSE)
@@ -200,19 +200,31 @@ impl Client {
             status,
             content_type,
             reader: BufReader::new(resp),
+            request_url: url.to_string(),
         })
     }
 }
 
-fn send(req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
+fn send(method: &str, url: &str, req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
     // Total request timeout — non-streaming only (see `Client::new`). Streaming
     // (`post_json_stream`) builds and sends its own request without this, so a
     // long generation is never cut short.
     let req = req.timeout(std::time::Duration::from_secs(120));
-    let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+    let resp = req.send().map_err(|e| {
+        let msg = e.to_string();
+        crate::diag::log_network_error(method, url, &msg);
+        AppError(msg)
+    })?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
-    let body = resp.bytes().map_err(|e| AppError(e.to_string()))?.to_vec();
+    let body = resp
+        .bytes()
+        .map_err(|e| {
+            let msg = e.to_string();
+            crate::diag::log_network_error(method, url, &msg);
+            AppError(msg)
+        })?
+        .to_vec();
     Ok(Resp {
         status,
         status_text,
@@ -227,6 +239,9 @@ pub struct EventStream {
     pub status: u16,
     pub content_type: String,
     reader: BufReader<reqwest::blocking::Response>,
+    /// The request URL, kept only for diagnostic logging on a mid-stream read
+    /// failure (see `next_line`).
+    request_url: String,
 }
 
 impl EventStream {
@@ -242,10 +257,11 @@ impl EventStream {
     /// Next line (including the trailing newline), or `None` at end of stream.
     pub fn next_line(&mut self) -> Result<Option<String>> {
         let mut line = String::new();
-        let n = self
-            .reader
-            .read_line(&mut line)
-            .map_err(|e| AppError(e.to_string()))?;
+        let n = self.reader.read_line(&mut line).map_err(|e| {
+            let msg = e.to_string();
+            crate::diag::log_network_error("POST", &self.request_url, &msg);
+            AppError(msg)
+        })?;
         Ok(if n == 0 { None } else { Some(line) })
     }
 


### PR DESCRIPTION
v1.1.1 이후 devel에 쌓인 변경사항을 main으로 승격.

- chat: `--file` 플래그와 인밴드 `file:` 토큰으로 이미지 첨부 지원 (#67)
- agent: `/model` 인자에 모델 목록 fuzzy-completion 추가 (#66)
- 네트워크/스트리밍 에러 진단성 개선 — `~/.monocle/cli.log` 추가 (#65)
- chat REPL에 rustyline 라인 편집 포팅 (#68)
- 버전: 1.1.1 → 1.2.0 (#71)

merge 후 `v1.2.0` 태그 push → release.yml이 빌드+GitHub Release 게시.