### PR TITLE
feat(chat): jarvice 기존 대화 스레드 목록/재개 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--thread <id>]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead |
+| `monocle chat list` | List existing jarvice chat threads (id/title/last-updated) — including threads created in jarvice's own web UI |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
@@ -210,12 +211,23 @@ Thread: 3fa3b2c1-...
 Bye.
 ```
 
-Continue a specific thread later (one-shot or REPL) with `--thread <id>`
+Continue a specific thread later (one-shot or REPL) with `--resume <id>`
 (the id a previous run printed to stderr as `Thread: ...`):
 
 ```bash
-echo "and in Python?" | monocle chat --responses --thread 3fa3b2c1-...
+echo "and in Python?" | monocle chat --responses --resume 3fa3b2c1-...
 ```
+
+List your existing threads (including ones started in jarvice's own web UI —
+both share the same storage) with the `list` subcommand:
+
+```bash
+monocle chat list
+```
+
+Continuing into the interactive REPL with `--resume <id>` (not one-shot)
+replays that thread's prior history to stderr before the prompt, so you can
+pick up a conversation started elsewhere.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,19 @@ Bye.
 
 The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
 and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
-Tab completes `/quit`/`/exit`, and a multi-line paste is inserted as a single input
-(submitted only on Enter, not one turn per line). Command history persists across
-sessions in `~/.monocle/chat_history` (kept separate from `monocle agent`'s history).
-The REPL remembers the conversation — each turn resends the full exchange so
-far, the same way `monocle agent` does — so follow-up questions ("what about
-in Python?") work without repeating context.
+Tab completes `/model`/`/quit`/`/exit` as a dropdown listing every match (not cycling
+one at a time), with the best match also shown as a dim inline hint as you type; a
+multi-line paste is inserted as a single input (submitted only on Enter, not one turn
+per line). Command history persists across sessions in `~/.monocle/chat_history` (kept
+separate from `monocle agent`'s history). The REPL remembers the conversation — each
+turn resends the full exchange so far, the same way `monocle agent` does — so
+follow-up questions ("what about in Python?") work without repeating context.
+
+Same as `monocle agent`'s REPL, `/model` shows the current model (or `/model <id>`
+switches it for later turns), and `/model <TAB>` fuzzy-completes against the model ids
+available to your account (fetched once at startup) — e.g. `/model cla<TAB>` narrows to
+matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
+list can't be fetched, completion just offers nothing (typing a full id still works).
 
 One-shot via stdin:
 
@@ -330,9 +337,10 @@ it for an interactive REPL. Progress goes to stderr, the answer to stdout; `--se
 
 The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
 and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
-Tab completes slash commands, and a multi-line paste is inserted as a single input
-(submitted only on Enter). Command history persists across sessions in
-`~/.monocle/agent_history`.
+Tab completes slash commands as a dropdown listing every match (not cycling one at a
+time), with the best match also shown as a dim inline hint as you type; a multi-line
+paste is inserted as a single input (submitted only on Enter). Command history
+persists across sessions in `~/.monocle/agent_history`.
 
 In the interactive REPL, lines starting with `/` are local management commands (handled
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -105,12 +105,20 @@ impl ReplHelper {
         // `/model <partial>` — fuzzy-match the argument against the cached model
         // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
         // to matching ids and a bare `/model <TAB>` shows the full dropdown.
-        // Replace only from just after "/model " (not column 0, unlike the
-        // command-name path below) — we're completing the argument, not the
-        // command word.
-        if let Some(query) = head.strip_prefix("/model ") {
-            let start = head.len() - query.len();
-            return (start, fuzzy_model_candidates(&self.models, query));
+        // Guarded (not a bare `head.strip_prefix("/model ")`) so a double space
+        // (`/model  cla`) still trims down to the right query instead of leaving
+        // a leading space that breaks the fuzzy match — `parse_model_command`
+        // (the real dispatcher) already tolerates this via its own final
+        // `.trim()`, so completion must too. `/models` (no separating space)
+        // still falls through to plain command-name completion below rather
+        // than being misread as `/model` with argument `s` — the same
+        // boundary `parse_model_command` draws.
+        if let Some(rest) = head.strip_prefix("/model") {
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                let query = rest.trim_start();
+                let start = head.len() - query.len();
+                return (start, fuzzy_model_candidates(&self.models, query));
+            }
         }
         let candidates = SLASH_COMMANDS
             .iter()
@@ -638,6 +646,30 @@ mod tests {
                 .map(|p| p.replacement)
                 .collect::<Vec<_>>(),
             vec!["/model".to_string()]
+        );
+    }
+
+    /// FIX #2: a double space after `/model` must not leave a leading space
+    /// in the extracted query — that would break the fuzzy match even
+    /// though `parse_model_command` (the real dispatcher) already tolerates
+    /// it via its own final `.trim()`.
+    #[test]
+    fn complete_model_argument_tolerates_double_space() {
+        let helper = ReplHelper {
+            models: Rc::new(model_ids(&["claude-sonnet-4-6", "gpt-4o"])),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model  cla";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, line.len() - "cla".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
         );
     }
 }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -4,14 +4,15 @@
 //! edit + cross-platform shell) into the agent-core loop, prints progress to
 //! stderr, and the final answer to stdout.
 
+use std::borrow::Cow;
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use fuzzy_matcher::skim::SkimMatcherV2;
-use fuzzy_matcher::FuzzyMatcher;
 use rustyline::completion::{Completer, Pair};
-use rustyline::{Context, Helper, Highlighter, Hinter, Validator};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::{Context, Helper, Validator};
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
@@ -22,8 +23,8 @@ use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
-use crate::commands::model_list::fetch_model_ids;
-use crate::commands::repl::{run_repl, LoopControl};
+use crate::commands::model_list::{fetch_model_ids, fuzzy_model_candidates, parse_model_command};
+use crate::commands::repl::{dim_hint, hint_from_candidates, run_repl, LoopControl};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -75,11 +76,13 @@ impl Observer for CliObserver {
 /// what `dispatch_command` / `parse_model_command` actually handle.
 const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
 
-/// rustyline line helper: Tab-completes slash commands, and (for `/model`)
-/// fuzzy-completes the argument against a model id list fetched once at REPL
-/// startup. Hinting/highlighting/validation are the derived no-op defaults —
-/// we only customize completion.
-#[derive(Helper, Hinter, Highlighter, Validator)]
+/// rustyline line helper: Tab-completes slash commands (as a real dropdown —
+/// see `commands::repl::run_repl`'s `CompletionType::List`), and (for
+/// `/model`) fuzzy-completes the argument against a model id list fetched
+/// once at REPL startup. Also hints the best-ranked candidate as dim inline
+/// ghost text via `Hinter`/`Highlighter`; validation stays the derived no-op
+/// default (multi-line handling comes from `bracketed_paste`).
+#[derive(Helper, Validator)]
 struct ReplHelper {
     /// Model ids fetched once before the loop starts (see `agent_command`).
     /// Empty when not logged in / the fetch failed — `/model` completion then
@@ -88,6 +91,38 @@ struct ReplHelper {
     /// the list is read-only for the session's lifetime (no need for a `Vec`
     /// clone per keystroke).
     models: Rc<Vec<String>>,
+}
+
+impl ReplHelper {
+    /// Shared by `Completer::complete` and `Hinter::hint` so the two can never
+    /// disagree on what's being completed.
+    fn candidates(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
+        // Only offer completion for a slash-command being typed at the line start.
+        let head = &line[..pos];
+        if !head.starts_with('/') {
+            return (0, Vec::new());
+        }
+        // `/model <partial>` — fuzzy-match the argument against the cached model
+        // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
+        // to matching ids and a bare `/model <TAB>` shows the full dropdown.
+        // Replace only from just after "/model " (not column 0, unlike the
+        // command-name path below) — we're completing the argument, not the
+        // command word.
+        if let Some(query) = head.strip_prefix("/model ") {
+            let start = head.len() - query.len();
+            return (start, fuzzy_model_candidates(&self.models, query));
+        }
+        let candidates = SLASH_COMMANDS
+            .iter()
+            .filter(|cmd| cmd.starts_with(head))
+            .map(|cmd| Pair {
+                display: cmd.to_string(),
+                replacement: cmd.to_string(),
+            })
+            .collect();
+        // Replace from column 0 (the whole slash token starts there).
+        (0, candidates)
+    }
 }
 
 impl Completer for ReplHelper {
@@ -99,57 +134,23 @@ impl Completer for ReplHelper {
         pos: usize,
         _ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        // Only offer completion for a slash-command being typed at the line start.
-        let head = &line[..pos];
-        if !head.starts_with('/') {
-            return Ok((0, Vec::new()));
-        }
-        // `/model <partial>` — fuzzy-match the argument against the cached model
-        // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
-        // to matching ids and a bare `/model <TAB>` shows the full dropdown.
-        // Replace only from just after "/model " (not column 0, unlike the
-        // command-name path below) — we're completing the argument, not the
-        // command word.
-        if let Some(query) = head.strip_prefix("/model ") {
-            let start = head.len() - query.len();
-            return Ok((start, fuzzy_model_candidates(&self.models, query)));
-        }
-        let candidates = SLASH_COMMANDS
-            .iter()
-            .filter(|cmd| cmd.starts_with(head))
-            .map(|cmd| Pair {
-                display: cmd.to_string(),
-                replacement: cmd.to_string(),
-            })
-            .collect();
-        // Replace from column 0 (the whole slash token starts there).
-        Ok((0, candidates))
+        Ok(self.candidates(line, pos))
     }
 }
 
-/// Fuzzy-match `query` against cached model ids for `/model` tab-completion.
-/// An empty query returns the full list unranked (the "show me what's
-/// available" dropdown); otherwise ids are scored with `fuzzy-matcher`'s skim
-/// algorithm (subsequence match, case-smart), kept only if they match at all,
-/// and sorted best match first.
-fn fuzzy_model_candidates(models: &[String], query: &str) -> Vec<Pair> {
-    let to_pair = |id: &String| Pair {
-        display: id.clone(),
-        replacement: id.clone(),
-    };
-    if query.is_empty() {
-        return models.iter().map(to_pair).collect();
+impl Hinter for ReplHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        let (start, candidates) = self.candidates(line, pos);
+        hint_from_candidates(line, start, pos, &candidates)
     }
-    // `ignore_case` (not the default smart-case) so typing in any case still
-    // narrows the (lowercase-by-convention) model ids — smart-case would make
-    // an all-caps query like "CLAUDE" match nothing.
-    let matcher = SkimMatcherV2::default().ignore_case();
-    let mut scored: Vec<(i64, &String)> = models
-        .iter()
-        .filter_map(|id| matcher.fuzzy_match(id, query).map(|score| (score, id)))
-        .collect();
-    scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
-    scored.into_iter().map(|(_, id)| to_pair(id)).collect()
+}
+
+impl Highlighter for ReplHelper {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        dim_hint(hint)
+    }
 }
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
@@ -301,23 +302,6 @@ fn dispatch_command(input: &str) -> Command {
         "/status" => Command::Status,
         "/exit" | "/quit" => Command::Quit,
         other => Command::Unknown(other.to_string()),
-    }
-}
-
-/// Pure parser for the `/model` command. Returns:
-/// - `None` — not a `/model` invocation (let normal dispatch handle it);
-/// - `Some(None)` — bare `/model` (show the current model);
-/// - `Some(Some(id))` — `/model <id>` (switch to `id`).
-fn parse_model_command(input: &str) -> Option<Option<String>> {
-    let trimmed = input.trim();
-    if trimmed == "/model" {
-        return Some(None);
-    }
-    let rest = trimmed.strip_prefix("/model ")?.trim();
-    if rest.is_empty() {
-        Some(None)
-    } else {
-        Some(Some(rest.to_string()))
     }
 }
 
