### PR TITLE
fix(chat): 대화 누적 버그 수정 + jarvice Responses API 모드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]...` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only) |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--thread <id>]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
@@ -102,6 +102,9 @@ and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y t
 Tab completes `/quit`/`/exit`, and a multi-line paste is inserted as a single input
 (submitted only on Enter, not one turn per line). Command history persists across
 sessions in `~/.monocle/chat_history` (kept separate from `monocle agent`'s history).
+The REPL remembers the conversation — each turn resends the full exchange so
+far, the same way `monocle agent` does — so follow-up questions ("what about
+in Python?") work without repeating context.
 
 One-shot via stdin:
 
@@ -174,6 +177,53 @@ for m in gpt-4o claude-sonnet-4-6 gemini-2-flash; do
   echo "count the people in this image" | monocle chat --file crowd.jpg --model "$m"
 done
 ```
+
+### 🧵 `--responses`: server-managed threads (experimental)
+
+`monocle chat --responses` talks to jarvice's custom **Responses API**
+(`/api/responses`) instead of the plain `/v1/chat/completions` path. It's not
+OpenAI's Responses API — it's monocle's own endpoint, named for the similar
+idea: the **server** persists the conversation thread, so the CLI sends only
+the new turn instead of resending the whole exchange.
+
+```bash
+monocle chat --responses --model claude-sonnet-4-6
+```
+
+```console
+Monocle Chat — Responses API (model: claude-sonnet-4-6)
+jarvice: https://acme.monocle-ai.com
+Type your message. Press Ctrl+D to exit.
+---
+> Hello
+Hello! How can I help you today?
+Thread: 3fa3b2c1-...
+
+> /quit
+Bye.
+```
+
+Continue a specific thread later (one-shot or REPL) with `--thread <id>`
+(the id a previous run printed to stderr as `Thread: ...`):
+
+```bash
+echo "and in Python?" | monocle chat --responses --thread 3fa3b2c1-...
+```
+
+Notes:
+
+- **jarvice-only** — this does not go through chat-proxy's router, so it
+  needs jarvice's own tenant URL (derived the same way as the rest of this
+  CLI, from your logged-in tenant domain). It's unrelated to `--model`
+  routing and can't be redirected.
+- **No streaming yet** — the reply is fetched non-streaming and printed once
+  it's fully generated, unlike the plain chat path's live token stream.
+- **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
+  endpoint has no equivalent fields (a warning is printed if you pass them).
+- **Known auth gap**: this endpoint currently rejects the CLI's access token
+  with a 401 (`JWT missing required claim: email`) against real staging/prod
+  tenants — the same open issue that blocks `monocle mcp` today. It's fine to
+  use against a local/mock dev stack in the meantime.
 
 ## 🔊 Audio (STT / TTS)
 

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -130,9 +130,11 @@ pub struct ChatRequest {
     pub tools: Vec<ToolDef>,
     /// Images to attach to the last user message as OpenAI vision parts (see
     /// `MonocleProvider::build_body`). Carried on the request rather than
-    /// `Message` because `monocle chat` rebuilds `messages` fresh every turn —
-    /// attachments never need to survive into a later turn (monocle-cli
-    /// file-attach plan).
+    /// `Message` because attachments are per-turn: both `monocle chat` and
+    /// `monocle agent` grow `messages` across turns, but only the CURRENT
+    /// turn's images are ever passed here — an earlier turn's images are not
+    /// re-embedded into later requests (the assistant's textual reply about
+    /// them is what persists in history).
     pub images: Vec<ImageAttachment>,
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,14 +16,38 @@ pub struct AuthSession {
     pub router_url: String,
 }
 
+/// `http` for a local dev host (`localhost`/`127.0.0.1`), else `https`.
+fn scheme_for_host(host: &str) -> &'static str {
+    let is_local = host.starts_with("localhost") || host.starts_with("127.0.0.1");
+    if is_local {
+        "http"
+    } else {
+        "https"
+    }
+}
+
 pub fn router_url_for(creds: &CredentialsData) -> String {
     if let Some(url) = &creds.router_url {
         return url.clone();
     }
-    let is_local = creds.tenant_domain.starts_with("localhost")
-        || creds.tenant_domain.starts_with("127.0.0.1");
-    let scheme = if is_local { "http" } else { "https" };
-    format!("{scheme}://{}", creds.tenant_domain)
+    format!(
+        "{}://{}",
+        scheme_for_host(&creds.tenant_domain),
+        creds.tenant_domain
+    )
+}
+
+/// jarvice's own base URL, always derived from `tenant_domain` — jarvice is
+/// tenant-host-routed (unlike chat-proxy behind `router_url`), so it is
+/// reachable only at its per-tenant hostname, never through `router_url`.
+/// Deliberately ignores `creds.router_url` (that's chat-proxy's address, a
+/// different host — conflating the two has been a recurring trap here).
+pub fn jarvice_url_for(creds: &CredentialsData) -> String {
+    format!(
+        "{}://{}",
+        scheme_for_host(&creds.tenant_domain),
+        creds.tenant_domain
+    )
 }
 
 /// Non-exiting variant of [`get_access_token`]. Returns an [`AppError`] instead

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,17 +5,18 @@ use rustyline::{Context, Helper, Highlighter, Hinter, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
-    ChatRequest, ImageAttachment, LlmProvider, Message, MonocleProvider,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
-use crate::auth::get_access_token;
+use crate::auth::{get_access_token, jarvice_url_for};
 use crate::commands::repl::{run_repl, LoopControl};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
 use crate::net::Client;
 use crate::origin::auth_headers;
+use crate::responses_api::ResponsesClient;
 use crate::util::home_dir;
 
 pub struct ChatOptions {
@@ -25,6 +26,11 @@ pub struct ChatOptions {
     pub max_tokens: Option<String>,
     /// `--file <PATH|URL>` values (repeatable), one-shot only.
     pub files: Vec<String>,
+    /// `--responses`: talk to jarvice's `/api/responses` (server-managed
+    /// thread) instead of the plain `/v1/chat/completions` path.
+    pub responses: bool,
+    /// `--thread <ID>`: continue an existing `--responses` thread.
+    pub thread: Option<String>,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -39,21 +45,17 @@ fn resolve_max_tokens(flag: Option<&str>) -> Option<i64> {
 }
 
 /// One streaming chat turn via the shared provider (chat-proxy routing): assistant
-/// text deltas are written to stdout (and flushed) as they arrive.
+/// text deltas are written to stdout (and flushed) as they arrive. `messages` is
+/// the full request the caller has already assembled (system prompt + any prior
+/// turns + this turn) — this fn only executes the network call and returns the
+/// assembled response so the caller can append it to its own running history.
 fn call_chat(
     provider: &MonocleProvider,
     model: &str,
-    system_prompt: Option<&str>,
-    user_message: &str,
+    messages: Vec<Message>,
     max_tokens: Option<i64>,
     images: &[ImageAttachment],
-) -> Result<()> {
-    let mut messages = Vec::new();
-    if let Some(sp) = system_prompt {
-        messages.push(Message::system(sp));
-    }
-    messages.push(Message::user(user_message));
-
+) -> Result<ChatResponse> {
     let req = ChatRequest {
         model: model.to_string(),
         messages,
@@ -74,7 +76,48 @@ fn call_chat(
     if resp.truncated {
         eprintln!("\n⚠ the response was cut short (partial output shown).");
     }
-    Ok(())
+    Ok(resp)
+}
+
+/// Read piped stdin (if not a TTY) and resolve `--file` + inband `file:<path>`
+/// tokens into one one-shot turn — shared by both the plain-completions and
+/// `--responses` paths. Returns `None` on an interactive TTY (nothing piped).
+/// Exits the process on a bad attachment ref or empty input, matching this
+/// command's existing fail-fast one-shot behavior.
+fn read_one_shot_input(
+    stdin_is_tty: bool,
+    files: &[String],
+) -> Result<Option<(String, Vec<ImageAttachment>)>> {
+    if stdin_is_tty {
+        return Ok(None);
+    }
+    let mut input = String::new();
+    std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
+    let (cleaned_text, inband_refs) = attachment::extract_inband_refs(input.trim());
+
+    let mut refs: Vec<String> = files.to_vec();
+    refs.extend(inband_refs);
+
+    let mut images: Vec<ImageAttachment> = Vec::new();
+    for r in &refs {
+        match attachment::resolve(r) {
+            Ok(img) => images.push(img),
+            Err(e) => {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let cleaned_text = cleaned_text.trim().to_string();
+    // Image-only messages are valid — only bail when BOTH the text and the
+    // attachments are empty.
+    if cleaned_text.is_empty() && images.is_empty() {
+        eprintln!("No input provided via stdin.");
+        std::process::exit(1);
+    }
+
+    Ok(Some((cleaned_text, images)))
 }
 
 /// Resolve inband `file:<path>` refs in a REPL line into images, mirroring the
@@ -138,6 +181,17 @@ impl Completer for ChatReplHelper {
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
+    if options.responses {
+        run_responses_chat(client, creds, options)
+    } else {
+        run_completions_chat(client, creds, options)
+    }
+}
+
+/// The default path: a stateless `/v1/chat/completions` call per turn, with
+/// this REPL accumulating the growing conversation itself (see `convo` below)
+/// and resending it in full each turn.
+fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     let model = options
         .model
         .as_deref()
@@ -177,37 +231,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     // Read stdin + resolve any attachments — cheap, local-only work that
     // should fail fast (bad path, unsupported MIME) before the second network
     // call (model-ID validation) below, but after the auth check above.
-    let one_shot_input: Option<(String, Vec<ImageAttachment>)> = if !stdin_is_tty {
-        let mut input = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
-        let (cleaned_text, inband_refs) = attachment::extract_inband_refs(input.trim());
-
-        let mut refs: Vec<String> = options.files.clone();
-        refs.extend(inband_refs);
-
-        let mut images: Vec<ImageAttachment> = Vec::new();
-        for r in &refs {
-            match attachment::resolve(r) {
-                Ok(img) => images.push(img),
-                Err(e) => {
-                    eprintln!("{e}");
-                    std::process::exit(1);
-                }
-            }
-        }
-
-        let cleaned_text = cleaned_text.trim().to_string();
-        // Image-only messages are valid — only bail when BOTH the text and the
-        // attachments are empty.
-        if cleaned_text.is_empty() && images.is_empty() {
-            eprintln!("No input provided via stdin.");
-            std::process::exit(1);
-        }
-
-        Some((cleaned_text, images))
-    } else {
-        None
-    };
+    let one_shot_input = read_one_shot_input(stdin_is_tty, &options.files)?;
 
     // Resolve system prompt.
     let system_prompt: Option<String> = if let Some(path) = &options.system_prompt_file {
@@ -254,14 +278,12 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
-        call_chat(
-            &provider,
-            &model,
-            system_prompt.as_deref(),
-            &text,
-            max_tokens,
-            &images,
-        )?;
+        let mut messages = Vec::new();
+        if let Some(sp) = &system_prompt {
+            messages.push(Message::system(sp));
+        }
+        messages.push(Message::user(&text));
+        call_chat(&provider, &model, messages, max_tokens, &images)?;
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
         out.flush()?;
@@ -283,6 +305,15 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
     // load/save, and the Ctrl-C/Ctrl-D/error loop itself are shared with
     // `monocle agent`'s REPL via `commands::repl::run_repl`.
     let history_path = home_dir().join(".monocle").join("chat_history");
+
+    // Conversation memory: mirrors `monocle agent`'s `Repl.convo` — grows for
+    // the life of the process instead of `call_chat` rebuilding a one-message
+    // request every turn (the REPL used to have no memory of earlier turns at
+    // all). Seeded once with the system prompt, if any.
+    let mut convo: Vec<Message> = Vec::new();
+    if let Some(sp) = &system_prompt {
+        convo.push(Message::system(sp));
+    }
 
     run_repl(ChatReplHelper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
@@ -307,18 +338,128 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
         // over from an earlier one (this REPL loops for the life of the
         // process, same as `monocle agent`'s).
         crate::diag::reset();
-        match call_chat(
-            &provider,
-            &model,
-            system_prompt.as_deref(),
-            &text,
-            max_tokens,
-            &images,
-        ) {
-            Ok(()) => {
+        // Roll back this turn's user message on failure (mirrors `monocle
+        // agent`'s `Repl::run_turn` mark/truncate) so a failed turn doesn't
+        // leave a dangling, reply-less user message in the history sent next time.
+        let mark = convo.len();
+        convo.push(Message::user(text));
+        match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
+            Ok(resp) => {
+                convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
                 out.flush()?;
+            }
+            Err(e) => {
+                convo.truncate(mark);
+                eprintln!("Error: {e}");
+                if crate::diag::was_logged() {
+                    eprintln!("  (details logged to {})", crate::diag::display_path());
+                }
+                eprintln!();
+            }
+        }
+        Ok(LoopControl::Continue)
+    })
+}
+
+/// `--responses`: jarvice's `/api/responses` (see `responses_api` module
+/// docs). The server owns the conversation thread — this REPL only tracks
+/// the `thread_id` to pass on the next turn, never a local message history.
+///
+/// jarvice-only (not reachable through chat-proxy's `router_url`); no custom
+/// `--system-prompt`/`--max-tokens` support (the endpoint has no such
+/// fields) — both are warned-and-ignored rather than silently dropped.
+fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
+    let model = options
+        .model
+        .as_deref()
+        .unwrap_or(DEFAULT_MODEL)
+        .to_string();
+
+    if options.max_tokens.is_some() {
+        eprintln!("⚠ --max-tokens is ignored with --responses (jarvice's Responses API has no such field)");
+    }
+    if options.system_prompt.is_some() || options.system_prompt_file.is_some() {
+        eprintln!("⚠ --system-prompt/--system-prompt-file is ignored with --responses (the endpoint has no generic system-prompt field, only a voice-mode speech_system_context)");
+    }
+
+    let stdin_is_tty = std::io::stdin().is_terminal();
+    if !options.files.is_empty() && stdin_is_tty {
+        eprintln!(
+            "--file requires piped input. Pipe your instruction, e.g.:\n  echo \"describe this image\" | monocle chat --responses --file photo.png"
+        );
+        std::process::exit(1);
+    }
+
+    // Auth FIRST, same rationale as the completions path — an expired/missing
+    // login must surface before any local-input error masks it.
+    let session = get_access_token(client, creds);
+    let stored = creds.read().ok_or_else(|| {
+        crate::error::AppError::new("Not logged in. Run `monocle login --tenant <domain>` first.")
+    })?;
+    // Deliberately `jarvice_url_for`, NOT `session.router_url` — `/api/responses`
+    // is jarvice-only, unreachable through chat-proxy (see `responses_api` docs).
+    let jarvice_url = jarvice_url_for(&stored);
+
+    let one_shot_input = read_one_shot_input(stdin_is_tty, &options.files)?;
+
+    let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
+
+    if let Some((text, images)) = one_shot_input {
+        eprintln!("Using model: {model}");
+        eprintln!("jarvice: {jarvice_url}");
+        let reply = rc.respond(&model, &text, &images, options.thread.as_deref())?;
+        println!("{}", reply.content);
+        if let Some(id) = reply.thread_id {
+            eprintln!("Thread: {id}");
+        }
+        return Ok(());
+    }
+
+    // Interactive REPL.
+    eprintln!("Monocle Chat — Responses API (model: {model})");
+    eprintln!("jarvice: {jarvice_url}");
+    eprintln!("Type your message. Press Ctrl+D to exit.");
+    eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
+    eprintln!("The server owns this conversation's thread — no local history is resent.");
+    eprintln!("---");
+
+    let history_path = home_dir().join(".monocle").join("chat_history");
+    // Not a `Vec<Message>` like `run_completions_chat`'s `convo` — the server
+    // persists the conversation; this is just the id to hand back next turn.
+    let mut thread_id: Option<String> = options.thread.clone();
+
+    run_repl(ChatReplHelper, history_path, "> ", |trimmed| {
+        if trimmed == "/quit" || trimmed == "/exit" {
+            eprintln!("Bye.");
+            return Ok(LoopControl::Quit);
+        }
+
+        let (text, images) = match resolve_repl_attachments(trimmed) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                eprintln!();
+                return Ok(LoopControl::Continue);
+            }
+        };
+
+        eprintln!();
+        crate::diag::reset();
+        match rc.respond(&model, &text, &images, thread_id.as_deref()) {
+            Ok(reply) => {
+                println!("{}", reply.content);
+                // Announce the thread id only when it's newly learned (the
+                // first turn) or changed — not on every turn, since it's
+                // normally stable for the rest of the session.
+                if reply.thread_id.is_some() && thread_id != reply.thread_id {
+                    thread_id = reply.thread_id;
+                    if let Some(id) = &thread_id {
+                        eprintln!("Thread: {id}");
+                    }
+                }
+                println!();
             }
             Err(e) => {
                 eprintln!("Error: {e}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@ pub mod net;
 pub mod oidc;
 pub mod origin;
 pub mod refresh;
+pub mod responses_api;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,17 @@ struct ChatArgs {
     /// (piped stdin) only — see also inband `file:<path>` tokens in the text.
     #[arg(long = "file")]
     file: Vec<String>,
+    /// Experimental: talk to jarvice's `/api/responses` instead of the plain
+    /// `/v1/chat/completions` — the server owns the conversation thread, so
+    /// this CLI doesn't accumulate history itself. jarvice-only (not reachable
+    /// through chat-proxy); no custom `--system-prompt` support (see
+    /// `responses_api` module docs).
+    #[arg(long)]
+    responses: bool,
+    /// With `--responses`, continue this existing server-side thread id
+    /// instead of starting a new one.
+    #[arg(long)]
+    thread: Option<String>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -175,6 +186,8 @@ impl From<ChatArgs> for ChatOptions {
             system_prompt_file: a.system_prompt_file,
             max_tokens: a.max_tokens,
             files: a.file,
+            responses: a.responses,
+            thread: a.thread,
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -20,6 +20,12 @@ pub struct Resp {
     pub status: u16,
     pub status_text: String,
     body: Vec<u8>,
+    /// Response headers, name lowercased (HTTP header names are case-insensitive)
+    /// — read via `header()`. Most callers only need `status`/`body`; this
+    /// exists for the few responses that carry state in a header instead of
+    /// the JSON body (e.g. jarvice's `/api/responses` returning the server-
+    /// created thread id via `X-Thread-Id`).
+    headers: Vec<(String, String)>,
 }
 
 impl Resp {
@@ -37,6 +43,15 @@ impl Resp {
 
     pub fn json<T: DeserializeOwned>(&self) -> Result<T> {
         Ok(serde_json::from_slice(&self.body)?)
+    }
+
+    /// Look up a response header by name (case-insensitive).
+    pub fn header(&self, name: &str) -> Option<&str> {
+        let name = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| *k == name)
+            .map(|(_, v)| v.as_str())
     }
 }
 
@@ -103,11 +118,13 @@ impl Client {
         let resp = req.send().map_err(|e| AppError(e.to_string()))?;
         let status = resp.status().as_u16();
         let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+        let headers = collect_headers(resp.headers());
         let body = resp.bytes().map_err(|e| AppError(e.to_string()))?.to_vec();
         Ok(Resp {
             status,
             status_text,
             body,
+            headers,
         })
     }
 
@@ -217,6 +234,7 @@ fn send(method: &str, url: &str, req: reqwest::blocking::RequestBuilder) -> Resu
     })?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+    let headers = collect_headers(resp.headers());
     let body = resp
         .bytes()
         .map_err(|e| {
@@ -229,7 +247,23 @@ fn send(method: &str, url: &str, req: reqwest::blocking::RequestBuilder) -> Resu
         status,
         status_text,
         body,
+        headers,
     })
+}
+
+/// Snapshot a `reqwest` header map into owned, lowercased `(name, value)`
+/// pairs — keeps `reqwest::header::HeaderMap` from leaking past this module.
+/// A non-UTF-8 header value is dropped rather than erroring the whole
+/// response over one exotic header.
+fn collect_headers(headers: &reqwest::header::HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|v| (k.as_str().to_ascii_lowercase(), v.to_string()))
+        })
+        .collect()
 }
 
 /// A streaming HTTP response — a blocking line reader over the body. Keeps the

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -1,0 +1,187 @@
+//! Client for jarvice's custom **"Responses API"** (`POST /api/responses`).
+//!
+//! This is NOT OpenAI's Responses API — it's a monocle-specific endpoint
+//! (jarvice `backend/open_webui/routers/responses.py`) that is, under the
+//! hood, still a plain chat completion. What earns it the "Responses API"
+//! name is that the **server owns the conversation thread**: a caller sends
+//! only the new turn (plus an optional `thread_id` to continue a thread the
+//! server already persisted), instead of resending the full message history
+//! the way a stateless `/v1/chat/completions` client must (see
+//! `commands::chat`'s own accumulating `convo`, which is exactly the
+//! bookkeeping this endpoint makes unnecessary).
+//!
+//! **jarvice-only.** Unlike `/v1/chat/completions` (reachable through
+//! chat-proxy's `router_url`), this endpoint is not proxied — it requires
+//! jarvice's own tenant-host-routed base URL (`auth::jarvice_url_for`).
+//!
+//! **Non-streaming only, for now.** jarvice streams token deltas over
+//! Socket.IO, not HTTP SSE; this client always sends `"stream": false`, which
+//! jarvice's endpoint honors by returning the full assembled reply
+//! synchronously in the HTTP JSON body (confirmed against jarvice's
+//! `create_response` → `process_chat_response`, the same non-streaming
+//! branch the legacy `/api/chat/completions` path already uses) — so a plain
+//! blocking-HTTP client needs no Socket.IO involvement at all.
+
+use serde_json::{json, Value};
+
+use crate::agent::providers::ImageAttachment;
+use crate::error::{AppError, Result};
+use crate::net::Client;
+use crate::origin::auth_headers;
+
+/// One turn's reply, plus the thread id to pass as `--thread`/the next turn's
+/// `thread_id` to keep the conversation going. jarvice always resolves (and
+/// returns) a thread id — creating one on the first turn of a session, or
+/// confirming the one passed in — so this is `Option` only defensively, in
+/// case a future response ever omits the header.
+pub struct ResponsesReply {
+    pub content: String,
+    pub thread_id: Option<String>,
+}
+
+/// Build the `input` field: a plain string when there's no attachment (the
+/// common case, and the shape jarvice's own docs lead with), or a content-
+/// block list (`input_text` + `input_image`) once at least one image is
+/// attached. An image-only turn (empty `text`) omits the `input_text` block
+/// rather than sending an empty one.
+fn build_input(text: &str, images: &[ImageAttachment]) -> Value {
+    if images.is_empty() {
+        return json!(text);
+    }
+    let mut parts: Vec<Value> = Vec::new();
+    if !text.is_empty() {
+        parts.push(json!({"type": "input_text", "text": text}));
+    }
+    for img in images {
+        parts.push(json!({"type": "input_image", "image_url": img.url}));
+    }
+    json!(parts)
+}
+
+pub struct ResponsesClient<'a> {
+    client: &'a Client,
+    token: String,
+    jarvice_url: String,
+}
+
+impl<'a> ResponsesClient<'a> {
+    pub fn new(
+        client: &'a Client,
+        token: impl Into<String>,
+        jarvice_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            token: token.into(),
+            jarvice_url: jarvice_url.into(),
+        }
+    }
+
+    /// One non-streaming turn. `thread_id` is `None` to start a brand-new
+    /// server-side thread (jarvice creates one and returns its id), or
+    /// `Some(id)` to continue a thread from an earlier call.
+    ///
+    /// Note: jarvice's `/api/responses` has no generic system-prompt field
+    /// (only a voice-mode `speech_system_context`) — a custom
+    /// `--system-prompt` has nothing to attach to here, unlike the plain
+    /// `/v1/chat/completions` path. Callers should warn and ignore it rather
+    /// than silently dropping it.
+    pub fn respond(
+        &self,
+        model: &str,
+        text: &str,
+        images: &[ImageAttachment],
+        thread_id: Option<&str>,
+    ) -> Result<ResponsesReply> {
+        let input = build_input(text, images);
+
+        let mut body = json!({
+            "model": model,
+            "input": input,
+            "stream": false,
+        });
+        if let Some(id) = thread_id {
+            body["thread"] = json!({"thread_id": id});
+        }
+
+        let bearer = format!("Bearer {}", self.token);
+        let resp = self.client.post_json(
+            &format!("{}/api/responses", self.jarvice_url),
+            &auth_headers(&bearer),
+            &body,
+        )?;
+        if !resp.ok() {
+            return Err(AppError::new(format!(
+                "Responses API error {}: {}",
+                resp.status,
+                resp.text()
+            )));
+        }
+        let data: Value = resp.json()?;
+        if data.get("choices").and_then(|c| c.get(0)).is_none() {
+            return Err(AppError::new(format!(
+                "unexpected /api/responses reply (no choices): {data}"
+            )));
+        }
+        let content = data["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let thread_id = resp.header("x-thread-id").map(str::to_string);
+        Ok(ResponsesReply { content, thread_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_only_input_serializes_as_plain_string() {
+        // The common case, and the shape jarvice's own docs lead with — no
+        // content-block wrapping when there's nothing to attach.
+        assert_eq!(build_input("hello", &[]), json!("hello"));
+    }
+
+    #[test]
+    fn image_input_becomes_content_block_list() {
+        let images = vec![ImageAttachment {
+            url: "data:image/png;base64,AAAA".to_string(),
+        }];
+        assert_eq!(
+            build_input("what is this?", &images),
+            json!([
+                {"type": "input_text", "text": "what is this?"},
+                {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+            ])
+        );
+    }
+
+    #[test]
+    fn image_only_input_omits_empty_text_block() {
+        let images = vec![ImageAttachment {
+            url: "https://example.com/a.png".to_string(),
+        }];
+        assert_eq!(
+            build_input("", &images),
+            json!([{"type": "input_image", "image_url": "https://example.com/a.png"}])
+        );
+    }
+
+    #[test]
+    fn multiple_images_preserve_order() {
+        let images = vec![
+            ImageAttachment {
+                url: "data:image/png;base64,AAAA".to_string(),
+            },
+            ImageAttachment {
+                url: "https://example.com/b.png".to_string(),
+            },
+        ];
+        let input = build_input("compare these", &images);
+        let parts = input.as_array().unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[1]["image_url"], json!("data:image/png;base64,AAAA"));
+        assert_eq!(parts[2]["image_url"], json!("https://example.com/b.png"));
+    }
+}


### PR DESCRIPTION
## 요약

**1) 버그 수정 — `monocle chat`이 대화를 전혀 기억하지 못하던 문제**

인터랙티브 REPL이 매 턴 `[system?, 이번 턴 메시지]`만 새로 만들어 보내고
있었음 — 이전 턴은 전혀 포함되지 않았다. `monocle agent`의 `Repl.convo`와
동일한 mark/truncate 패턴으로 전체 히스토리를 누적하도록 수정.

**2) 신규 기능 — `monocle chat --responses [--thread <id>]`**

jarvice의 커스텀 Responses API(`POST /api/responses`)를 테스트할 수 있는
모드를 추가. OpenAI Responses API를 복제한 게 아니라, **서버가 대화
스레드를 직접 관리**한다는 점에서 개념적으로 유사하다고 이름 붙인
자체 구현.

- jarvice 전용 엔드포인트 — chat-proxy(`router_url`)가 아닌
  `tenant_domain`에서 파생한 jarvice URL이 필요 (`auth::jarvice_url_for`
  추가, `router_url`과 절대 혼용하지 않음).
- 스트리밍은 Socket.IO를 쓰지만, `stream:false`로 요청하면 완성된 응답을
  동기 HTTP 바디로 그대로 받을 수 있음을 jarvice 소스로 직접 확인 —
  별도 의존성(Socket.IO 클라이언트) 없이 구현.
- 서버가 발급하는 `X-Thread-Id` 헤더를 읽기 위해 `net.rs`의 `Resp`에
  헤더 접근(`header()`)을 추가.
- `--system-prompt`/`--system-prompt-file`/`--max-tokens`는 이 엔드포인트에
  대응 필드가 없어 경고 후 무시.

**알려진 제약**: 이 엔드포인트는 다른 jarvice user 라우트와 같은 stark
JWT 인증을 쓰는데, user 타입 access_token에 `email` 클레임이 없는 기존
이슈(`monocle mcp`를 막고 있는 것과 동일, stark#1061)로 인해 실제
스테이징/prod 테넌트에서는 401이 날 가능성이 높다 — 코드 주석과
README에 명시. 로컬/mock 환경에서 먼저 검증하는 것을 권장.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 96 passed (92 → 96, `responses_api` 신규 테스트 4개)
- [x] `cargo fmt --check` clean
- [x] 서브에이전트(Opus)로 diff 리뷰 — accumulation rollback, 헤더 파싱,
      jarvice_url 파생, stdout/stderr 채널 분리 등 검증. REPL에서
      thread id가 노출되지 않던 문제 1건 발견 후 수정 완료.
- [ ] 실제 스테이징 테넌트 대상 `--responses` 인증 테스트는 stark#1061
      해결 후로 보류 (사용자 결정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)