### PR TITLE
deploy(prod): SHA256SUMS 릴리스 체크섬 생성 + 검증

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      - name: Generate SHA256SUMS
+        run: sha256sum monocle-*.tar.gz monocle-*.zip > SHA256SUMS
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -91,4 +93,5 @@ jobs:
             monocle-linux-x64.tar.gz
             monocle-linux-arm64.tar.gz
             monocle-windows-x64.zip
+            SHA256SUMS
           generate_release_notes: true

--- a/install.ps1
+++ b/install.ps1
@@ -30,6 +30,31 @@ $Tmp = New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP ([System.G
 $Zip = Join-Path $Tmp $Asset
 
 Invoke-WebRequest -Uri $Url -OutFile $Zip
+
+$SumsUrl = "https://github.com/$Repo/releases/download/$Version/SHA256SUMS"
+$SumsFile = Join-Path $Tmp "SHA256SUMS"
+$sumsAvailable = $true
+try {
+    Invoke-WebRequest -Uri $SumsUrl -OutFile $SumsFile -ErrorAction Stop
+} catch {
+    Write-Host "Warning: SHA256SUMS not available, skipping checksum verification."
+    $sumsAvailable = $false
+}
+
+if ($sumsAvailable) {
+    $line = Select-String -Path $SumsFile -Pattern ([regex]::Escape($Asset)) -SimpleMatch | Select-Object -First 1
+    if ($line) {
+        $expected = ($line.Line -split '\s+')[0].ToLower()
+        $actual = (Get-FileHash -Path $Zip -Algorithm SHA256).Hash.ToLower()
+        if ($expected -ne $actual) {
+            throw "Checksum verification failed for $Asset (expected $expected, got $actual)"
+        }
+        Write-Host "Checksum verified: $Asset"
+    } else {
+        Write-Host "Warning: no checksum entry for $Asset, skipping checksum verification."
+    }
+}
+
 Expand-Archive -Path $Zip -DestinationPath $Tmp -Force
 Move-Item -Force (Join-Path $Tmp "$Binary.exe") (Join-Path $InstallDir "$Binary.exe")
 Remove-Item -Recurse -Force $Tmp

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,45 @@ detect_platform() {
   esac
 }
 
+# Verify $1 (a downloaded file path) against its entry for $2 (the asset
+# filename as it appears in SHA256SUMS) in $3 (the release's SHA256SUMS,
+# already downloaded to a local path). A missing sums file or missing entry
+# is a soft warning (old releases predate this — must still install); an
+# actual hash mismatch is a hard error, since that's the real security check.
+verify_checksum() {
+  FILE="$1"
+  ASSET_NAME="$2"
+  SUMS_FILE="$3"
+
+  if [ ! -f "$SUMS_FILE" ]; then
+    echo "Warning: SHA256SUMS not available, skipping checksum verification." >&2
+    return 0
+  fi
+
+  EXPECTED="$(grep -F "$ASSET_NAME" "$SUMS_FILE" | awk '{print $1}' | head -1)"
+  if [ -z "$EXPECTED" ]; then
+    echo "Warning: no checksum entry for ${ASSET_NAME}, skipping checksum verification." >&2
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$FILE" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "$FILE" | awk '{print $1}')"
+  else
+    echo "Warning: no sha256sum/shasum found, skipping checksum verification." >&2
+    return 0
+  fi
+
+  if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "Error: checksum verification failed for ${ASSET_NAME}" >&2
+    echo "  expected: ${EXPECTED}" >&2
+    echo "  actual:   ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Checksum verified: ${ASSET_NAME}"
+}
+
 in_path() {
   case ":$PATH:" in
     *":$1:"*) return 0 ;;
@@ -77,12 +116,16 @@ main() {
 
   mkdir -p "$INSTALL_DIR" 2>/dev/null || true
 
+  SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS"
+
   case "$PLATFORM" in
     *windows*)
       ASSET="monocle-${PLATFORM}.zip"
       URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
       TMPDIR="$(mktemp -d)"
       curl -fsSL "$URL" -o "${TMPDIR}/${ASSET}"
+      curl -fsSL "$SUMS_URL" -o "${TMPDIR}/SHA256SUMS" 2>/dev/null || true
+      verify_checksum "${TMPDIR}/${ASSET}" "${ASSET}" "${TMPDIR}/SHA256SUMS"
       unzip -o "${TMPDIR}/${ASSET}" -d "${TMPDIR}" > /dev/null
       mv "${TMPDIR}/${BINARY}.exe" "${INSTALL_DIR}/${BINARY}.exe"
       rm -rf "$TMPDIR"
@@ -93,6 +136,8 @@ main() {
       URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
       TMPDIR="$(mktemp -d)"
       curl -fsSL "$URL" -o "${TMPDIR}/${ASSET}"
+      curl -fsSL "$SUMS_URL" -o "${TMPDIR}/SHA256SUMS" 2>/dev/null || true
+      verify_checksum "${TMPDIR}/${ASSET}" "${ASSET}" "${TMPDIR}/SHA256SUMS"
       tar xzf "${TMPDIR}/${ASSET}" -C "${TMPDIR}"
       chmod +x "${TMPDIR}/${BINARY}"
       if [ -w "$INSTALL_DIR" ]; then

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 use std::path::Path;
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use crate::error::{AppError, Result};
 use crate::net::Client;
@@ -52,6 +53,49 @@ fn asset_filename(platform: &str) -> String {
 /// The GitHub Releases download URL for `<vTAG>/<asset>`.
 fn download_url(tag: &str, asset: &str) -> String {
     format!("https://github.com/{REPO}/releases/download/{tag}/{asset}")
+}
+
+/// Parse a `sha256sum`-style SHA256SUMS listing and find the hash for
+/// `asset`. Tolerates the optional `*` binary-mode marker some tools prefix
+/// onto the filename column.
+fn find_checksum<'a>(sums: &'a str, asset: &str) -> Option<&'a str> {
+    sums.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let hash = parts.next()?;
+        let name = parts.next()?.trim_start_matches('*');
+        (name == asset).then_some(hash)
+    })
+}
+
+/// Fetch `SHA256SUMS` from the same release tag and verify `bytes` (the
+/// already-downloaded asset) against its entry. Soft-skips (warns, returns
+/// `Ok`) if the sums file can't be fetched or has no matching entry — old
+/// releases predate this and must still be installable. An actual mismatch
+/// is a hard error.
+fn verify_checksum(client: &Client, tag: &str, asset: &str, bytes: &[u8]) -> Result<()> {
+    let url = download_url(tag, "SHA256SUMS");
+    let resp = match client.get(&url, &[("User-Agent", "monocle-cli")]) {
+        Ok(r) if r.ok() => r,
+        _ => {
+            eprintln!("⚠ SHA256SUMS not available, skipping checksum verification");
+            return Ok(());
+        }
+    };
+    let sums = resp.text();
+    let Some(expected) = find_checksum(&sums, asset) else {
+        eprintln!("⚠ no checksum entry for {asset}, skipping checksum verification");
+        return Ok(());
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        return Err(AppError::new(format!(
+            "checksum verification failed for {asset}: expected {expected}, got {actual}"
+        )));
+    }
+    eprintln!("Checksum verified: {asset}");
+    Ok(())
 }
 
 /// Compare `current` against `latest` as semver. Returns `None` if EITHER string