@@ -594,75 +578,13 @@ mod tests {
         assert!(!use_prompt_approver(true, false));
     }
 
-    #[test]
-    fn parse_model_command_variants() {
-        // Not a /model command.
-        assert_eq!(parse_model_command("hello"), None);
-        assert_eq!(parse_model_command("/models"), None);
-        assert_eq!(parse_model_command("/help"), None);
-        // Bare /model (with or without surrounding / trailing space) shows current.
-        assert_eq!(parse_model_command("/model"), Some(None));
-        assert_eq!(parse_model_command("  /model  "), Some(None));
-        assert_eq!(parse_model_command("/model   "), Some(None));
-        // /model <id> switches.
-        assert_eq!(
-            parse_model_command("/model gpt-4o"),
-            Some(Some("gpt-4o".to_string()))
-        );
-        assert_eq!(
-            parse_model_command("/model  claude-x  "),
-            Some(Some("claude-x".to_string()))
-        );
-    }
+    // `parse_model_command`/`fuzzy_model_candidates` themselves are now
+    // covered by `commands::model_list`'s own tests (they moved there so
+    // `chat.rs` can share them) — this module keeps only the `ReplHelper`-
+    // specific completion-offset tests below.
 
     fn model_ids(ids: &[&str]) -> Vec<String> {
         ids.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn fuzzy_model_candidates_empty_query_returns_full_list_unranked() {
-        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
-        let got: Vec<String> = fuzzy_model_candidates(&models, "")
-            .into_iter()
-            .map(|p| p.replacement)
-            .collect();
-        assert_eq!(got, models);
-    }
-
-    #[test]
-    fn fuzzy_model_candidates_narrows_by_subsequence() {
-        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
-        let got: Vec<String> = fuzzy_model_candidates(&models, "cla")
-            .into_iter()
-            .map(|p| p.replacement)
-            .collect();
-        assert_eq!(got, vec!["claude-sonnet-4-6", "claude-opus-4"]);
-    }
-
-    #[test]
-    fn fuzzy_model_candidates_ranks_tighter_match_first() {
-        // "gpt4o" as a subsequence appears in both, but a contiguous match in
-        // "gpt-4o" should outrank the more scattered match in "gpt-4-omni".
-        let models = model_ids(&["gpt-4-omni", "gpt-4o"]);
-        let got: Vec<String> = fuzzy_model_candidates(&models, "gpt4o")
-            .into_iter()
-            .map(|p| p.replacement)
-            .collect();
-        assert_eq!(got.first().map(String::as_str), Some("gpt-4o"));
-    }
-
-    #[test]
-    fn fuzzy_model_candidates_excludes_non_matches() {
-        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o"]);
-        let got = fuzzy_model_candidates(&models, "zzz");
-        assert!(got.is_empty());
-    }
-
-    #[test]
-    fn fuzzy_model_candidates_case_insensitive() {
-        let models = model_ids(&["claude-sonnet-4-6"]);
-        let got = fuzzy_model_candidates(&models, "CLAUDE");
-        assert_eq!(got.len(), 1);
     }
 
     /// The completion `start` offset is what rustyline uses to splice the

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -4,15 +4,9 @@
 //! edit + cross-platform shell) into the agent-core loop, prints progress to
 //! stderr, and the final answer to stdout.
 
-use std::borrow::Cow;
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
-use std::rc::Rc;
 
-use rustyline::completion::{Completer, Pair};
-use rustyline::highlight::Highlighter;
-use rustyline::hint::Hinter;
-use rustyline::{Context, Helper, Validator};
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
@@ -23,8 +17,8 @@ use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
-use crate::commands::model_list::{fetch_model_ids, fuzzy_model_candidates, parse_model_command};
-use crate::commands::repl::{dim_hint, hint_from_candidates, run_repl, LoopControl};
+use crate::commands::model_list::{fetch_model_ids, handle_model_command};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -75,91 +69,6 @@ impl Observer for CliObserver {
 /// by `/help`. Kept here (next to the dispatcher) so completion never drifts from
 /// what `dispatch_command` / `parse_model_command` actually handle.
 const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
-
-/// rustyline line helper: Tab-completes slash commands (as a real dropdown —
-/// see `commands::repl::run_repl`'s `CompletionType::List`), and (for
-/// `/model`) fuzzy-completes the argument against a model id list fetched
-/// once at REPL startup. Also hints the best-ranked candidate as dim inline
-/// ghost text via `Hinter`/`Highlighter`; validation stays the derived no-op
-/// default (multi-line handling comes from `bracketed_paste`).
-#[derive(Helper, Validator)]
-struct ReplHelper {
-    /// Model ids fetched once before the loop starts (see `agent_command`).
-    /// Empty when not logged in / the fetch failed — `/model` completion then
-    /// just offers no candidates, same defensive posture as the rest of the
-    /// interactive path. `Rc` because `Editor::set_helper` takes ownership and
-    /// the list is read-only for the session's lifetime (no need for a `Vec`
-    /// clone per keystroke).
-    models: Rc<Vec<String>>,
-}
-
-impl ReplHelper {
-    /// Shared by `Completer::complete` and `Hinter::hint` so the two can never
-    /// disagree on what's being completed.
-    fn candidates(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
-        // Only offer completion for a slash-command being typed at the line start.
-        let head = &line[..pos];
-        if !head.starts_with('/') {
-            return (0, Vec::new());
-        }
-        // `/model <partial>` — fuzzy-match the argument against the cached model
-        // ids instead of the flat command-name list, so `/model cla<TAB>` narrows
-        // to matching ids and a bare `/model <TAB>` shows the full dropdown.
-        // Guarded (not a bare `head.strip_prefix("/model ")`) so a double space
-        // (`/model  cla`) still trims down to the right query instead of leaving
-        // a leading space that breaks the fuzzy match — `parse_model_command`
-        // (the real dispatcher) already tolerates this via its own final
-        // `.trim()`, so completion must too. `/models` (no separating space)
-        // still falls through to plain command-name completion below rather
-        // than being misread as `/model` with argument `s` — the same
-        // boundary `parse_model_command` draws.
-        if let Some(rest) = head.strip_prefix("/model") {
-            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
-                let query = rest.trim_start();
-                let start = head.len() - query.len();
-                return (start, fuzzy_model_candidates(&self.models, query));
-            }
-        }
-        let candidates = SLASH_COMMANDS
-            .iter()
-            .filter(|cmd| cmd.starts_with(head))
-            .map(|cmd| Pair {
-                display: cmd.to_string(),
-                replacement: cmd.to_string(),
-            })
-            .collect();
-        // Replace from column 0 (the whole slash token starts there).
-        (0, candidates)
-    }
-}
-
-impl Completer for ReplHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        _ctx: &Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        Ok(self.candidates(line, pos))
-    }
-}
-
-impl Hinter for ReplHelper {
-    type Hint = String;
-
-    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
-        let (start, candidates) = self.candidates(line, pos);
-        hint_from_candidates(line, start, pos, &candidates)
-    }
-}
-
-impl Highlighter for ReplHelper {
-    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
-        dim_hint(hint)
-    }
-}
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
 /// tool call and reads a y/N answer from stdin. Default (empty / non-y / EOF) is
@@ -440,22 +349,16 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     // the escapes print as literal characters, so rustyline's cursor-column
     // math (0-width) diverges from the terminal's real cursor position —
     // seen as the cursor sitting ~10 columns in in PowerShell before any input.
