### PR TITLE
fix(install): install.ps1 PATH 자동 영구등록 + 현재 세션 반영

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -38,10 +38,17 @@ Write-Host "Installed: $InstallDir\$Binary.exe"
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$InstallDir*") {
+    $newUserPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
     Write-Host ""
-    Write-Host "WARNING: $InstallDir is not in your PATH."
-    Write-Host "Add it with:"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$InstallDir;`" + [Environment]::GetEnvironmentVariable('Path','User'), 'User')"
+    Write-Host "Added $InstallDir to your PATH."
+}
+
+# SetEnvironmentVariable only persists to the registry for *future* processes —
+# this already-running shell keeps its own PATH snapshot, so `monocle` below
+# would still fail to resolve without also updating this process's $env:Path.
+if ($env:Path -notlike "*$InstallDir*") {
+    $env:Path = "$InstallDir;$env:Path"
 }
 
 Write-Host ""


### PR DESCRIPTION
## 문제

실사용 중 발견(v1.2.0 Windows 설치 재현): `install.ps1`이 PATH 미등록 시
`SetEnvironmentVariable` 명령어를 화면에 출력만 하고 사용자가 직접 복붙해야
했다. 복붙해서 실행해도 레지스트리(향후 프로세스용)만 갱신될 뿐 **이미 열려있는
현재 세션의 `$env:Path`는 그대로**라, 스크립트가 마지막에 안내하는
`monocle login`이 같은 세션에서 항상 `CommandNotFoundException`으로 실패했다.

## 수정

- PATH 미등록이면 `SetEnvironmentVariable`을 스크립트가 직접 호출해 영구 등록
  (안내만 하던 것 → 실행). 이미 등록돼 있으면 중복 추가 없음.
- `$env:Path`도 같은 세션에서 즉시 갱신 — 설치 직후 `monocle login`이 새 창을
  열지 않아도 바로 동작.

## Test plan

- [x] 로컬 pwsh(7.6.3, 리눅스)로 스크립트 전체 실행 — 현재 세션 PATH 갱신 확인
- [x] PATH 블록 3회 재실행으로 idempotency(중복 항목 없음) 확인
- [ ] 실제 Windows에서 재현 시나리오(재설치 후 같은 세션에서 `monocle login`)로 확인