### PR TITLE
deploy(prod): 서드파티 GitHub Actions SHA 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   verify-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify Cargo.toml version matches tag
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
@@ -44,10 +44,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -71,7 +71,7 @@ jobs:
           Compress-Archive -Path monocle.exe -DestinationPath ../../../${{ matrix.name }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}.*
@@ -80,13 +80,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
       - name: Generate SHA256SUMS
         run: sha256sum monocle-*.tar.gz monocle-*.zip > SHA256SUMS
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             monocle-macos-arm64.tar.gz


### PR DESCRIPTION
## 요약

`devel` → `main` 프로모션 PR입니다.

### 포함된 변경 (PR #90)

- `ci.yml` / `release.yml`의 모든 GitHub Actions(actions/checkout,
  actions/cache, actions/upload-artifact, actions/download-artifact,
  dtolnay/rust-toolchain, softprops/action-gh-release)를 태그/브랜치 참조
  대신 커밋 SHA로 고정 (공급망 공격 방지)
- 코드/바이너리 동작 변경 없음 — CI 파이프라인 정의만 변경

v1.1.1 릴리스 때 플래그된 두 번째 보안 후속 작업(SHA256SUMS는 v1.4.0에서
완료)을 마저 해결.

### 검증

- PR #90 자체의 CI가 고정된 SHA로 정상 통과 확인 완료
