### PR TITLE
feat(release): SHA256SUMS 생성 및 클라이언트 체크섬 검증 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      - name: Generate SHA256SUMS
+        run: sha256sum monocle-*.tar.gz monocle-*.zip > SHA256SUMS
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -91,4 +93,5 @@ jobs:
             monocle-linux-x64.tar.gz
             monocle-linux-arm64.tar.gz
             monocle-windows-x64.zip
+            SHA256SUMS
           generate_release_notes: true

--- a/install.ps1
+++ b/install.ps1
@@ -30,6 +30,31 @@ $Tmp = New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP ([System.G
 $Zip = Join-Path $Tmp $Asset
 
 Invoke-WebRequest -Uri $Url -OutFile $Zip
+
+$SumsUrl = "https://github.com/$Repo/releases/download/$Version/SHA256SUMS"
+$SumsFile = Join-Path $Tmp "SHA256SUMS"
+$sumsAvailable = $true
+try {
+    Invoke-WebRequest -Uri $SumsUrl -OutFile $SumsFile -ErrorAction Stop
+} catch {
+    Write-Host "Warning: SHA256SUMS not available, skipping checksum verification."
+    $sumsAvailable = $false
+}
+
+if ($sumsAvailable) {
+    $line = Select-String -Path $SumsFile -Pattern ([regex]::Escape($Asset)) -SimpleMatch | Select-Object -First 1
+    if ($line) {
+        $expected = ($line.Line -split '\s+')[0].ToLower()
+        $actual = (Get-FileHash -Path $Zip -Algorithm SHA256).Hash.ToLower()
+        if ($expected -ne $actual) {
+            throw "Checksum verification failed for $Asset (expected $expected, got $actual)"
+        }
+        Write-Host "Checksum verified: $Asset"
+    } else {
+        Write-Host "Warning: no checksum entry for $Asset, skipping checksum verification."
+    }
+}
+
 Expand-Archive -Path $Zip -DestinationPath $Tmp -Force
 Move-Item -Force (Join-Path $Tmp "$Binary.exe") (Join-Path $InstallDir "$Binary.exe")
 Remove-Item -Recurse -Force $Tmp

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,45 @@ detect_platform() {
   esac
 }
 
+# Verify $1 (a downloaded file path) against its entry for $2 (the asset
+# filename as it appears in SHA256SUMS) in $3 (the release's SHA256SUMS,
+# already downloaded to a local path). A missing sums file or missing entry
+# is a soft warning (old releases predate this — must still install); an
+# actual hash mismatch is a hard error, since that's the real security check.
+verify_checksum() {
+  FILE="$1"
+  ASSET_NAME="$2"
+  SUMS_FILE="$3"
+
+  if [ ! -f "$SUMS_FILE" ]; then
+    echo "Warning: SHA256SUMS not available, skipping checksum verification." >&2
+    return 0
+  fi
+
+  EXPECTED="$(grep -F "$ASSET_NAME" "$SUMS_FILE" | awk '{print $1}' | head -1)"
+  if [ -z "$EXPECTED" ]; then
+    echo "Warning: no checksum entry for ${ASSET_NAME}, skipping checksum verification." >&2
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$FILE" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "$FILE" | awk '{print $1}')"
+  else
+    echo "Warning: no sha256sum/shasum found, skipping checksum verification." >&2
+    return 0
+  fi
+
+  if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "Error: checksum verification failed for ${ASSET_NAME}" >&2
+    echo "  expected: ${EXPECTED}" >&2
+    echo "  actual:   ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Checksum verified: ${ASSET_NAME}"
+}
+
 in_path() {
   case ":$PATH:" in
     *":$1:"*) return 0 ;;
@@ -77,12 +116,16 @@ main() {
 
   mkdir -p "$INSTALL_DIR" 2>/dev/null || true
 
+  SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS"
+
   case "$PLATFORM" in
     *windows*)
       ASSET="monocle-${PLATFORM}.zip"
       URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
       TMPDIR="$(mktemp -d)"
       curl -fsSL "$URL" -o "${TMPDIR}/${ASSET}"
+      curl -fsSL "$SUMS_URL" -o "${TMPDIR}/SHA256SUMS" 2>/dev/null || true
+      verify_checksum "${TMPDIR}/${ASSET}" "${ASSET}" "${TMPDIR}/SHA256SUMS"
       unzip -o "${TMPDIR}/${ASSET}" -d "${TMPDIR}" > /dev/null
       mv "${TMPDIR}/${BINARY}.exe" "${INSTALL_DIR}/${BINARY}.exe"
       rm -rf "$TMPDIR"
@@ -93,6 +136,8 @@ main() {
       URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
       TMPDIR="$(mktemp -d)"
       curl -fsSL "$URL" -o "${TMPDIR}/${ASSET}"
+      curl -fsSL "$SUMS_URL" -o "${TMPDIR}/SHA256SUMS" 2>/dev/null || true
+      verify_checksum "${TMPDIR}/${ASSET}" "${ASSET}" "${TMPDIR}/SHA256SUMS"
       tar xzf "${TMPDIR}/${ASSET}" -C "${TMPDIR}"
       chmod +x "${TMPDIR}/${BINARY}"
       if [ -w "$INSTALL_DIR" ]; then

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 use std::path::Path;
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use crate::error::{AppError, Result};
 use crate::net::Client;
@@ -52,6 +53,49 @@ fn asset_filename(platform: &str) -> String {
 /// The GitHub Releases download URL for `<vTAG>/<asset>`.
 fn download_url(tag: &str, asset: &str) -> String {
     format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
+}
+
+/// Parse a `sha256sum`-style SHA256SUMS listing and find the hash for
+/// `asset`. Tolerates the optional `*` binary-mode marker some tools prefix
+/// onto the filename column.
+fn find_checksum<'a>(sums: &'a str, asset: &str) -> Option<&'a str> {
+    sums.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let hash = parts.next()?;
+        let name = parts.next()?.trim_start_matches('*');
+        (name == asset).then_some(hash)
+    })
+}
+
+/// Fetch `SHA256SUMS` from the same release tag and verify `bytes` (the
+/// already-downloaded asset) against its entry. Soft-skips (warns, returns
+/// `Ok`) if the sums file can't be fetched or has no matching entry — old
+/// releases predate this and must still be installable. An actual mismatch
+/// is a hard error.
+fn verify_checksum(client: &Client, tag: &str, asset: &str, bytes: &[u8]) -> Result<()> {
+    let url = download_url(tag, "SHA256SUMS");
+    let resp = match client.get(&url, &[("User-Agent", "monocle-cli")]) {
+        Ok(r) if r.ok() => r,
+        _ => {
+            eprintln!("⚠ SHA256SUMS not available, skipping checksum verification");
+            return Ok(());
+        }
+    };
+    let sums = resp.text();
+    let Some(expected) = find_checksum(&sums, asset) else {
+        eprintln!("⚠ no checksum entry for {asset}, skipping checksum verification");
+        return Ok(());
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        return Err(AppError::new(format!(
+            "checksum verification failed for {asset}: expected {expected}, got {actual}"
+        )));
+    }
+    eprintln!("Checksum verified: {asset}");
+    Ok(())
 }
 
 /// Compare `current` against `latest` as semver. Returns `None` if EITHER string