-    let helper = ReplHelper {
-        models: Rc::new(model_ids),
+    let helper = ModelReplHelper {
+        commands: SLASH_COMMANDS,
+        models: model_ids,
     };
     let history_path = home_dir().join(".monocle").join("agent_history");
 
     run_repl(helper, history_path, "» ", |msg| {
         // `/model` switches the model for subsequent turns (handled before
         // the general dispatch since it carries an argument).
-        if let Some(model_cmd) = parse_model_command(msg) {
-            match model_cmd {
-                Some(id) => {
-                    eprintln!("{}", c::dim(&format!("model → {id}")));
-                    repl.model = id;
-                }
-                None => eprintln!("{}", c::dim(&format!("model: {}", repl.model))),
-            }
+        if handle_model_command(msg, &mut repl.model) {
             return Ok(LoopControl::Continue);
         }
         // Slash commands are handled locally (never sent to the agent/LLM),
@@ -537,7 +440,6 @@ fn one_line(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustyline::history::DefaultHistory;
 
     #[test]
     fn dispatch_recognizes_management_commands() {
@@ -586,90 +488,8 @@ mod tests {
         assert!(!use_prompt_approver(true, false));
     }
 
-    // `parse_model_command`/`fuzzy_model_candidates` themselves are now
-    // covered by `commands::model_list`'s own tests (they moved there so
-    // `chat.rs` can share them) — this module keeps only the `ReplHelper`-
-    // specific completion-offset tests below.
-
-    fn model_ids(ids: &[&str]) -> Vec<String> {
-        ids.iter().map(|s| s.to_string()).collect()
-    }
-
-    /// The completion `start` offset is what rustyline uses to splice the
-    /// chosen candidate back into the line — get it wrong and accepting a
-    /// completion corrupts the line. For `/model <partial>` it must point
-    /// just past `"/model "`, not column 0 (unlike the command-name path),
-    /// so accepting a candidate replaces only the partial id.
-    #[test]
-    fn complete_model_argument_uses_offset_after_prefix() {
-        let helper = ReplHelper {
-            models: Rc::new(model_ids(&["claude-sonnet-4-6", "gpt-4o"])),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/model cla";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, "/model ".len());
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec!["claude-sonnet-4-6".to_string()]
-        );
-
-        // Bare "/model " (empty partial) offers the full dropdown, still
-        // anchored right after the prefix.
-        let line = "/model ";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, "/model ".len());
-        assert_eq!(candidates.len(), 2);
-    }
-
-    /// Command-name completion (`/mo<TAB>` → `/model`) must be unaffected by
-    /// the new `/model` argument branch.
-    #[test]
-    fn complete_command_name_unaffected_by_model_argument_branch() {
-        let helper = ReplHelper {
-            models: Rc::new(model_ids(&["claude-sonnet-4-6"])),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/mo";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, 0);
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec!["/model".to_string()]
-        );
-    }
-
-    /// FIX #2: a double space after `/model` must not leave a leading space
-    /// in the extracted query — that would break the fuzzy match even
-    /// though `parse_model_command` (the real dispatcher) already tolerates
-    /// it via its own final `.trim()`.
-    #[test]
-    fn complete_model_argument_tolerates_double_space() {
-        let helper = ReplHelper {
-            models: Rc::new(model_ids(&["claude-sonnet-4-6", "gpt-4o"])),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/model  cla";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, line.len() - "cla".len());
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec!["claude-sonnet-4-6".to_string()]
-        );
-    }
+    // `parse_model_command`/`fuzzy_model_candidates` themselves are covered
+    // by `commands::model_list`'s own tests; the shared `ModelReplHelper`
+    // (Completer/Hinter) is now covered by `commands::repl`'s tests, since
+    // that's where it lives.
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -2,12 +2,14 @@ use std::io::{IsTerminal, Write};
 
 use serde_json::Value;
 
+use chrono::TimeZone;
+
 use crate::agent::providers::{
     ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
-use crate::auth::{get_access_token, jarvice_url_for};
+use crate::auth::{get_access_token, jarvice_url_for, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
 use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
 use crate::credentials::Credentials;
@@ -28,8 +30,8 @@ pub struct ChatOptions {
     /// `--responses`: talk to jarvice's `/api/responses` (server-managed
     /// thread) instead of the plain `/v1/chat/completions` path.
     pub responses: bool,
-    /// `--thread <ID>`: continue an existing `--responses` thread.
-    pub thread: Option<String>,
+    /// `--resume <ID>`: continue an existing `--responses` thread.
+    pub resume: Option<String>,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -344,6 +346,32 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     })
 }
 
+/// Resolve a validated session + jarvice's own base URL + a ready-to-use
+/// `Authorization` header value — shared by `run_responses_chat` and
+/// `chat_list_command`, since both need the same auth + jarvice-host
+/// resolution. Deliberately `jarvice_url_for`, NOT `session.router_url`
+/// (chat-proxy) — see `responses_api` module docs for why.
+fn resolve_jarvice(client: &Client, creds: &Credentials) -> Result<(AuthSession, String, String)> {
+    let session = get_access_token(client, creds);
+    let stored = creds.read().ok_or_else(|| {
+        crate::error::AppError::new("Not logged in. Run `monocle login --tenant <domain>` first.")
+    })?;
+    let jarvice_url = jarvice_url_for(&stored);
+    let bearer = format!("Bearer {}", session.token);
+    Ok((session, jarvice_url, bearer))
+}
+
+/// `monocle chat list` — list the current user's existing jarvice threads
+/// (id/title/last-updated) and exit. Always jarvice's thread storage — there
+/// is nothing else to list in the plain completions mode, so this never takes
+/// a `--responses` flag.
+pub fn chat_list_command(client: &Client, creds: &Credentials) -> Result<()> {
+    let (_session, jarvice_url, bearer) = resolve_jarvice(client, creds)?;
+    let threads = crate::jarvice_chats::list_threads(client, &jarvice_url, &bearer)?;
+    print_threads_table(&threads);
+    Ok(())
+}
+
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
 /// docs). The server owns the conversation thread — this REPL only tracks
 /// the `thread_id` to pass on the next turn, never a local message history.
@@ -375,13 +403,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
 
     // Auth FIRST, same rationale as the completions path — an expired/missing
     // login must surface before any local-input error masks it.
-    let session = get_access_token(client, creds);
-    let stored = creds.read().ok_or_else(|| {
-        crate::error::AppError::new("Not logged in. Run `monocle login --tenant <domain>` first.")
-    })?;
-    // Deliberately `jarvice_url_for`, NOT `session.router_url` — `/api/responses`
-    // is jarvice-only, unreachable through chat-proxy (see `responses_api` docs).
-    let jarvice_url = jarvice_url_for(&stored);
+    let (session, jarvice_url, bearer) = resolve_jarvice(client, creds)?;
 
     let one_shot_input = read_one_shot_input(stdin_is_tty, &options.files)?;
 
@@ -390,7 +412,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("jarvice: {jarvice_url}");
-        let reply = rc.respond(&model, &text, &images, options.thread.as_deref())?;
+        let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
@@ -409,7 +431,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     let history_path = home_dir().join(".monocle").join("chat_history");
     // Not a `Vec<Message>` like `run_completions_chat`'s `convo` — the server
     // persists the conversation; this is just the id to hand back next turn.
-    let mut thread_id: Option<String> = options.thread.clone();
+    let mut thread_id: Option<String> = options.resume.clone();
     // Best-effort, same defensive posture as `agent.rs`'s REPL: this path has
     // no startup model-list fetch to piggyback on (unlike the completions
     // path's validation call), so fetch once here for `/model` completion.
@@ -418,6 +440,36 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         commands: CHAT_SLASH_COMMANDS,
         models: model_ids,
     };
+
+    // Replay prior history for an existing thread, REPL-only (never in the
+    // one-shot path above, never on stdout — this repo treats stdout as
+    // strictly the answer/data channel). A fetch failure must not block
+    // continuing the thread, so it's a warning, not a propagated error.
+    if let Some(id) = &thread_id {
+        match crate::jarvice_chats::get_thread(client, &jarvice_url, &bearer, id) {
+            Ok(detail) => {
+                let turns = detail
+                    .current_id
+                    .as_deref()
+                    .map(|cur| crate::jarvice_chats::linearize(&detail.messages, cur))
+                    .unwrap_or_default();
+                if !turns.is_empty() {
+                    eprintln!("--- prior history ---");
+                    for node in turns {
+                        match node.role.as_str() {
+                            "user" => eprintln!("> {}", node.content),
+                            "assistant" => eprintln!("{}", node.content),
+                            _ => {}
+                        }
+                    }
+                    eprintln!("--- end history ---");
+                }
+            }
+            Err(e) => {
+                eprintln!("Warning: could not load thread history: {e}");
+            }
+        }
+    }
 
     run_repl(helper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
@@ -466,6 +518,61 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         }
         Ok(LoopControl::Continue)
     })
+}
+
+/// Render `monocle chat list`'s table to stdout — this is a terminal
+/// print-and-exit command (like `monocle models`), so stdout is the correct
+/// channel here, unlike the history-replay path below.
+fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
+    use crate::commands::model_list::pad;
+
+    if threads.is_empty() {
+        eprintln!("No threads found.");
+        return;
+    }
+
+    let id_width = threads
+        .iter()
+        .map(|t| t.id.chars().count())
+        .chain([9])
+        .max()
+        .unwrap();
+    let title_width = threads
+        .iter()
+        .map(|t| t.title.chars().count())
+        .chain([5])
+        .max()
+        .unwrap();
+
+    let mut out = std::io::stdout();
+    let _ = writeln!(
+        out,
+        "{}  {}  UPDATED",
+        pad("THREAD ID", id_width),
+        pad("TITLE", title_width)
+    );
+    let _ = writeln!(
+        out,
+        "{}  {}  {}",
+        "─".repeat(id_width),
+        "─".repeat(title_width),
+        "─".repeat(16)
+    );
+    for t in threads {
+        let updated = chrono::Utc
+            .timestamp_opt(t.updated_at, 0)
+            .single()
+            .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            out,
+            "{}  {}  {}",
+            pad(&t.id, id_width),
+            pad(&t.title, title_width),
+            updated
+        );
+    }
+    eprintln!("\n{} thread(s).", threads.len());
 }
 
 #[cfg(test)]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,11 +1,5 @@
-use std::borrow::Cow;
 use std::io::{IsTerminal, Write};
-use std::rc::Rc;
 
