### PR TITLE
release: v1.2.2 — 버전 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
agent REPL 프롬프트 색상 제거(Windows 커서 밀림 수정, #76)를 v1.2.2로 릴리스.

Cargo.toml/Cargo.lock: `1.2.1` → `1.2.2`.