### PR TITLE
fix(install.ps1): 체크섬 검증이 항상 조용히 스킵되던 버그 수정

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/install.ps1
+++ b/install.ps1
@@ -42,7 +42,12 @@ try {
 }
 
 if ($sumsAvailable) {
-    $line = Select-String -Path $SumsFile -Pattern ([regex]::Escape($Asset)) -SimpleMatch | Select-Object -First 1
+    # -SimpleMatch already means "treat -Pattern as a literal string" — passing
+    # a [regex]::Escape()'d value here (as an earlier version of this script
+    # did) is a bug: SimpleMatch doesn't unescape it, so the literal escape
+    # backslashes never match the real unescaped filename, and verification
+    # silently no-ops on every real run. Pass $Asset as-is.
+    $line = Select-String -Path $SumsFile -Pattern $Asset -SimpleMatch | Select-Object -First 1
     if ($line) {
         $expected = ($line.Line -split '\s+')[0].ToLower()
         $actual = (Get-FileHash -Path $Zip -Algorithm SHA256).Hash.ToLower()


### PR DESCRIPTION
## 요약

`install.ps1`의 체크섬 검증이 **Windows 경로에서 항상 조용히 스킵되고
있었다** — v1.4.0/v1.4.1에서 실제 `install.ps1`을 PowerShell Core(pwsh)로
직접 실행해 발견.

## 원인

```powershell
$line = Select-String -Path $SumsFile -Pattern ([regex]::Escape($Asset)) -SimpleMatch
```

`-SimpleMatch`는 `-Pattern`을 이미 리터럴 문자열로 취급한다. 여기에
`[regex]::Escape()`로 이스케이프한 문자열을 넘기면, 패턴 안에 실제 파일에는
없는 리터럴 백슬래시(`monocle-windows-x64\.zip`)가 섞여 들어가 절대 매치되지
않는다. 그 결과 `SHA256SUMS`에 해당 항목이 실제로 존재함에도 매번
"no checksum entry" 경고를 내며 조용히 검증을 건너뛰었다 — 크래시하지
않고 조용히 스킵되므로 CI/유닛 테스트로는 잡히지 않았다.

`install.sh`의 동등 로직(`grep -F`)은 이 문제가 없다 — 이미 실제 v1.4.0
릴리스로 검증 완료.

## 수정

`-SimpleMatch`에는 원본 문자열을 그대로 넘긴다(이스케이프 불필요 —
그게 SimpleMatch의 존재 이유):
```powershell
$line = Select-String -Path $SumsFile -Pattern $Asset -SimpleMatch
```

## 검증

실제 `v1.4.1` 릴리스를 대상으로 pwsh(cross-platform)로 재현·수정·재검증:
- 수정 전: `Warning: no checksum entry for monocle-windows-x64.zip, skipping checksum verification.`
- 수정 후: `Checksum verified: monocle-windows-x64.zip`
- 해시 불일치 감지 로직(`$expected -ne $actual`)은 이 버그와 무관한 단순
  문자열 비교라 별도 재확인: 조작한 SHA256SUMS로도 항목 조회 자체는
  정상 동작 확인

## 후속

머지 후 패치 릴리스(v1.4.2)로 즉시 배포 권장 — v1.4.0/v1.4.1을 pin해서
설치한 Windows 사용자는 계속 이 버그의 영향을 받는다.
