### PR TITLE
Release v1.2.2: devel → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -458,7 +458,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     // is not triggered at the idle prompt (we just start a fresh line). During a
     // turn the terminal is back in cooked mode, so Ctrl-C raises SIGINT and that
     // handler cancels the running turn, exactly as before.
-    let prompt = format!("{} ", c::cyan("»"));
+    // Plain, uncolored — a prompt string handed to `rl.readline()` must not
+    // carry raw ANSI escapes. rustyline computes the prompt's on-screen width
+    // by skipping recognized escape sequences (0-width), but on Windows the
+    // console only interprets those bytes as color if
+    // ENABLE_VIRTUAL_TERMINAL_PROCESSING is active; when that fails to enable,
+    // the escapes print as literal characters, so rustyline's cursor-column
+    // math (0-width) diverges from the terminal's real cursor position —
+    // seen as the cursor sitting ~10 columns in in PowerShell before any input.
+    let prompt = "» ".to_string();
     loop {
         match rl.readline(&prompt) {
             Ok(line) => {


### PR DESCRIPTION
agent REPL 프롬프트 색상 제거(Windows 커서 밀림 수정, #76)를 main으로 승격.

- fix(agent): Windows PowerShell에서 raw ANSI 프롬프트로 인한 rustyline
  커서-컬럼 계산 오류 수정 — 색 없는 프롬프트로 변경
- 버전: 1.2.1 → 1.2.2 (#77)

merge 후 `v1.2.2` 태그 push → release.yml이 빌드+GitHub Release 게시.