### PR TITLE
refactor(repl): chat/agent REPL 공통 골격을 commands::repl로 추출

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -11,9 +11,7 @@ use std::rc::Rc;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use rustyline::completion::{Completer, Pair};
-use rustyline::error::ReadlineError;
-use rustyline::history::DefaultHistory;
-use rustyline::{Config, Context, Editor, Helper, Highlighter, Hinter, Validator};
+use rustyline::{Context, Helper, Highlighter, Hinter, Validator};
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
@@ -25,6 +23,7 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::fetch_model_ids;
+use crate::commands::repl::{run_repl, LoopControl};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -429,35 +428,18 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     // ONLY here, on the interactive TTY path — the headless / piped / ACP paths
     // above never touch it, keeping the engine UI-free (CLAUDE.md 설계 원칙:
     // rich UI is the host's job via `monocle acp`). This is input-line editing
-    // only; it does not take over scrollback/paging.
+    // only; it does not take over scrollback/paging. The Editor build,
+    // bracketed-paste config, history load/save, and the Ctrl-C/Ctrl-D/error
+    // loop itself are shared with `monocle chat`'s REPL via
+    // `commands::repl::run_repl`; only the helper (Tab-completion) and the
+    // per-line dispatch below are specific to this REPL.
     //
-    // `bracketed_paste(true)` makes a multi-line paste arrive as a SINGLE input
-    // buffer (submitted only on Enter) instead of each embedded newline being read
-    // as a separate accept-line → separate turn. This is already rustyline 14's
-    // default (`Config::default().enable_bracketed_paste == true`), so on a
-    // terminal that supports bracketed paste it worked before too; we set it
-    // explicitly (via `Editor::with_config`, replacing `DefaultEditor`) to make
-    // the guarantee visible and stop line-splitting regressing if the default
-    // changes. The `ReplHelper` adds Tab-completion of slash commands.
-    let config = Config::builder().bracketed_paste(true).build();
-    let mut rl: Editor<ReplHelper, DefaultHistory> =
-        Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
-    rl.set_helper(Some(ReplHelper {
-        models: Rc::new(model_ids),
-    }));
-    let history_path = home_dir().join(".monocle").join("agent_history");
-    if let Some(parent) = history_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    // Best-effort history persistence: a missing/unreadable file just means an
-    // empty history this session.
-    let _ = rl.load_history(&history_path);
-
     // rustyline reads the prompt in raw mode, where Ctrl-C surfaces as
     // `Interrupted` WITHOUT raising SIGINT — so the `ctrlc` turn-cancel handler
     // is not triggered at the idle prompt (we just start a fresh line). During a
     // turn the terminal is back in cooked mode, so Ctrl-C raises SIGINT and that
     // handler cancels the running turn, exactly as before.
+    //
     // Plain, uncolored — a prompt string handed to `rl.readline()` must not
     // carry raw ANSI escapes. rustyline computes the prompt's on-screen width
     // by skipping recognized escape sequences (0-width), but on Windows the
@@ -466,97 +448,87 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     // the escapes print as literal characters, so rustyline's cursor-column
     // math (0-width) diverges from the terminal's real cursor position —
     // seen as the cursor sitting ~10 columns in in PowerShell before any input.
