### PR TITLE
release: v1.3.0 — jarvice 대화 스레드 목록/재개 + Responses API 모드 + REPL /model 자동완성

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
## 요약

`main`에 이미 반영된 PR #81/#82/#83 변경 사항을 묶어 릴리스하기 위한 버전
올림 커밋입니다. `Cargo.toml`/`Cargo.lock` 외 코드 변경은 없습니다.

- 1.2.2 → 1.3.0
- REPL `/model` 커맨드 + chat/agent 공통 Tab 자동완성 (PR #81, 리뷰 이후
  correctness 2건 + cleanup 4건 수정 포함)
- `monocle chat --responses`에 jarvice 기존 대화 스레드 목록/재개 기능
  (`chat list` 서브커맨드, `--resume` 플래그) 추가 (PR #82)

머지 후 `v1.3.0` 태그를 생성/푸시하면 `.github/workflows/release.yml`이
트리거되어 4개 플랫폼 바이너리를 빌드하고 GitHub Release를 자동 게시합니다.

## 완료 (2026-07-14)

머지 완료, `v1.3.0` 태그 푸시 완료, release 워크플로 성공(4개 플랫폼 빌드 +
GitHub Release 게시 확인): https://github.com/warmblood-kr/monocle-cli/releases/tag/v1.3.0
