### PR TITLE
Release v1.2.1: devel → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/install.ps1
+++ b/install.ps1
@@ -38,10 +38,17 @@ Write-Host "Installed: $InstallDir\$Binary.exe"
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$InstallDir*") {
+    $newUserPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
     Write-Host ""
-    Write-Host "WARNING: $InstallDir is not in your PATH."
-    Write-Host "Add it with:"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$InstallDir;`" + [Environment]::GetEnvironmentVariable('Path','User'), 'User')"
+    Write-Host "Added $InstallDir to your PATH."
+}
+
+# SetEnvironmentVariable only persists to the registry for *future* processes —
+# this already-running shell keeps its own PATH snapshot, so `monocle` below
+# would still fail to resolve without also updating this process's $env:Path.
+if ($env:Path -notlike "*$InstallDir*") {
+    $env:Path = "$InstallDir;$env:Path"
 }
 
 Write-Host ""


### PR DESCRIPTION
install.ps1 PATH 자동 영구등록 + 현재 세션 반영 수정(#73)을 main으로 승격.

- fix(install): PATH 미등록 시 안내만 하던 것을 직접 SetEnvironmentVariable로
  영구 등록, $env:Path도 즉시 갱신
- 버전: 1.2.0 → 1.2.1 (#74)

merge 후 `v1.2.1` 태그 push → release.yml이 빌드+GitHub Release 게시.