### PR TITLE
fix(agent): 인터랙티브 REPL 프롬프트 색상 제거 (Windows 커서 밀림)

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -458,7 +458,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     // is not triggered at the idle prompt (we just start a fresh line). During a
     // turn the terminal is back in cooked mode, so Ctrl-C raises SIGINT and that
     // handler cancels the running turn, exactly as before.
-    let prompt = format!("{} ", c::cyan("»"));
+    // Plain, uncolored — a prompt string handed to `rl.readline()` must not
+    // carry raw ANSI escapes. rustyline computes the prompt's on-screen width
+    // by skipping recognized escape sequences (0-width), but on Windows the
+    // console only interprets those bytes as color if
+    // ENABLE_VIRTUAL_TERMINAL_PROCESSING is active; when that fails to enable,
+    // the escapes print as literal characters, so rustyline's cursor-column
+    // math (0-width) diverges from the terminal's real cursor position —
+    // seen as the cursor sitting ~10 columns in in PowerShell before any input.
+    let prompt = "» ".to_string();
     loop {
         match rl.readline(&prompt) {
             Ok(line) => {


### PR DESCRIPTION
## 문제 (실사용 재현)

Windows PowerShell에서 `monocle agent` 실행 시 readline 프롬프트가 뜨자마자
커서가 오른쪽으로 10~15컬럼 밀린 채 나타나고, 타이핑은 그 위치부터 시작되다가
백스페이스하면 다시 맨 왼쪽으로 튐.

## 원인

프롬프트를 `format!("{} ", c::cyan("»"))`로 만들어 raw ANSI 이스케이프
(`\x1b[36m...\x1b[39m`)를 문자열에 직접 삽입하고 있었다. rustyline은 이
이스케이프를 폭 0으로 계산해 커서 컬럼을 추정하는데, Windows 콘솔이
`ENABLE_VIRTUAL_TERMINAL_PROCESSING`을 활성화 못 시키면 그 바이트가 색상으로
해석되지 않고 리터럴 문자로 화면에 찍혀, rustyline의 내부 커서 모델과 실제
물리적 커서 위치가 어긋난다 — 재현된 증상과 정확히 일치(rustyline 14.0.0
`tty/windows.rs` 소스로 확인).

## 수정

`monocle chat` REPL과 동일하게 색 없는 평문 프롬프트로 변경. `rl.readline()`에
넘기는 문자열에 애초에 이스케이프가 없으니 이 버그 클래스 자체가 사라진다.

## Test plan

- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`
      (92 passed) 전부 통과
- [ ] 실제 Windows PowerShell에서 재설치 후 `monocle agent` 커서 정상 확인