@@ -243,6 +287,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
         )));
     }
     let bytes = resp.bytes();
+    verify_checksum(client, &tag, &asset, bytes)?;
 
     let temp_name = if cfg!(windows) {
         format!("monocle-upgrade-{}.exe", std::process::id())
@@ -305,6 +350,30 @@ mod tests {
     fn asset_platform_rejects_unknown() {
         assert!(asset_platform("linux", "riscv64").is_err());
         assert!(asset_platform("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn find_checksum_matches_exact_filename() {
+        let sums = "abc123  monocle-linux-x64.tar.gz\ndef456  monocle-macos-arm64.tar.gz\n";
+        assert_eq!(
+            find_checksum(sums, "monocle-linux-x64.tar.gz"),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn find_checksum_handles_binary_mode_marker() {
+        let sums = "abc123 *monocle-linux-x64.tar.gz\n";
+        assert_eq!(
+            find_checksum(sums, "monocle-linux-x64.tar.gz"),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn find_checksum_none_when_missing() {
+        let sums = "abc123  monocle-linux-x64.tar.gz\n";
+        assert_eq!(find_checksum(sums, "monocle-windows-x64.zip"), None);
     }
 
     #[test]


### PR DESCRIPTION
## 요약

릴리스가 4개 플랫폼 바이너리를 체크섬 없이 배포하고 있었고, `install.sh` /
`install.ps1` / `monocle upgrade` 어느 클라이언트 경로도 다운로드한 자산의
무결성을 검증하지 않았다. 다음 4가지 변경으로 이를 해결한다.

1. **`.github/workflows/release.yml`** — `release` job에서 아티팩트 다운로드
   직후 `sha256sum monocle-*.tar.gz monocle-*.zip > SHA256SUMS`로 체크섬 파일을
   생성하고, `SHA256SUMS`를 릴리스 자산 목록에 추가.
2. **`install.sh`** — `verify_checksum()` 함수 추가(`detect_platform()` 뒤,
   `in_path()` 앞). windows/유닉스 두 다운로드 분기 모두에서 자산 다운로드 직후
   `SHA256SUMS`도 함께 받아 검증하도록 삽입.
3. **`install.ps1`** — zip 다운로드 직후, 압축 해제 전에 `SHA256SUMS` 다운로드 +
   검증 로직 삽입. 해시 불일치 시 `throw`는 다운로드 `try/catch` 블록 **바깥**에
   위치시켜, 실제 불일치가 "다운로드 실패"로 조용히 삼켜지지 않도록 함.
4. **`src/commands/upgrade.rs`** — `find_checksum()`(순수 파서, 유닛 테스트 3개
   포함) + `verify_checksum()` 추가, `sha2` crate(`Cargo.toml`에 이미 존재)로 SHA256
   계산. `upgrade_command`에서 자산 다운로드 직후 호출.

## 핵심 보안 속성

- **실제 해시 불일치 → 하드 실패** (exit 1 / `Err`) — 이게 진짜 보안 체크.
- **`SHA256SUMS` 파일 자체가 없음 → 소프트 실패** (경고 출력 후 계속 설치) —
  이 기능 이전에 나온 구버전 릴리스 태그(예: v0.5.0)를 pin해서 설치하는 경우
  `SHA256SUMS`가 영원히 존재하지 않으므로, 이를 하드 실패로 만들면 구버전
  설치가 전부 깨진다.

## 테스트

- `install.sh`의 `verify_checksum()`을 별도 하네스 스크립트로 추출해(원본은
  건드리지 않음) 3가지 시나리오를 합성 테스트:
  - 해시 일치 → "Checksum verified" 출력 + exit 0 (PASS)
  - 해시 불일치 → "Error: checksum verification failed" 출력 + exit 1 (PASS)
  - `SHA256SUMS` 파일 없음 → 경고 출력 + exit 0 (PASS)
- Rust: `cargo build --release` / `cargo test`(신규 `find_checksum` 유닛 테스트
  3개 포함, 전부 통과) / `cargo clippy --all-targets -- -D warnings` /
  `cargo fmt --check` 전부 클린.

## 알려진 한계

**"체크섬 일치" 성공 경로는 실제 GitHub 인프라 상에서는 아직 end-to-end로
검증되지 않았다.** 현재 배포된 v1.3.0은 이 기능 이전 릴리스라 `SHA256SUMS`
자산이 없다. 이 PR이 머지되고 **이 기능이 반영된 새 릴리스가 실제로 나온 뒤**,
그 릴리스를 대상으로 `install.sh` / `install.ps1` / `monocle upgrade`를 다시
한 번 실제로 실행해 성공 검증 경로를 확인하는 후속 작업이 필요하다.

Refs: monocle-cli#86 / monocle#240