-use rustyline::completion::{Completer, Pair};
-use rustyline::highlight::Highlighter;
-use rustyline::hint::Hinter;
-use rustyline::{Context, Helper, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
@@ -14,9 +8,8 @@ use crate::agent::providers::{
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for};
-use crate::colors as c;
-use crate::commands::model_list::{fetch_model_ids, fuzzy_model_candidates, parse_model_command};
-use crate::commands::repl::{dim_hint, hint_from_candidates, run_repl, LoopControl};
+use crate::commands::model_list::{fetch_model_ids, handle_model_command};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -152,90 +145,6 @@ fn resolve_repl_attachments(
 /// `/help`/`/config`/`/status`.
 const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/exit", "/quit"];
 
-/// rustyline line helper for `monocle chat`'s REPL: Tab-completes slash
-/// commands as a real dropdown (see `commands::repl::run_repl`'s
-/// `CompletionType::List`), and (for `/model`) fuzzy-completes the argument
-/// against a model id list fetched once at startup — same behavior as
-/// `agent.rs`'s `ReplHelper`, which this mirrors. Also hints the best-ranked
-/// candidate as dim inline ghost text via `Hinter`/`Highlighter`; validation
-/// stays the derived no-op default.
-#[derive(Helper, Validator)]
-struct ChatReplHelper {
-    /// Model ids fetched once before the loop starts. Empty when not logged
-    /// in / the fetch failed — `/model` completion then just offers no
-    /// candidates. `Rc` because `Editor::set_helper` takes ownership and the
-    /// list is read-only for the session's lifetime.
-    models: Rc<Vec<String>>,
-}
-
-impl ChatReplHelper {
-    /// Shared by `Completer::complete` and `Hinter::hint` so the two can
-    /// never disagree on what's being completed.
-    fn candidates(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
-        // Only offer completion for a slash-command being typed at line start.
-        let head = &line[..pos];
-        if !head.starts_with('/') {
-            return (0, Vec::new());
-        }
-        // `/model <partial>` — fuzzy-match the argument against the cached
-        // model ids, anchored just after "/model " (not column 0) so accepting
-        // a candidate replaces only the partial id. Guarded (not a bare
-        // `head.strip_prefix("/model ")`) so a double space (`/model  cla`)
-        // still trims down to the right query instead of leaving a leading
-        // space that breaks the fuzzy match — `parse_model_command` (the real
-        // dispatcher) already tolerates this via its own final `.trim()`, so
-        // completion must too. `/models` (no separating space) still falls
-        // through to plain command-name completion below rather than being
-        // misread as `/model` with argument `s` — the same boundary
-        // `parse_model_command` draws.
-        if let Some(rest) = head.strip_prefix("/model") {
-            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
-                let query = rest.trim_start();
-                let start = head.len() - query.len();
-                return (start, fuzzy_model_candidates(&self.models, query));
-            }
-        }
-        let candidates = CHAT_SLASH_COMMANDS
-            .iter()
-            .filter(|cmd| cmd.starts_with(head))
-            .map(|cmd| Pair {
-                display: cmd.to_string(),
-                replacement: cmd.to_string(),
-            })
-            .collect();
-        // Replace from column 0 (the whole slash token starts there).
-        (0, candidates)
-    }
-}
-
-impl Completer for ChatReplHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        _ctx: &Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        Ok(self.candidates(line, pos))
-    }
-}
-
-impl Hinter for ChatReplHelper {
-    type Hint = String;
-
-    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
-        let (start, candidates) = self.candidates(line, pos);
-        hint_from_candidates(line, start, pos, &candidates)
-    }
-}
-
-impl Highlighter for ChatReplHelper {
-    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
-        dim_hint(hint)
-    }
-}
-
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     if options.responses {
         run_responses_chat(client, creds, options)
@@ -367,8 +276,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     // load/save, and the Ctrl-C/Ctrl-D/error loop itself are shared with
     // `monocle agent`'s REPL via `commands::repl::run_repl`.
     let history_path = home_dir().join(".monocle").join("chat_history");
-    let helper = ChatReplHelper {
-        models: Rc::new(model_ids),
+    let helper = ModelReplHelper {
+        commands: CHAT_SLASH_COMMANDS,
+        models: model_ids,
     };
 
     // Conversation memory: mirrors `monocle agent`'s `Repl.convo` — grows for
@@ -388,14 +298,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // `/model` switches the model for subsequent turns — handled before
         // the general dispatch since it carries an argument, same as
         // `monocle agent`'s REPL.
-        if let Some(model_cmd) = parse_model_command(trimmed) {
-            match model_cmd {
-                Some(id) => {
-                    eprintln!("{}", c::dim(&format!("model → {id}")));
-                    model = id;
-                }
-                None => eprintln!("{}", c::dim(&format!("model: {model}"))),
-            }
+        if handle_model_command(trimmed, &mut model) {
             return Ok(LoopControl::Continue);
         }
 
@@ -511,8 +414,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     // no startup model-list fetch to piggyback on (unlike the completions
     // path's validation call), so fetch once here for `/model` completion.
     let model_ids = fetch_model_ids(client, creds).unwrap_or_default();
-    let helper = ChatReplHelper {
-        models: Rc::new(model_ids),
+    let helper = ModelReplHelper {
+        commands: CHAT_SLASH_COMMANDS,
+        models: model_ids,
     };
 
     run_repl(helper, history_path, "> ", |trimmed| {
@@ -523,14 +427,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         // `/model` switches the model for subsequent turns — handled before
         // the general dispatch since it carries an argument, same as
         // `monocle agent`'s REPL.
-        if let Some(model_cmd) = parse_model_command(trimmed) {
-            match model_cmd {
-                Some(id) => {
-                    eprintln!("{}", c::dim(&format!("model → {id}")));
-                    model = id;
-                }
-                None => eprintln!("{}", c::dim(&format!("model: {model}"))),
-            }
+        if handle_model_command(trimmed, &mut model) {
             return Ok(LoopControl::Continue);
         }
 
@@ -573,93 +470,11 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_max_tokens, resolve_repl_attachments, ChatReplHelper};
-    use rustyline::completion::Completer;
-    use rustyline::history::DefaultHistory;
-    use rustyline::Context;
-    use std::rc::Rc;
+    use super::{resolve_max_tokens, resolve_repl_attachments};
 
-    #[test]
-    fn complete_slash_command_narrows_to_matching_prefix() {
-        let helper = ChatReplHelper {
-            models: Rc::new(vec![]),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/qu";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, 0);
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec!["/quit".to_string()]
-        );
-    }
-
-    #[test]
-    fn complete_bare_slash_offers_both_commands() {
-        let helper = ChatReplHelper {
-            models: Rc::new(vec![]),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, 0);
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec![
-                "/model".to_string(),
-                "/exit".to_string(),
-                "/quit".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn complete_non_slash_text_offers_nothing() {
-        let helper = ChatReplHelper {
-            models: Rc::new(vec![]),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "hello";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, 0);
-        assert!(candidates.is_empty());
-    }
-
-    /// FIX #2: a double space after `/model` must not leave a leading space
-    /// in the extracted query — that would break the fuzzy match even
-    /// though `parse_model_command` (the real dispatcher) already tolerates
-    /// it via its own final `.trim()`.
-    #[test]
-    fn complete_model_argument_tolerates_double_space() {
-        let helper = ChatReplHelper {
-            models: Rc::new(vec!["claude-sonnet-4-6".to_string(), "gpt-4o".to_string()]),
-        };
-        let history = DefaultHistory::new();
-        let ctx = Context::new(&history);
-
-        let line = "/model  cla";
-        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
-        assert_eq!(start, line.len() - "cla".len());
-        assert_eq!(
-            candidates
-                .into_iter()
-                .map(|p| p.replacement)
-                .collect::<Vec<_>>(),
-            vec!["claude-sonnet-4-6".to_string()]
-        );
-    }
+    // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
+    // `/model` fuzzy completion) now lives in `commands::repl` and is
+    // covered there, since that's where its Completer/Hinter impls live.
 
     #[test]
     fn absent_flag_omits() {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -179,10 +179,21 @@ impl ChatReplHelper {
         }
         // `/model <partial>` — fuzzy-match the argument against the cached
         // model ids, anchored just after "/model " (not column 0) so accepting
-        // a candidate replaces only the partial id.
-        if let Some(query) = head.strip_prefix("/model ") {
-            let start = head.len() - query.len();
-            return (start, fuzzy_model_candidates(&self.models, query));
+        // a candidate replaces only the partial id. Guarded (not a bare
+        // `head.strip_prefix("/model ")`) so a double space (`/model  cla`)
+        // still trims down to the right query instead of leaving a leading
+        // space that breaks the fuzzy match — `parse_model_command` (the real
+        // dispatcher) already tolerates this via its own final `.trim()`, so
+        // completion must too. `/models` (no separating space) still falls
+        // through to plain command-name completion below rather than being
+        // misread as `/model` with argument `s` — the same boundary
+        // `parse_model_command` draws.
+        if let Some(rest) = head.strip_prefix("/model") {
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                let query = rest.trim_start();
+                let start = head.len() - query.len();
+                return (start, fuzzy_model_candidates(&self.models, query));
+            }
         }
         let candidates = CHAT_SLASH_COMMANDS
             .iter()
@@ -624,6 +635,30 @@ mod tests {
         let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
         assert_eq!(start, 0);
         assert!(candidates.is_empty());
+    }
+
+    /// FIX #2: a double space after `/model` must not leave a leading space
+    /// in the extracted query — that would break the fuzzy match even
+    /// though `parse_model_command` (the real dispatcher) already tolerates
+    /// it via its own final `.trim()`.
+    #[test]
+    fn complete_model_argument_tolerates_double_space() {
+        let helper = ChatReplHelper {
+            models: Rc::new(vec!["claude-sonnet-4-6".to_string(), "gpt-4o".to_string()]),
+        };
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model  cla";
+        let (start, candidates) = helper.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, line.len() - "cla".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
+        );
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,7 +1,11 @@
+use std::borrow::Cow;
 use std::io::{IsTerminal, Write};
+use std::rc::Rc;
 
 use rustyline::completion::{Completer, Pair};
-use rustyline::{Context, Helper, Highlighter, Hinter, Validator};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::{Context, Helper, Validator};
 use serde_json::Value;
 
 use crate::agent::providers::{
@@ -10,7 +14,9 @@ use crate::agent::providers::{
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for};
-use crate::commands::repl::{run_repl, LoopControl};
+use crate::colors as c;
+use crate::commands::model_list::{fetch_model_ids, fuzzy_model_candidates, parse_model_command};
+use crate::commands::repl::{dim_hint, hint_from_candidates, run_repl, LoopControl};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -141,31 +147,42 @@ fn resolve_repl_attachments(
     Ok((cleaned_text.trim().to_string(), images))
 }
 
-/// The slash commands the REPL understands — just quitting, for now (chat has
-/// no `/help`/`/model`/`/config`/`/status`, unlike `monocle agent`'s REPL).
-const CHAT_SLASH_COMMANDS: &[&str] = &["/exit", "/quit"];
+/// The slash commands the REPL understands. `/model` mirrors `monocle
+/// agent`'s REPL (switches the model for subsequent turns); chat still has no
+/// `/help`/`/config`/`/status`.
+const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/exit", "/quit"];
 
-/// rustyline line helper for `monocle chat`'s REPL: Tab-completes the two
-/// slash commands. Hinting/highlighting/validation are the derived no-op
-/// defaults — multi-line handling comes from `bracketed_paste`, not a custom
-/// `Validator`. Deliberately simpler than `agent.rs`'s `ReplHelper` (no
-/// `/model`-argument fuzzy completion, no model-id list to carry).
-#[derive(Helper, Hinter, Highlighter, Validator)]
-struct ChatReplHelper;
+/// rustyline line helper for `monocle chat`'s REPL: Tab-completes slash
+/// commands as a real dropdown (see `commands::repl::run_repl`'s
+/// `CompletionType::List`), and (for `/model`) fuzzy-completes the argument
+/// against a model id list fetched once at startup — same behavior as
+/// `agent.rs`'s `ReplHelper`, which this mirrors. Also hints the best-ranked
+/// candidate as dim inline ghost text via `Hinter`/`Highlighter`; validation
+/// stays the derived no-op default.
+#[derive(Helper, Validator)]
+struct ChatReplHelper {
+    /// Model ids fetched once before the loop starts. Empty when not logged
+    /// in / the fetch failed — `/model` completion then just offers no
+    /// candidates. `Rc` because `Editor::set_helper` takes ownership and the
+    /// list is read-only for the session's lifetime.
+    models: Rc<Vec<String>>,
+}
 
-impl Completer for ChatReplHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        _ctx: &Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+impl ChatReplHelper {
+    /// Shared by `Completer::complete` and `Hinter::hint` so the two can
+    /// never disagree on what's being completed.
+    fn candidates(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
         // Only offer completion for a slash-command being typed at line start.
         let head = &line[..pos];
         if !head.starts_with('/') {
-            return Ok((0, Vec::new()));
+            return (0, Vec::new());
+        }
+        // `/model <partial>` — fuzzy-match the argument against the cached
+        // model ids, anchored just after "/model " (not column 0) so accepting
+        // a candidate replaces only the partial id.
+        if let Some(query) = head.strip_prefix("/model ") {
+            let start = head.len() - query.len();
+            return (start, fuzzy_model_candidates(&self.models, query));
         }
         let candidates = CHAT_SLASH_COMMANDS
             .iter()
@@ -176,7 +193,35 @@ impl Completer for ChatReplHelper {
             })
             .collect();
         // Replace from column 0 (the whole slash token starts there).
-        Ok((0, candidates))
+        (0, candidates)
+    }
+}
+
+impl Completer for ChatReplHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        Ok(self.candidates(line, pos))
+    }
+}
+
+impl Hinter for ChatReplHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        let (start, candidates) = self.candidates(line, pos);
+        hint_from_candidates(line, start, pos, &candidates)
+    }
+}
+
+impl Highlighter for ChatReplHelper {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        dim_hint(hint)
     }
 }
 
@@ -192,7 +237,7 @@ pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) 
 /// this REPL accumulating the growing conversation itself (see `convo` below)
 /// and resending it in full each turn.
 fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
-    let model = options
+    let mut model = options
         .model
         .as_deref()
         .unwrap_or(DEFAULT_MODEL)
@@ -244,7 +289,12 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         options.system_prompt.clone()
     };
 
-    // Validate the model ID against the available models (non-fatal on failure).
+    // Validate the model ID against the available models (non-fatal on
+    // failure), and keep the full id list around — reused below as the
+    // interactive REPL's `/model` completion candidates instead of a second
+    // fetch (`agent.rs`'s REPL fetches separately since it has no equivalent
+    // startup validation call to piggyback on).
+    let mut model_ids: Vec<String> = Vec::new();
     if let Ok(resp) = client.get(
         &format!("{router_url}{}", endpoints::MODELS),
         &auth_headers(&bearer),
@@ -268,6 +318,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                     }
                     std::process::exit(1);
                 }
+                model_ids = ids;
             }
         }
     }