-    let prompt = "» ".to_string();
-    loop {
-        match rl.readline(&prompt) {
-            Ok(line) => {
-                let msg = line.trim();
-                if msg.is_empty() {
-                    continue;
+    let helper = ReplHelper {
+        models: Rc::new(model_ids),
+    };
+    let history_path = home_dir().join(".monocle").join("agent_history");
+
+    run_repl(helper, history_path, "» ", |msg| {
+        // `/model` switches the model for subsequent turns (handled before
+        // the general dispatch since it carries an argument).
+        if let Some(model_cmd) = parse_model_command(msg) {
+            match model_cmd {
+                Some(id) => {
+                    eprintln!("{}", c::dim(&format!("model → {id}")));
+                    repl.model = id;
                 }
-                let _ = rl.add_history_entry(line.as_str());
-                // `/model` switches the model for subsequent turns (handled before
-                // the general dispatch since it carries an argument).
-                if let Some(model_cmd) = parse_model_command(msg) {
-                    match model_cmd {
-                        Some(id) => {
-                            eprintln!("{}", c::dim(&format!("model → {id}")));
-                            repl.model = id;
-                        }
-                        None => eprintln!("{}", c::dim(&format!("model: {}", repl.model))),
-                    }
-                    continue;
-                }
-                // Slash commands are handled locally (never sent to the agent/LLM),
-                // and printed to stderr so stdout stays the clean answer channel.
-                match dispatch_command(msg) {
-                    Command::Quit => {
-                        eprintln!("Bye.");
-                        break;
-                    }
-                    Command::Help => eprintln!("{}", help_text()),
-                    Command::Config => eprintln!(
-                        "{}",
-                        config_text(
-                            &repl.model,
-                            repl.max_steps,
-                            &repl.workdir,
-                            repl.session_name()
-                        )
-                    ),
-                    Command::Status => {
-                        let login = login_view(repl.creds);
+                None => eprintln!("{}", c::dim(&format!("model: {}", repl.model))),
+            }
+            return Ok(LoopControl::Continue);
+        }
+        // Slash commands are handled locally (never sent to the agent/LLM),
+        // and printed to stderr so stdout stays the clean answer channel.
+        match dispatch_command(msg) {
+            Command::Quit => {
+                eprintln!("Bye.");
+                Ok(LoopControl::Quit)
+            }
+            Command::Help => {
+                eprintln!("{}", help_text());
+                Ok(LoopControl::Continue)
+            }
+            Command::Config => {
+                eprintln!(
+                    "{}",
+                    config_text(
+                        &repl.model,
+                        repl.max_steps,
+                        &repl.workdir,
+                        repl.session_name()
+                    )
+                );
+                Ok(LoopControl::Continue)
+            }
+            Command::Status => {
+                let login = login_view(repl.creds);
+                eprintln!(
+                    "{}",
+                    status_text(
+                        login.as_ref(),
+                        &repl.model,
+                        repl.max_steps,
+                        &repl.workdir,
+                        repl.session_name(),
+                    )
+                );
+                Ok(LoopControl::Continue)
+            }
+            Command::Unknown(cmd) => {
+                eprintln!("unknown command: {cmd} (try /help)");
+                Ok(LoopControl::Continue)
+            }
+            Command::Turn => {
+                // Reset before this turn's work runs, so the hint below
+                // reflects only whether *this* turn logged a network error —
+                // not a stale flag left over from an earlier one.
+                crate::diag::reset();
+                // A transient per-turn error must not tear down the session.
+                if let Err(e) = repl.run_turn(msg.to_string()) {
+                    eprintln!("{} {e}", c::red("Error:"));
+                    if crate::diag::was_logged() {
                         eprintln!(
-                            "{}",
-                            status_text(
-                                login.as_ref(),
-                                &repl.model,
-                                repl.max_steps,
-                                &repl.workdir,
-                                repl.session_name(),
-                            )
+                            "  {}",
+                            c::dim(&format!(
+                                "(details logged to {})",
+                                crate::diag::display_path()
+                            ))
                         );
                     }
-                    Command::Unknown(cmd) => {
-                        eprintln!("unknown command: {cmd} (try /help)");
-                    }
-                    Command::Turn => {
-                        // Reset before this turn's work runs, so the hint below
-                        // reflects only whether *this* turn logged a network
-                        // error — not a stale flag left over from an earlier one.
-                        crate::diag::reset();
-                        // A transient per-turn error must not tear down the session.
-                        if let Err(e) = repl.run_turn(msg.to_string()) {
-                            eprintln!("{} {e}", c::red("Error:"));
-                            if crate::diag::was_logged() {
-                                eprintln!(
-                                    "  {}",
-                                    c::dim(&format!(
-                                        "(details logged to {})",
-                                        crate::diag::display_path()
-                                    ))
-                                );
-                            }
-                        }
-                    }
                 }
-            }
-            // Ctrl-C at the idle prompt: don't quit — just start a fresh prompt.
-            Err(ReadlineError::Interrupted) => continue,
-            // Ctrl-D (EOF): quit, matching the previous read_line behavior.
-            Err(ReadlineError::Eof) => {
-                eprintln!("Bye.");
-                break;
-            }
-            Err(e) => {
-                eprintln!("{} {e}", c::red("Error:"));
-                break;
+                Ok(LoopControl::Continue)
             }
         }
-    }
-
-    let _ = rl.save_history(&history_path);
-    Ok(())
+    })
 }
 
 /// Collapse whitespace and truncate, for compact one-line progress output.
@@ -573,6 +545,7 @@ fn one_line(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustyline::history::DefaultHistory;
 
     #[test]
     fn dispatch_recognizes_management_commands() {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,9 +1,7 @@
 use std::io::{IsTerminal, Write};
 
 use rustyline::completion::{Completer, Pair};
-use rustyline::error::ReadlineError;
-use rustyline::history::DefaultHistory;
-use rustyline::{Config, Context, Editor, Helper, Highlighter, Hinter, Validator};
+use rustyline::{Context, Helper, Highlighter, Hinter, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
@@ -12,6 +10,7 @@ use crate::agent::providers::{
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::get_access_token;
+use crate::commands::repl::{run_repl, LoopControl};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -279,101 +278,58 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
     eprintln!("---");
 
-    // rustyline gives the input line proper editing (←/→, ↑/↓ history, Emacs
-    // Ctrl-A/E/K/Y) with its default Emacs keymap + file history, mirroring
-    // `monocle agent`'s REPL (`src/commands/agent.rs`). `bracketed_paste(true)`
-    // makes a multi-line paste arrive as a single input buffer (submitted only
-    // on Enter) instead of each embedded newline being read as a separate
-    // accept-line → separate turn.
-    let config = Config::builder().bracketed_paste(true).build();
-    let mut rl: Editor<ChatReplHelper, DefaultHistory> =
-        Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
-    rl.set_helper(Some(ChatReplHelper));
     // Separate history file from `monocle agent`'s — the two REPLs' histories
-    // stay independent.
+    // stay independent. The Editor build, bracketed-paste config, history
+    // load/save, and the Ctrl-C/Ctrl-D/error loop itself are shared with
+    // `monocle agent`'s REPL via `commands::repl::run_repl`.
     let history_path = home_dir().join(".monocle").join("chat_history");
-    if let Some(parent) = history_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    // Best-effort history persistence: a missing/unreadable file just means an
-    // empty history this session.
-    let _ = rl.load_history(&history_path);
 
-    let prompt = "> ";
-    loop {
-        match rl.readline(prompt) {
-            Ok(line) => {
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                // History gets the raw typed line (before `file:` tokens are
-                // stripped) — recalling it via ↑ should show what was actually
-                // typed, matching the non-attachment behavior this REPL already
-                // had.
-                let _ = rl.add_history_entry(line.as_str());
-                if trimmed == "/quit" || trimmed == "/exit" {
-                    eprintln!("Bye.");
-                    break;
-                }
+    run_repl(ChatReplHelper, history_path, "> ", |trimmed| {
+        if trimmed == "/quit" || trimmed == "/exit" {
+            eprintln!("Bye.");
+            return Ok(LoopControl::Quit);
+        }
 
-                let (text, images) = match resolve_repl_attachments(trimmed) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        // Same per-turn recovery as a `call_chat` error below:
-                        // print and go back to the prompt, no `call_chat` call
-                        // for this turn.
-                        eprintln!("Error: {e}");
-                        eprintln!();
-                        continue;
-                    }
-                };
-
+        let (text, images) = match resolve_repl_attachments(trimmed) {
+            Ok(v) => v,
+            Err(e) => {
+                // Same per-turn recovery as a `call_chat` error below: print
+                // and go back to the prompt, no `call_chat` call this turn.
+                eprintln!("Error: {e}");
                 eprintln!();
-                // Reset before this turn's work runs, so the hint below reflects
-                // only whether *this* turn logged a network error — not a stale
-                // flag left over from an earlier one (this REPL loops for the
-                // life of the process, same as `monocle agent`'s).
-                crate::diag::reset();
-                match call_chat(
-                    &provider,
-                    &model,
-                    system_prompt.as_deref(),
-                    &text,
-                    max_tokens,
-                    &images,
-                ) {
-                    Ok(()) => {
-                        let mut out = std::io::stdout();
-                        out.write_all(b"\n\n")?;
-                        out.flush()?;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                        if crate::diag::was_logged() {
-                            eprintln!("  (details logged to {})", crate::diag::display_path());
-                        }
-                        eprintln!();
-                    }
-                }
+                return Ok(LoopControl::Continue);
             }
-            // Ctrl-C: don't quit — just start a fresh prompt (matches `monocle
-            // agent`'s idle-prompt behavior).
-            Err(ReadlineError::Interrupted) => continue,
-            // Ctrl-D (EOF): quit, matching the previous read_line behavior.
-            Err(ReadlineError::Eof) => {
-                eprintln!("Bye.");
-                break;
+        };
+
+        eprintln!();
+        // Reset before this turn's work runs, so the hint below reflects only
+        // whether *this* turn logged a network error — not a stale flag left
+        // over from an earlier one (this REPL loops for the life of the
+        // process, same as `monocle agent`'s).
+        crate::diag::reset();
+        match call_chat(
+            &provider,
+            &model,
+            system_prompt.as_deref(),
+            &text,
+            max_tokens,
+            &images,
+        ) {
+            Ok(()) => {
+                let mut out = std::io::stdout();
+                out.write_all(b"\n\n")?;
+                out.flush()?;
             }
             Err(e) => {
                 eprintln!("Error: {e}");
-                break;
+                if crate::diag::was_logged() {
+                    eprintln!("  (details logged to {})", crate::diag::display_path());
+                }
+                eprintln!();
             }
         }
-    }
-
-    let _ = rl.save_history(&history_path);
-    Ok(())
+        Ok(LoopControl::Continue)
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod chat;
 pub mod claude;
 pub mod login;
 pub mod model_list;
+pub mod repl;
 pub mod setup;
 pub mod status;
 pub mod token;

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -1,0 +1,81 @@
+//! Shared interactive-REPL scaffolding for `monocle chat` and `monocle agent`.
+//!
+//! Both commands independently built a bracketed-paste rustyline `Editor`,
+//! loaded/saved a history file, and drove the same Ctrl-C/Ctrl-D/read-eval
+//! loop — this factors that duplication into one place so the two REPLs
+//! can't drift on the parts that should behave identically (paste handling,
+//! interrupt/EOF semantics, error reporting).
+
+use rustyline::error::ReadlineError;
+use rustyline::history::DefaultHistory;
+use rustyline::{Config, Editor, Helper};
+use std::path::PathBuf;
+
+use crate::colors as c;
+use crate::error::Result;
+
+/// What the per-line callback wants the loop to do next.
+pub enum LoopControl {
+    Continue,
+    Quit,
+}
+
+/// Drives an interactive REPL to completion.
+///
+/// Builds the `Editor` with `bracketed_paste(true)` (a multi-line paste
+/// arrives as one input buffer, submitted only on Enter, instead of each
+/// embedded newline being read as a separate accept-line), loads history from
+/// `history_path` (best-effort — a missing/unreadable file just means an
+/// empty history this session) and saves it back on exit, then loops on
+/// `rl.readline(prompt)`.
+///
+/// `on_line` receives each non-empty trimmed line (already added to history)
+/// and returns whether the loop should continue or quit. Ctrl-C at the idle
+/// prompt just starts a fresh line (rustyline surfaces it as `Interrupted`
+/// without raising SIGINT); Ctrl-D (EOF) quits with a "Bye." message. `prompt`
+/// must be plain text with no raw ANSI escapes — see `agent.rs`'s prompt
+/// comment for why (rustyline's cursor-column math assumes 0-width escapes,
+/// which breaks when a terminal doesn't actually interpret them as color).
+pub fn run_repl<H: Helper>(
+    helper: H,
+    history_path: PathBuf,
+    prompt: &str,
+    mut on_line: impl FnMut(&str) -> Result<LoopControl>,
+) -> Result<()> {
+    let config = Config::builder().bracketed_paste(true).build();
+    let mut rl: Editor<H, DefaultHistory> =
+        Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
+    rl.set_helper(Some(helper));
+    if let Some(parent) = history_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = rl.load_history(&history_path);
+
+    loop {
+        match rl.readline(prompt) {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let _ = rl.add_history_entry(line.as_str());
+                match on_line(trimmed)? {
+                    LoopControl::Continue => {}
+                    LoopControl::Quit => break,
+                }
+            }
+            Err(ReadlineError::Interrupted) => continue,
+            Err(ReadlineError::Eof) => {
+                eprintln!("Bye.");
+                break;
+            }
+            Err(e) => {
+                eprintln!("{} {e}", c::red("Error:"));
+                break;
+            }
+        }
+    }
+
+    let _ = rl.save_history(&history_path);
+    Ok(())
+}


### PR DESCRIPTION
## 요약

- `monocle chat`과 `monocle agent`의 REPL이 각자 거의 동일한 rustyline `Editor`
  구성(bracketed-paste, history load/save)과 Ctrl-C/Ctrl-D/에러 처리 루프를
  중복 구현하고 있었음 — 새 모듈 `src/commands/repl.rs::run_repl()`로 공통
  골격을 추출.
- 각 REPL 고유 로직(chat의 첨부파일 처리, agent의 슬래시 커맨드/`/model` 전환/
  turn 실행)은 `on_line` 클로저로 그대로 유지 — 동작 변화 없음(순수 리팩토링).
- 유일한 의도된 변화: 최종 catch-all 에러 출력을 agent 쪽의 색상 표기(`c::red`)로
  통일. `c::red`는 `NO_COLOR`/비TTY 환경에서 평문으로 폴백하므로 그런 환경에서는
  기존과 동일하게 보임.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 92 passed, 0 failed (리팩토링 전과 동일한 개수)
- [x] `cargo fmt --check` clean
- [x] 서브에이전트로 diff 재검토 — 두 REPL 모두 동작 동일성 확인(히스토리 삽입,
      Ctrl-C/Ctrl-D 처리, 에러 전파 경로, 클로저 캡처 시맨틱 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)