### PR TITLE
release: v1.2.1 — 버전 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
install.ps1의 PATH 자동 영구등록 + 현재 세션 반영 수정(#73)을 v1.2.1로 릴리스.

Cargo.toml/Cargo.lock: `1.2.0` → `1.2.1`.