### PR TITLE
ci: 서드파티 GitHub Actions를 커밋 SHA로 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   verify-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify Cargo.toml version matches tag
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
@@ -44,10 +44,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -71,7 +71,7 @@ jobs:
           Compress-Archive -Path monocle.exe -DestinationPath ../../../${{ matrix.name }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}.*
@@ -80,13 +80,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
       - name: Generate SHA256SUMS
         run: sha256sum monocle-*.tar.gz monocle-*.zip > SHA256SUMS
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             monocle-macos-arm64.tar.gz


### PR DESCRIPTION
## 요약

`ci.yml`/`release.yml`의 모든 서드파티/GitHub 제공 액션을 `@v4`/`@stable` 같은
태그·브랜치 참조 대신 현재 그 참조가 가리키는 커밋 SHA로 고정한다. 태그는
소유자가 재작성할 수 있고 브랜치는 그냥 이동하므로, 고정하지 않으면
공급망 공격(action 저장소가 침해되어 같은 태그를 악성 커밋으로 재지정하는
경우) 벡터가 된다.

이번에 고정한 6개 액션 (`git ls-remote`로 현재 SHA 직접 확인):

| 액션 | 참조 | SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/cache` | v4 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | v4 | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `dtolnay/rust-toolchain` | stable | `4be7066ada62dd38de10e7b70166bc74ed198c30` |
| `softprops/action-gh-release` | v2 | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |

각 줄에 원래 태그/브랜치를 주석으로 남겨 가독성과 dependabot 추적을 유지한다.

Refs: 이전에 v1.1.1 릴리스 때 "결여된 보안 후속 작업"으로 플래그된 두 번째
항목(SHA256SUMS는 v1.4.0에서 이미 완료)을 마저 해결.

## 검증

- YAML 문법 확인 (`python3 -c "import yaml; yaml.safe_load(...)"`) — 통과
- 실제 CI 실행 결과로 액션들이 여전히 정상 동작하는지 확인 (이 PR 자체의
  CI 통과 여부가 그 검증)