@@ -297,7 +348,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         eprintln!("System prompt loaded ({} chars)", sp.chars().count());
     }
     eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
+    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
     eprintln!("---");
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
@@ -305,6 +356,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     // load/save, and the Ctrl-C/Ctrl-D/error loop itself are shared with
     // `monocle agent`'s REPL via `commands::repl::run_repl`.
     let history_path = home_dir().join(".monocle").join("chat_history");
+    let helper = ChatReplHelper {
+        models: Rc::new(model_ids),
+    };
 
     // Conversation memory: mirrors `monocle agent`'s `Repl.convo` — grows for
     // the life of the process instead of `call_chat` rebuilding a one-message
@@ -315,10 +369,23 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         convo.push(Message::system(sp));
     }
 
-    run_repl(ChatReplHelper, history_path, "> ", |trimmed| {
+    run_repl(helper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
             eprintln!("Bye.");
             return Ok(LoopControl::Quit);
+        }
+        // `/model` switches the model for subsequent turns — handled before
+        // the general dispatch since it carries an argument, same as
+        // `monocle agent`'s REPL.
+        if let Some(model_cmd) = parse_model_command(trimmed) {
+            match model_cmd {
+                Some(id) => {
+                    eprintln!("{}", c::dim(&format!("model → {id}")));
+                    model = id;
+                }
+                None => eprintln!("{}", c::dim(&format!("model: {model}"))),
+            }
+            return Ok(LoopControl::Continue);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -371,7 +438,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
 /// `--system-prompt`/`--max-tokens` support (the endpoint has no such
 /// fields) — both are warned-and-ignored rather than silently dropped.
 fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
-    let model = options
+    let mut model = options
         .model
         .as_deref()
         .unwrap_or(DEFAULT_MODEL)
@@ -421,7 +488,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     eprintln!("Monocle Chat — Responses API (model: {model})");
     eprintln!("jarvice: {jarvice_url}");
     eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /quit, /exit — a multi-line paste is one input.");
+    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
     eprintln!("The server owns this conversation's thread — no local history is resent.");
     eprintln!("---");
 
@@ -429,11 +496,31 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     // Not a `Vec<Message>` like `run_completions_chat`'s `convo` — the server
     // persists the conversation; this is just the id to hand back next turn.
     let mut thread_id: Option<String> = options.thread.clone();
+    // Best-effort, same defensive posture as `agent.rs`'s REPL: this path has
+    // no startup model-list fetch to piggyback on (unlike the completions
+    // path's validation call), so fetch once here for `/model` completion.
+    let model_ids = fetch_model_ids(client, creds).unwrap_or_default();
+    let helper = ChatReplHelper {
+        models: Rc::new(model_ids),
+    };
 
-    run_repl(ChatReplHelper, history_path, "> ", |trimmed| {
+    run_repl(helper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
             eprintln!("Bye.");
             return Ok(LoopControl::Quit);
+        }
+        // `/model` switches the model for subsequent turns — handled before
+        // the general dispatch since it carries an argument, same as
+        // `monocle agent`'s REPL.
+        if let Some(model_cmd) = parse_model_command(trimmed) {
+            match model_cmd {
+                Some(id) => {
+                    eprintln!("{}", c::dim(&format!("model → {id}")));
+                    model = id;
+                }
+                None => eprintln!("{}", c::dim(&format!("model: {model}"))),
+            }
+            return Ok(LoopControl::Continue);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -479,10 +566,13 @@ mod tests {
     use rustyline::completion::Completer;
     use rustyline::history::DefaultHistory;
     use rustyline::Context;
+    use std::rc::Rc;
 
     #[test]
     fn complete_slash_command_narrows_to_matching_prefix() {
-        let helper = ChatReplHelper;
+        let helper = ChatReplHelper {
+            models: Rc::new(vec![]),
+        };
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
 
@@ -500,7 +590,9 @@ mod tests {
 
     #[test]
     fn complete_bare_slash_offers_both_commands() {
-        let helper = ChatReplHelper;
+        let helper = ChatReplHelper {
+            models: Rc::new(vec![]),
+        };
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
 
@@ -512,13 +604,19 @@ mod tests {
                 .into_iter()
                 .map(|p| p.replacement)
                 .collect::<Vec<_>>(),
-            vec!["/exit".to_string(), "/quit".to_string()]
+            vec![
+                "/model".to_string(),
+                "/exit".to_string(),
+                "/quit".to_string()
+            ]
         );
     }
 
     #[test]
     fn complete_non_slash_text_offers_nothing() {
-        let helper = ChatReplHelper;
+        let helper = ChatReplHelper {
+            models: Rc::new(vec![]),
+        };
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
 

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -74,21 +74,57 @@ pub fn fetch_model_ids(client: &Client, creds: &Credentials) -> Result<Vec<Strin
         .collect())
 }
 
+/// A parsed `/model` REPL invocation, shared by `chat`'s and `agent`'s REPL
+/// dispatch.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ModelCommand {
+    /// Not a `/model` invocation at all.
+    NotModel,
+    /// Bare `/model` — show the current model.
+    Show,
+    /// `/model <id>` — switch to `id`.
+    Switch(String),
+}
+
 /// Pure parser for the `/model` command, shared by `chat`'s and `agent`'s
-/// REPL dispatch. Returns:
-/// - `None` — not a `/model` invocation (let normal dispatch handle it);
-/// - `Some(None)` — bare `/model` (show the current model);
-/// - `Some(Some(id))` — `/model <id>` (switch to `id`).
-pub fn parse_model_command(input: &str) -> Option<Option<String>> {
+/// REPL dispatch.
+pub fn parse_model_command(input: &str) -> ModelCommand {
     let trimmed = input.trim();
     if trimmed == "/model" {
-        return Some(None);
+        return ModelCommand::Show;
     }
-    let rest = trimmed.strip_prefix("/model ")?.trim();
-    if rest.is_empty() {
-        Some(None)
-    } else {
-        Some(Some(rest.to_string()))
+    match trimmed.strip_prefix("/model ") {
+        None => ModelCommand::NotModel,
+        Some(rest) => {
+            let rest = rest.trim();
+            if rest.is_empty() {
+                ModelCommand::Show
+            } else {
+                ModelCommand::Switch(rest.to_string())
+            }
+        }
+    }
+}
+
+/// Handle a `/model` line if `trimmed` is one: prints the switch/show
+/// message and updates `*model` in place. Returns `true` if this input was
+/// a `/model` invocation (caller should treat it as consumed and not fall
+/// through to normal dispatch), `false` otherwise. Shared by `chat`'s (both
+/// the completions and `--responses` REPLs) and `agent`'s REPL dispatch so
+/// the "handle `/model` on Enter" logic can't drift between the three call
+/// sites.
+pub fn handle_model_command(trimmed: &str, model: &mut String) -> bool {
+    match parse_model_command(trimmed) {
+        ModelCommand::NotModel => false,
+        ModelCommand::Show => {
+            eprintln!("{}", crate::colors::dim(&format!("model: {model}")));
+            true
+        }
+        ModelCommand::Switch(id) => {
+            eprintln!("{}", crate::colors::dim(&format!("model → {id}")));
+            *model = id;
+            true
+        }
     }
 }
 
@@ -191,22 +227,39 @@ mod tests {
     #[test]
     fn parse_model_command_variants() {
         // Not a /model command.
-        assert_eq!(parse_model_command("hello"), None);
-        assert_eq!(parse_model_command("/models"), None);
-        assert_eq!(parse_model_command("/help"), None);
+        assert_eq!(parse_model_command("hello"), ModelCommand::NotModel);
+        assert_eq!(parse_model_command("/models"), ModelCommand::NotModel);
+        assert_eq!(parse_model_command("/help"), ModelCommand::NotModel);
         // Bare /model (with or without surrounding / trailing space) shows current.
-        assert_eq!(parse_model_command("/model"), Some(None));
-        assert_eq!(parse_model_command("  /model  "), Some(None));
-        assert_eq!(parse_model_command("/model   "), Some(None));
+        assert_eq!(parse_model_command("/model"), ModelCommand::Show);
+        assert_eq!(parse_model_command("  /model  "), ModelCommand::Show);
+        assert_eq!(parse_model_command("/model   "), ModelCommand::Show);
         // /model <id> switches.
         assert_eq!(
             parse_model_command("/model gpt-4o"),
-            Some(Some("gpt-4o".to_string()))
+            ModelCommand::Switch("gpt-4o".to_string())
         );
         assert_eq!(
             parse_model_command("/model  claude-x  "),
-            Some(Some("claude-x".to_string()))
+            ModelCommand::Switch("claude-x".to_string())
         );
+    }
+
+    #[test]
+    fn handle_model_command_switches_shows_and_passes_through() {
+        let mut model = "old-model".to_string();
+
+        // Not a /model line — unconsumed, model untouched.
+        assert!(!handle_model_command("hello", &mut model));
+        assert_eq!(model, "old-model");
+
+        // Bare /model — consumed, just shows (no mutation).
+        assert!(handle_model_command("/model", &mut model));
+        assert_eq!(model, "old-model");
+
+        // /model <id> — consumed, switches.
+        assert!(handle_model_command("/model new-model", &mut model));
+        assert_eq!(model, "new-model");
     }
 
     fn model_ids(ids: &[&str]) -> Vec<String> {

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -27,7 +27,7 @@ struct ModelsResponse {
     data: Vec<ModelInfo>,
 }
 
-fn pad(s: &str, width: usize) -> String {
+pub(crate) fn pad(s: &str, width: usize) -> String {
     let len = s.chars().count();
     if len >= width {
         s.to_string()

--- a/src/commands/model_list.rs
+++ b/src/commands/model_list.rs
@@ -1,5 +1,8 @@
 use std::io::Write;
 
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use rustyline::completion::Pair;
 use serde::Deserialize;
 
 use crate::auth::{get_access_token, try_access_token, AuthSession};
@@ -58,17 +61,60 @@ fn fetch_models_with_session(client: &Client, session: &AuthSession) -> Result<V
     Ok(resp.json::<ModelsResponse>()?.data)
 }
 
-/// Fetch just the model ids — what the `agent` REPL's `/model` completer needs.
-/// Uses the non-exiting [`try_access_token`] (not [`get_access_token`]) so a
-/// missing login or a network hiccup returns an `Err` instead of killing the
-/// process; `agent.rs` treats that as "no candidates" and starts the REPL
-/// anyway rather than propagating.
+/// Fetch just the model ids — what both `chat` and `agent`'s `/model`
+/// completers need. Uses the non-exiting [`try_access_token`] (not
+/// [`get_access_token`]) so a missing login or a network hiccup returns an
+/// `Err` instead of killing the process; callers treat that as "no
+/// candidates" and start the REPL anyway rather than propagating.
 pub fn fetch_model_ids(client: &Client, creds: &Credentials) -> Result<Vec<String>> {
     let session = try_access_token(client, creds)?;
     Ok(fetch_models_with_session(client, &session)?
         .into_iter()
         .map(|m| m.id)
         .collect())
+}
+
+/// Pure parser for the `/model` command, shared by `chat`'s and `agent`'s
+/// REPL dispatch. Returns:
+/// - `None` — not a `/model` invocation (let normal dispatch handle it);
+/// - `Some(None)` — bare `/model` (show the current model);
+/// - `Some(Some(id))` — `/model <id>` (switch to `id`).
+pub fn parse_model_command(input: &str) -> Option<Option<String>> {
+    let trimmed = input.trim();
+    if trimmed == "/model" {
+        return Some(None);
+    }
+    let rest = trimmed.strip_prefix("/model ")?.trim();
+    if rest.is_empty() {
+        Some(None)
+    } else {
+        Some(Some(rest.to_string()))
+    }
+}
+
+/// Fuzzy-match `query` against cached model ids for `/model` tab-completion,
+/// shared by `chat`'s and `agent`'s REPL helpers. An empty query returns the
+/// full list unranked (the "show me what's available" dropdown); otherwise
+/// ids are scored with `fuzzy-matcher`'s skim algorithm (subsequence match,
+/// case-smart), kept only if they match at all, and sorted best match first.
+pub fn fuzzy_model_candidates(models: &[String], query: &str) -> Vec<Pair> {
+    let to_pair = |id: &String| Pair {
+        display: id.clone(),
+        replacement: id.clone(),
+    };
+    if query.is_empty() {
+        return models.iter().map(to_pair).collect();
+    }
+    // `ignore_case` (not the default smart-case) so typing in any case still
+    // narrows the (lowercase-by-convention) model ids — smart-case would make
+    // an all-caps query like "CLAUDE" match nothing.
+    let matcher = SkimMatcherV2::default().ignore_case();
+    let mut scored: Vec<(i64, &String)> = models
+        .iter()
+        .filter_map(|id| matcher.fuzzy_match(id, query).map(|score| (score, id)))
+        .collect();
+    scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+    scored.into_iter().map(|(_, id)| to_pair(id)).collect()
 }
 
 pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
@@ -136,4 +182,80 @@ pub fn model_list_command(client: &Client, creds: &Credentials) -> Result<()> {
 
     eprintln!("\n{} model(s) available.", models.len());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_model_command_variants() {
+        // Not a /model command.
+        assert_eq!(parse_model_command("hello"), None);
+        assert_eq!(parse_model_command("/models"), None);
+        assert_eq!(parse_model_command("/help"), None);
+        // Bare /model (with or without surrounding / trailing space) shows current.
+        assert_eq!(parse_model_command("/model"), Some(None));
+        assert_eq!(parse_model_command("  /model  "), Some(None));
+        assert_eq!(parse_model_command("/model   "), Some(None));
+        // /model <id> switches.
+        assert_eq!(
+            parse_model_command("/model gpt-4o"),
+            Some(Some("gpt-4o".to_string()))
+        );
+        assert_eq!(
+            parse_model_command("/model  claude-x  "),
+            Some(Some("claude-x".to_string()))
+        );
+    }
+
+    fn model_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_empty_query_returns_full_list_unranked() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, models);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_narrows_by_subsequence() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o", "claude-opus-4"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "cla")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got, vec!["claude-sonnet-4-6", "claude-opus-4"]);
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_ranks_tighter_match_first() {
+        // "gpt4o" as a subsequence appears in both, but a contiguous match in
+        // "gpt-4o" should outrank the more scattered match in "gpt-4-omni".
+        let models = model_ids(&["gpt-4-omni", "gpt-4o"]);
+        let got: Vec<String> = fuzzy_model_candidates(&models, "gpt4o")
+            .into_iter()
+            .map(|p| p.replacement)
+            .collect();
+        assert_eq!(got.first().map(String::as_str), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_excludes_non_matches() {
+        let models = model_ids(&["claude-sonnet-4-6", "gpt-4o"]);
+        let got = fuzzy_model_candidates(&models, "zzz");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_model_candidates_case_insensitive() {
+        let models = model_ids(&["claude-sonnet-4-6"]);
+        let got = fuzzy_model_candidates(&models, "CLAUDE");
+        assert_eq!(got.len(), 1);
+    }
 }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -6,14 +6,17 @@
 //! can't drift on the parts that should behave identically (paste handling,
 //! interrupt/EOF semantics, error reporting).
 
-use rustyline::completion::Pair;
+use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
 use rustyline::history::DefaultHistory;
-use rustyline::{CompletionType, Config, Editor, Helper};
+use rustyline::{CompletionType, Config, Context, Editor, Helper, Validator};
 use std::borrow::Cow;
 use std::path::PathBuf;
 
 use crate::colors as c;
+use crate::commands::model_list::fuzzy_model_candidates;
 use crate::error::Result;
 
 /// What the per-line callback wants the loop to do next.
@@ -61,6 +64,97 @@ pub fn hint_from_candidates(
 /// default (undimmed) hint color.
 pub fn dim_hint(hint: &str) -> Cow<'_, str> {
     Cow::Owned(c::dim(hint))
+}
+
+/// rustyline line helper shared by `monocle chat`'s and `monocle agent`'s
+/// REPLs (`agent.rs`'s former `ReplHelper` and `chat.rs`'s former
+/// `ChatReplHelper` were near-verbatim duplicates, differing only in which
+/// slash commands they offer): Tab-completes slash commands as a real
+/// dropdown (see `run_repl`'s `CompletionType::List`), and (for `/model`)
+/// fuzzy-completes the argument against a model id list fetched once at REPL
+/// startup. Also hints the best-ranked candidate as dim inline ghost text via
+/// `Hinter`/`Highlighter`; validation stays the derived no-op default
+/// (multi-line handling comes from `bracketed_paste`).
+#[derive(Helper, Validator)]
+pub struct ModelReplHelper {
+    /// The slash commands this REPL understands — `agent`'s richer set vs.
+    /// `chat`'s `/model`, `/exit`, `/quit` — offered by command-name
+    /// completion and shown by `/help` where applicable.
+    pub commands: &'static [&'static str],
+    /// Model ids fetched once before the loop starts. Empty when not logged
+    /// in / the fetch failed — `/model` completion then just offers no
+    /// candidates, same defensive posture as the rest of the interactive
+    /// path. Plain `Vec` (not `Rc`): each helper is constructed exactly once
+    /// and moved by value into `Editor::set_helper`, never cloned or shared.
+    pub models: Vec<String>,
+}
+
+impl ModelReplHelper {
+    /// Shared by `Completer::complete` and `Hinter::hint` so the two can
+    /// never disagree on what's being completed.
+    fn candidates(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
+        // Only offer completion for a slash-command being typed at the line start.
+        let head = &line[..pos];
+        if !head.starts_with('/') {
+            return (0, Vec::new());
+        }
+        // `/model <partial>` — fuzzy-match the argument against the cached
+        // model ids instead of the flat command-name list, so `/model
+        // cla<TAB>` narrows to matching ids and a bare `/model <TAB>` shows
+        // the full dropdown. Guarded (not a bare `head.strip_prefix("/model
+        // ")`) so a double space (`/model  cla`) still trims down to the
+        // right query instead of leaving a leading space that breaks the
+        // fuzzy match, while `/models` (no separating space) still falls
+        // through to plain command-name completion instead of being
+        // misread as `/model` with argument `s` — the same boundary the
+        // real dispatcher (`parse_model_command`) draws.
+        if let Some(rest) = head.strip_prefix("/model") {
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                let query = rest.trim_start();
+                let start = head.len() - query.len();
+                return (start, fuzzy_model_candidates(&self.models, query));
+            }
+        }
+        let candidates = self
+            .commands
+            .iter()
+            .filter(|cmd| cmd.starts_with(head))
+            .map(|cmd| Pair {
+                display: cmd.to_string(),
+                replacement: cmd.to_string(),
+            })
+            .collect();
+        // Replace from column 0 (the whole slash token starts there).
+        (0, candidates)
+    }
+}
+
+impl Completer for ModelReplHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        Ok(self.candidates(line, pos))
+    }
+}
+
+impl Hinter for ModelReplHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        let (start, candidates) = self.candidates(line, pos);
+        hint_from_candidates(line, start, pos, &candidates)
+    }
+}
+
+impl Highlighter for ModelReplHelper {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        dim_hint(hint)
+    }
 }
 
 /// Drives an interactive REPL to completion.
@@ -133,26 +227,176 @@ pub fn run_repl<H: Helper>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustyline::history::DefaultHistory;
 
-    fn pair(id: &str) -> Pair {
-        Pair {
-            display: id.to_string(),
-            replacement: id.to_string(),
+    /// A representative command list — not either real `SLASH_COMMANDS`
+    /// (`agent.rs`) or `CHAT_SLASH_COMMANDS` (`chat.rs`), just enough
+    /// variety to exercise `ModelReplHelper` generically.
+    const TEST_COMMANDS: &[&str] = &["/help", "/model", "/exit", "/quit"];
+
+    fn model_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn helper(models: &[&str]) -> ModelReplHelper {
+        ModelReplHelper {
+            commands: TEST_COMMANDS,
+            models: model_ids(models),
         }
+    }
+
+    #[test]
+    fn complete_slash_command_narrows_to_matching_prefix() {
+        let h = helper(&[]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/qu";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/quit".to_string()]
+        );
+    }
+
+    #[test]
+    fn complete_bare_slash_offers_all_commands() {
+        let h = helper(&[]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec![
+                "/help".to_string(),
+                "/model".to_string(),
+                "/exit".to_string(),
+                "/quit".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn complete_non_slash_text_offers_nothing() {
+        let h = helper(&[]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "hello";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert!(candidates.is_empty());
+    }
+
+    /// The completion `start` offset is what rustyline uses to splice the
+    /// chosen candidate back into the line — get it wrong and accepting a
+    /// completion corrupts the line. For `/model <partial>` it must point
+    /// just past `"/model "`, not column 0 (unlike the command-name path),
+    /// so accepting a candidate replaces only the partial id.
+    #[test]
+    fn complete_model_argument_uses_offset_after_prefix() {
+        let h = helper(&["claude-sonnet-4-6", "gpt-4o"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model cla";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
+        );
+
+        // Bare "/model " (empty partial) offers the full dropdown, still
+        // anchored right after the prefix.
+        let line = "/model ";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, "/model ".len());
+        assert_eq!(candidates.len(), 2);
+    }
+
+    /// Command-name completion (`/mo<TAB>` → `/model`) must be unaffected by
+    /// the `/model` argument branch.
+    #[test]
+    fn complete_command_name_unaffected_by_model_argument_branch() {
+        let h = helper(&["claude-sonnet-4-6"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/mo";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["/model".to_string()]
+        );
+    }
+
+    /// FIX #2: a double space after `/model` must not leave a leading space
+    /// in the extracted query — that would break the fuzzy match even
+    /// though `parse_model_command` (the real dispatcher) already tolerates
+    /// it via its own final `.trim()`.
+    #[test]
+    fn complete_model_argument_tolerates_double_space() {
+        let h = helper(&["claude-sonnet-4-6", "gpt-4o"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/model  cla";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, line.len() - "cla".len());
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|p| p.replacement)
+                .collect::<Vec<_>>(),
+            vec!["claude-sonnet-4-6".to_string()]
+        );
+    }
+
+    /// `/models` (no separating space) must not be misread as `/model` with
+    /// argument `s` — same boundary `parse_model_command` draws.
+    #[test]
+    fn complete_does_not_treat_slash_models_as_model_argument() {
+        let h = helper(&["claude-sonnet-4-6"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "/models";
+        let (start, candidates) = h.complete(line, line.len(), &ctx).unwrap();
+        assert_eq!(start, 0);
+        assert!(candidates.is_empty());
     }
 
     /// FIX #1: `fuzzy_model_candidates` matches case-insensitively, so the
     /// top candidate for an all-caps query can differ in case from what was
     /// typed — the hint must still appear, using the candidate's own
-    /// casing for the ghost suffix (not a case-sensitive `strip_prefix`,
-    /// which would silently return `None` here).
+    /// casing for the ghost suffix.
     #[test]
     fn hint_shows_case_insensitive_prefix_match_with_candidate_casing() {
-        let candidates = vec![pair("claude-sonnet-4-6")];
+        let h = helper(&["claude-sonnet-4-6", "gpt-4o"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
         let line = "/model CLA";
-        let start = line.len() - "CLA".len();
         assert_eq!(
-            hint_from_candidates(line, start, line.len(), &candidates),
+            h.hint(line, line.len(), &ctx),
             Some("ude-sonnet-4-6".to_string())
         );
     }
@@ -161,12 +405,11 @@ mod tests {
     /// suffix — `None` is correct, not a stripped/garbled remainder.
     #[test]
     fn hint_is_none_for_non_prefix_subsequence_match() {
-        let candidates = vec![pair("claude-sonnet-4-6")];
+        let h = helper(&["claude-sonnet-4-6"]);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
         let line = "/model sonnet";
-        let start = line.len() - "sonnet".len();
-        assert_eq!(
-            hint_from_candidates(line, start, line.len(), &candidates),
-            None
-        );
+        assert_eq!(h.hint(line, line.len(), &ctx), None);
     }
 }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -28,6 +28,15 @@ pub enum LoopControl {
 /// untyped remainder of the best (first-ranked) candidate — or `None` if the
 /// cursor isn't at the end of the line (mid-line edits shouldn't grow a hint
 /// past the cursor) or there's nothing left to complete.
+///
+/// The comparison is case-insensitive (matching `fuzzy_model_candidates`'
+/// `ignore_case` matcher), but the hint text itself is always the
+/// candidate's own casing — so typing `/model CLA` against a cached
+/// `claude-...` id still ghosts `ude-...`, not a re-cased echo of what was
+/// typed. When the top candidate isn't a prefix of what's typed at all (a
+/// genuine subsequence match, e.g. `/model sonnet` matching
+/// `claude-sonnet-4-6`), there's no sensible ghost suffix and this returns
+/// `None`.
 pub fn hint_from_candidates(
     line: &str,
     start: usize,
@@ -39,7 +48,12 @@ pub fn hint_from_candidates(
     }
     let typed = &line[start..pos];
     let best = candidates.first()?;
-    best.replacement.strip_prefix(typed).map(str::to_string)
+    let candidate_head = best.replacement.get(..typed.len())?;
+    if candidate_head.eq_ignore_ascii_case(typed) {
+        Some(best.replacement[typed.len()..].to_string())
+    } else {
+        None
+    }
 }
 
 /// Dim an inline hint with ANSI, so both REPL helpers' `Highlighter::
@@ -114,4 +128,45 @@ pub fn run_repl<H: Helper>(
 
     let _ = rl.save_history(&history_path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pair(id: &str) -> Pair {
+        Pair {
+            display: id.to_string(),
+            replacement: id.to_string(),
+        }
+    }
+
+    /// FIX #1: `fuzzy_model_candidates` matches case-insensitively, so the
+    /// top candidate for an all-caps query can differ in case from what was
+    /// typed — the hint must still appear, using the candidate's own
+    /// casing for the ghost suffix (not a case-sensitive `strip_prefix`,
+    /// which would silently return `None` here).
+    #[test]
+    fn hint_shows_case_insensitive_prefix_match_with_candidate_casing() {
+        let candidates = vec![pair("claude-sonnet-4-6")];
+        let line = "/model CLA";
+        let start = line.len() - "CLA".len();
+        assert_eq!(
+            hint_from_candidates(line, start, line.len(), &candidates),
+            Some("ude-sonnet-4-6".to_string())
+        );
+    }
+
+    /// A genuine subsequence (non-prefix) fuzzy match has no sensible ghost
+    /// suffix — `None` is correct, not a stripped/garbled remainder.
+    #[test]
+    fn hint_is_none_for_non_prefix_subsequence_match() {
+        let candidates = vec![pair("claude-sonnet-4-6")];
+        let line = "/model sonnet";
+        let start = line.len() - "sonnet".len();
+        assert_eq!(
+            hint_from_candidates(line, start, line.len(), &candidates),
+            None
+        );
+    }
 }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -6,9 +6,11 @@
 //! can't drift on the parts that should behave identically (paste handling,
 //! interrupt/EOF semantics, error reporting).
 
+use rustyline::completion::Pair;
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
-use rustyline::{Config, Editor, Helper};
+use rustyline::{CompletionType, Config, Editor, Helper};
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use crate::colors as c;
@@ -18,6 +20,33 @@ use crate::error::Result;
 pub enum LoopControl {
     Continue,
     Quit,
+}
+
+/// Ghost-text hint shared by both REPL helpers' `Hinter` impls: given the
+/// already-typed line, the cursor position, and the same `(start, candidates)`
+/// pair their `Completer::complete` computed for that line/pos, returns the
+/// untyped remainder of the best (first-ranked) candidate — or `None` if the
+/// cursor isn't at the end of the line (mid-line edits shouldn't grow a hint
+/// past the cursor) or there's nothing left to complete.
+pub fn hint_from_candidates(
+    line: &str,
+    start: usize,
+    pos: usize,
+    candidates: &[Pair],
+) -> Option<String> {
+    if pos != line.len() {
+        return None;
+    }
+    let typed = &line[start..pos];
+    let best = candidates.first()?;
+    best.replacement.strip_prefix(typed).map(str::to_string)
+}
+
+/// Dim an inline hint with ANSI, so both REPL helpers' `Highlighter::
+/// highlight_hint` render candidates the same washed-out gray instead of the
+/// default (undimmed) hint color.
+pub fn dim_hint(hint: &str) -> Cow<'_, str> {
+    Cow::Owned(c::dim(hint))
 }
 
 /// Drives an interactive REPL to completion.
@@ -42,7 +71,14 @@ pub fn run_repl<H: Helper>(
     prompt: &str,
     mut on_line: impl FnMut(&str) -> Result<LoopControl>,
 ) -> Result<()> {
-    let config = Config::builder().bracketed_paste(true).build();
+    // `CompletionType::List` shows every matching candidate at once on Tab
+    // (a dropdown), instead of the default `Circular`'s cycle-one-at-a-time —
+    // the actual "dropdown" experience slash-command/model completion is
+    // meant to have.
+    let config = Config::builder()
+        .bracketed_paste(true)
+        .completion_type(CompletionType::List)
+        .build();
     let mut rl: Editor<H, DefaultHistory> =
         Editor::with_config(config).map_err(|e| crate::error::AppError::new(e.to_string()))?;
     rl.set_helper(Some(helper));

--- a/src/jarvice_chats.rs
+++ b/src/jarvice_chats.rs
@@ -1,0 +1,191 @@
+//! Client for jarvice's existing chat-thread storage (`/api/v1/chats`), used
+//! to let `monocle chat --responses` discover and replay threads that already
+//! exist — including ones created entirely from jarvice's own web UI, since
+//! both write to the exact same `chat` table (`backend/open_webui/models/chats.py`).
+//!
+//! **jarvice-only**, same as `responses_api` — reachable only at jarvice's own
+//! tenant-host-routed base URL (`auth::jarvice_url_for`), never through
+//! chat-proxy's `router_url`.
+//!
+//! Endpoint shapes (verified against jarvice `devel`,
+//! `backend/open_webui/routers/chats.py` / `models/chats.py`): the outer chat
+//! envelope (`id`, `title`, `updated_at`, `created_at`, ...) is plain
+//! snake_case with no camelCase conversion, but the nested `chat.history`
+//! blob is a raw, untyped JSON dict written verbatim by backend code that
+//! mirrors the frontend's own camelCase keys (`parentId`, `childrenIds`,
+//! `currentId`) — hence the per-field `#[serde(rename = ...)]` below instead
+//! of a blanket `rename_all`.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::net::Client;
+use crate::origin::auth_headers;
+
+#[derive(Debug, Deserialize)]
+pub struct ChatSummary {
+    pub id: String,
+    pub title: String,
+    pub updated_at: i64,
+    pub created_at: i64,
+}
+
+/// One node in a thread's message tree. Only the fields this CLI's replay
+/// needs — jarvice's actual nodes also carry `timestamp`/`model`/`files`,
+/// left out since nothing here reads them yet.
+#[derive(Debug, Deserialize)]
+pub struct MessageNode {
+    #[allow(dead_code)] // kept for parity with the source shape; not read yet
+    pub id: String,
+    #[serde(rename = "parentId")]
+    pub parent_id: Option<String>,
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Deserialize)]
+struct ChatHistory {
+    #[serde(default)]
+    messages: HashMap<String, MessageNode>,
+    #[serde(rename = "currentId", default)]
+    current_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChatBlob {
+    history: ChatHistory,
+}
+
+#[derive(Deserialize)]
+struct ChatDetailResponse {
+    #[allow(dead_code)] // not surfaced yet; kept for future use (e.g. a header)
+    title: String,
+    chat: ChatBlob,
+}
+
+/// One thread's full history, already unwrapped past jarvice's `chat.history`
+/// envelope — ready for [`linearize`].
+pub struct ChatDetail {
+    pub messages: HashMap<String, MessageNode>,
+    pub current_id: Option<String>,
+}
+
+/// `GET /api/v1/chats/` — the current user's threads (id/title/timestamps
+/// only, no message bodies), same list jarvice's own sidebar reads.
+pub fn list_threads(client: &Client, jarvice_url: &str, bearer: &str) -> Result<Vec<ChatSummary>> {
+    let resp = client.get(
+        &format!("{jarvice_url}/api/v1/chats/"),
+        &auth_headers(bearer),
+    )?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "API error {}: {}",
+            resp.status,
+            resp.text()
+        )));
+    }
+    resp.json()
+}
+
+/// `GET /api/v1/chats/{id}` — one thread's full nested message tree.
+pub fn get_thread(
+    client: &Client,
+    jarvice_url: &str,
+    bearer: &str,
+    id: &str,
+) -> Result<ChatDetail> {
+    let resp = client.get(
+        &format!("{jarvice_url}/api/v1/chats/{id}"),
+        &auth_headers(bearer),
+    )?;
+    if !resp.ok() {
+        return Err(AppError::new(format!(
+            "API error {}: {}",
+            resp.status,
+            resp.text()
+        )));
+    }
+    let parsed: ChatDetailResponse = resp.json()?;
+    Ok(ChatDetail {
+        messages: parsed.chat.history.messages,
+        current_id: parsed.chat.history.current_id,
+    })
+}
+
+/// Walk `parentId` links from `current_id` back to the root, then reverse —
+/// the Rust port of jarvice's own `utils/misc.py::get_message_list`. Follows
+/// only the single active ancestry; a message that isn't on that path (an
+/// abandoned edit/regenerate branch, reachable only via some other node's
+/// `childrenIds`) is silently excluded — rendering branches is out of scope,
+/// matching the plan's v1 decision.
+pub fn linearize<'a>(
+    messages: &'a HashMap<String, MessageNode>,
+    current_id: &str,
+) -> Vec<&'a MessageNode> {
+    let mut out = Vec::new();
+    let mut cursor = Some(current_id.to_string());
+    while let Some(id) = cursor {
+        match messages.get(&id) {
+            Some(node) => {
+                cursor = node.parent_id.clone();
+                out.push(node);
+            }
+            None => break,
+        }
+    }
+    out.reverse();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, parent: Option<&str>, role: &str, content: &str) -> MessageNode {
+        MessageNode {
+            id: id.to_string(),
+            parent_id: parent.map(str::to_string),
+            role: role.to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn linearize_walks_a_linear_chain_root_first() {
+        let mut messages = HashMap::new();
+        messages.insert("a".to_string(), node("a", None, "user", "hi"));
+        messages.insert("b".to_string(), node("b", Some("a"), "assistant", "hello"));
+        messages.insert("c".to_string(), node("c", Some("b"), "user", "thanks"));
+
+        let got = linearize(&messages, "c");
+        let ids: Vec<&str> = got.iter().map(|n| n.content.as_str()).collect();
+        assert_eq!(ids, vec!["hi", "hello", "thanks"]);
+    }
+
+    #[test]
+    fn linearize_excludes_an_abandoned_branch() {
+        // a -> b -> c (current path), plus a -> b2 (an edited/regenerated
+        // sibling of b that is NOT an ancestor of currentId "c").
+        let mut messages = HashMap::new();
+        messages.insert("a".to_string(), node("a", None, "user", "hi"));
+        messages.insert("b".to_string(), node("b", Some("a"), "assistant", "hello"));
+        messages.insert(
+            "b2".to_string(),
+            node("b2", Some("a"), "assistant", "regenerated reply"),
+        );
+        messages.insert("c".to_string(), node("c", Some("b"), "user", "thanks"));
+
+        let got = linearize(&messages, "c");
+        let contents: Vec<&str> = got.iter().map(|n| n.content.as_str()).collect();
+        assert_eq!(contents, vec!["hi", "hello", "thanks"]);
+        assert!(!contents.contains(&"regenerated reply"));
+    }
+
+    #[test]
+    fn linearize_empty_when_current_id_missing() {
+        let messages: HashMap<String, MessageNode> = HashMap::new();
+        assert!(linearize(&messages, "does-not-exist").is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod credentials;
 pub mod diag;
 pub mod endpoints;
 pub mod error;
+pub mod jarvice_chats;
 pub mod net;
 pub mod oidc;
 pub mod origin;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use monocle_cli::commands::audio_transcribe::{audio_transcribe_command, AudioTra
 use monocle_cli::commands::audio_transcribe_azure::{
     audio_transcribe_azure_command, AudioTranscribeAzureOptions,
 };
-use monocle_cli::commands::chat::{chat_command, ChatOptions};
+use monocle_cli::commands::chat::{chat_command, chat_list_command, ChatOptions};
 use monocle_cli::commands::claude::claude_command;
 use monocle_cli::commands::login::login_command;
 use monocle_cli::commands::model_list::model_list_command;
@@ -107,7 +107,12 @@ enum Commands {
     /// List available models from the Monocle router
     Models,
     /// Chat with LLM via Monocle router (interactive REPL or pipe from stdin)
-    Chat(ChatArgs),
+    Chat {
+        #[command(subcommand)]
+        command: Option<ChatCommand>,
+        #[command(flatten)]
+        args: ChatArgs,
+    },
     /// [Experimental] Headless agent loop with tools (read/write/edit + shell)
     Agent {
         /// The task/prompt (optional; omit to type it interactively, or pipe via stdin)
@@ -173,9 +178,11 @@ struct ChatArgs {
     #[arg(long)]
     responses: bool,
     /// With `--responses`, continue this existing server-side thread id
-    /// instead of starting a new one.
+    /// instead of starting a new one. When entering the interactive REPL,
+    /// its prior history is replayed to stderr before the prompt. (See also
+    /// `monocle chat list` to discover thread ids.)
     #[arg(long)]
-    thread: Option<String>,
+    resume: Option<String>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -187,9 +194,17 @@ impl From<ChatArgs> for ChatOptions {
             max_tokens: a.max_tokens,
             files: a.file,
             responses: a.responses,
-            thread: a.thread,
+            resume: a.resume,
         }
     }
+}
+
+#[derive(Subcommand)]
+enum ChatCommand {
+    /// List existing jarvice chat threads (id/title/last-updated) — including
+    /// threads created from jarvice's own web UI, since both share the same
+    /// storage. Always lists jarvice's threads; doesn't take `--responses`.
+    List,
 }
 
 #[derive(Subcommand)]
@@ -316,7 +331,10 @@ fn main() {
         }
         Commands::Acp => monocle_cli::acp::serve(),
         Commands::Models => model_list_command(&client, &creds),
-        Commands::Chat(args) => chat_command(&client, &creds, args.into()),
+        Commands::Chat { command, args } => match command {
+            Some(ChatCommand::List) => chat_list_command(&client, &creds),
+            None => chat_command(&client, &creds, args.into()),
+        },
         Commands::Agent {
             prompt,
             workdir,
@@ -457,8 +475,31 @@ mod tests {
     fn chat_file_flag_repeats_into_vec() {
         let cli = Cli::parse_from(["monocle", "chat", "--file", "a.png", "--file", "b.png"]);
         match cli.command {
-            Commands::Chat(args) => {
+            Commands::Chat { args, .. } => {
                 assert_eq!(args.file, vec!["a.png".to_string(), "b.png".to_string()]);
+            }
+            _ => panic!("expected Chat command"),
+        }
+    }
+
+    #[test]
+    fn chat_list_parses_as_list_subcommand() {
+        let cli = Cli::parse_from(["monocle", "chat", "list"]);
+        match cli.command {
+            Commands::Chat { command, .. } => {
+                assert!(matches!(command, Some(ChatCommand::List)));
+            }
+            _ => panic!("expected Chat command"),
+        }
+    }
+
+    #[test]
+    fn chat_resume_flag_parses() {
+        let cli = Cli::parse_from(["monocle", "chat", "--responses", "--resume", "abc-123"]);
+        match cli.command {
+            Commands::Chat { command, args } => {
+                assert!(command.is_none());
+                assert_eq!(args.resume.as_deref(), Some("abc-123"));
             }
             _ => panic!("expected Chat command"),
         }

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -29,7 +29,7 @@ use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::auth_headers;
 
-/// One turn's reply, plus the thread id to pass as `--thread`/the next turn's
+/// One turn's reply, plus the thread id to pass as `--resume`/the next turn's
 /// `thread_id` to keep the conversation going. jarvice always resolves (and
 /// returns) a thread id — creating one on the first turn of a session, or
 /// confirming the one passed in — so this is `Option` only defensively, in


### PR DESCRIPTION
## 요약

`--responses` 모드에서 jarvice에 이미 존재하는 대화 스레드(웹 UI에서 생성된
것 포함)를 조회하고 이어서 사용할 수 있도록 두 가지를 추가합니다.

- `monocle chat list` — 서브커맨드. 현재 사용자의 jarvice 스레드 목록(id/제목/
  최근 수정 시각)을 출력하고 종료합니다. `--responses` 플래그가 필요 없습니다
  (완전 모드에는 조회할 스레드 개념 자체가 없으므로).
- `--resume <id>` — 기존 `--thread <id>`를 대체(완전 rename, `--list-threads`는
  제거). REPL로 진입할 때 재개한 스레드의 이전 대화 내역을 stderr로 재생하고
  (stdout에는 절대 나타나지 않음 — 응답/데이터는 stdout, 진행 안내는 stderr라는
  이 repo의 불변식을 지킴), 조회 실패 시에도 경고만 출력하고 REPL은 계속 진행합니다.

새 모듈 `src/jarvice_chats.rs`가 jarvice의 `GET /api/v1/chats/` /
`GET /api/v1/chats/{id}` 를 감싸고, 브랜치(수정/재생성)를 배제한 `currentId`
단일 조상 경로만 선형화하는 `linearize()`를 포함합니다(유닛 테스트 3개).

Tracking: warmblood-kr/monocle#234

## ~~⚠️ 이 PR을 리뷰하기 전에~~ (해결됨 — PR #81 머지 완료)

~~이 브랜치는 아직 머지되지 않은 PR #81 위에 얹혀 있어 diff에 PR #81의 변경
사항도 함께 보였습니다.~~ **PR #81이 먼저 머지되었고(코드 리뷰 발견 사항 7건
중 6건 수정 포함), 이 PR도 그 위에서 devel → main으로 머지되어 v1.3.0으로
릴리스되었습니다.** 이 섹션은 리뷰 시점 참고용으로 남겨둡니다.

## 테스트

- `cargo build --release && cargo test && cargo clippy --all-targets -- -D warnings && cargo fmt --check` 모두 통과 확인
- `monocle chat --help` / `monocle chat list --help` 로 새 플래그/서브커맨드 노출 확인
- [ ] 실제 staging 테넌트에서 `monocle chat list` → 실제 스레드 확인, `monocle chat --responses --resume <id>` 로 웹 UI에서 만든 스레드 이어받기 확인 (아직 미실행)