@@ -243,6 +287,7 @@ pub fn upgrade_command(client: &Client, check_only: bool) -> Result<()> {
         )));
     }
     let bytes = resp.bytes();
+    verify_checksum(client, &tag, &asset, bytes)?;
 
     let temp_name = if cfg!(windows) {
         format!("monocle-upgrade-{}.exe", std::process::id())
@@ -305,6 +350,30 @@ mod tests {
     fn asset_platform_rejects_unknown() {
         assert!(asset_platform("linux", "riscv64").is_err());
         assert!(asset_platform("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn find_checksum_matches_exact_filename() {
+        let sums = "abc123  monocle-linux-x64.tar.gz\ndef456  monocle-macos-arm64.tar.gz\n";
+        assert_eq!(
+            find_checksum(sums, "monocle-linux-x64.tar.gz"),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn find_checksum_handles_binary_mode_marker() {
+        let sums = "abc123 *monocle-linux-x64.tar.gz\n";
+        assert_eq!(
+            find_checksum(sums, "monocle-linux-x64.tar.gz"),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn find_checksum_none_when_missing() {
+        let sums = "abc123  monocle-linux-x64.tar.gz\n";
+        assert_eq!(find_checksum(sums, "monocle-windows-x64.zip"), None);
     }
 
     #[test]


### PR DESCRIPTION
## 요약

`devel` → `main` 프로모션 PR입니다.

### 포함된 변경 (PR #87)

- `.github/workflows/release.yml` — 릴리스 시 `SHA256SUMS` 생성 + 자산으로 첨부
- `install.sh` / `install.ps1` — 다운로드한 아카이브를 `SHA256SUMS`와 대조 검증
  (해시 불일치 시 하드 실패, `SHA256SUMS` 자체가 없으면 소프트 경고 후 계속 —
  이 기능 이전 릴리스 태그를 pin해서 설치하는 경우도 계속 동작해야 하므로)
- `monocle upgrade`(`upgrade.rs`) self-replace 경로도 동일하게 검증

Refs: monocle-cli#86 / monocle#240

### 검증

- `devel`에서 build / test / clippy / fmt 모두 clean 확인 완료
- `install.sh`의 체크섬 검증 로직은 3가지 시나리오(일치/불일치/파일없음) 합성
  테스트로 확인 완료

### 참고

**"체크섬 일치" 성공 경로는 아직 실제 GitHub 인프라 상에서 end-to-end로
검증되지 않았습니다** — 현재 `main`의 최신 릴리스(v1.3.0)는 이 기능 이전
릴리스라 `SHA256SUMS` 자산이 없습니다. 이 PR이 머지되고 새 버전이 릴리스된
뒤, 그 릴리스를 대상으로 실제 검증이 필요합니다 (이번 프로모션이 바로 그
새 릴리스를 만들기 위한 것입니다).
