### PR TITLE
release: v1.4.1 — 서드파티 GitHub Actions SHA 고정

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
버전 올림 1.4.0 → 1.4.1 (patch — CI 파이프라인 정의만 변경, 코드/바이너리 동작 변경 없음). `Cargo.toml`/`Cargo.lock` 외 변경 없음. PR #91이 이미 main에 반영한 GitHub Actions SHA 고정을 릴리스하기 위함.