### PR TITLE
release: v1.4.0 — 릴리스 바이너리 SHA256 체크섬 생성 + 검증

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
버전 올림 1.3.0 → 1.4.0. `Cargo.toml`/`Cargo.lock` 외 코드 변경 없음 (PR #88이 이미 main에 반영한 SHA256SUMS 생성/검증 기능을 릴리스하기 위함). 머지 후 `v1.4.0` 태그를 생성/푸시하면 release.yml이 트리거되어 이번에는 `SHA256SUMS`가 포함된 릴리스가 게시됩니다.