### PR TITLE
feat(chat): 마지막 턴 진단 정보를 보여주는 /diag REPL 명령어 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ available to your account (fetched once at startup) — e.g. `/model cla<TAB>` n
 matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
 list can't be fetched, completion just offers nothing (typing a full id still works).
 
+`/diag` shows diagnostics for the **last** turn only — nothing is printed automatically
+after a reply, it's opt-in on demand. Handy with a router alias (e.g. `monocle-auto`) to
+see which concrete model actually served the response:
+
+```console
+> /diag
+--- diag ---
+Endpoint: https://api.monocle-ai.com/v1/chat/completions
+Requested model: monocle-auto
+Served model: claude-sonnet-4-6
+Latency: 842ms
+Tokens: 120 prompt + 45 completion = 165 total
+--- end diag ---
+```
+
+`Served model` and `Tokens` are only shown when the backend reports them (always true for
+`monocle chat`'s default path; `--responses`, below, reports neither today, so those lines
+are simply omitted rather than printed as empty). Before the first turn, `/diag` just
+prints a hint to send a message first.
+
 One-shot via stdin:
 
 ```console
@@ -217,6 +237,10 @@ Continue a specific thread later (one-shot or REPL) with `--resume <id>`
 ```bash
 echo "and in Python?" | monocle chat --responses --resume 3fa3b2c1-...
 ```
+
+`/diag` also works in this REPL, but the Responses API doesn't echo back a served
+model or token usage, so those lines are omitted — only `Endpoint`/`Requested
+model`/`Latency` are shown.
 
 List your existing threads (including ones started in jarvice's own web UI —
 both share the same storage) with the `list` subcommand:

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -160,6 +160,33 @@ pub struct ChatResponse {
     /// magic `finish_reason` string. A complete-but-then-dropped stream (the
     /// model already sent `finish_reason`) is NOT truncated.
     pub truncated: bool,
+    /// Token counts, when the backend reports them. Always present on a
+    /// non-streaming reply (the OpenAI-compatible `usage` object is part of
+    /// the standard, non-opt-in response shape); for streaming, only present
+    /// because `MonocleProvider::build_body` opts in via
+    /// `stream_options.include_usage` — see that fn's doc comment.
+    pub usage: Option<TokenUsage>,
+}
+
+/// Token counts for one turn (OpenAI-compatible `usage` object:
+/// `prompt_tokens` + `completion_tokens` = `total_tokens`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Parse an OpenAI-compatible `usage` object off a response/chunk body, if
+/// present. Shared by the non-streaming parser and the streaming assembler's
+/// final-chunk handling.
+fn parse_usage(data: &Value) -> Option<TokenUsage> {
+    let usage = data.get("usage")?;
+    Some(TokenUsage {
+        prompt_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
+        completion_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
+        total_tokens: usage["total_tokens"].as_u64().unwrap_or(0) as u32,
+    })
 }
 
 /// Ensure every assembled tool call has a non-empty `id`, synthesizing a stable
@@ -192,12 +219,14 @@ fn parse_response_value(data: &Value) -> Result<ChatResponse> {
     let finish_reason = data["choices"][0]["finish_reason"]
         .as_str()
         .map(String::from);
+    let usage = parse_usage(data);
     Ok(ChatResponse {
         content,
         tool_calls,
         model,
         finish_reason,
         truncated: false,
+        usage,
     })
 }
 
@@ -243,6 +272,10 @@ fn assemble_sse_stream(
     let mut model: Option<String> = None;
     let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
     let mut truncated = false;
+    // Only present when the request opted in via `stream_options.include_usage`
+    // (see `MonocleProvider::build_body`) — OpenAI-compatible servers then send
+    // one extra terminal chunk carrying `usage` alongside an empty `choices`.
+    let mut usage: Option<TokenUsage> = None;
 
     loop {
         let raw = match next_line() {
@@ -277,6 +310,9 @@ fn assemble_sse_stream(
         };
         if model.is_none() {
             model = v["model"].as_str().map(String::from);
+        }
+        if usage.is_none() {
+            usage = parse_usage(&v);
         }
         let choice = &v["choices"][0];
         if let Some(fr) = choice["finish_reason"].as_str() {
@@ -344,6 +380,7 @@ fn assemble_sse_stream(
         model,
         finish_reason,
         truncated,
+        usage,
     })
 }
 
@@ -425,6 +462,12 @@ impl MonocleProvider {
             "messages": messages,
             "stream": stream,
         });
+        if stream {
+            // OpenAI-compatible streaming omits `usage` unless the request
+            // opts in — without this, a streamed turn's `/diag` would never
+            // have token counts (only the non-streaming path would).
+            body["stream_options"] = json!({"include_usage": true});
+        }
         if let Some(max_tokens) = req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
@@ -607,6 +650,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn non_streaming_response_with_usage_is_parsed() {
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15},
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: 12,
+                completion_tokens: 3,
+                total_tokens: 15,
+            })
+        );
+    }
+
+    #[test]
+    fn non_streaming_response_without_usage_is_none() {
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(resp.usage, None);
+    }
+
+    #[test]
+    fn streaming_final_usage_chunk_is_captured() {
+        // Mirrors the terminal chunk an OpenAI-compatible server sends when the
+        // request opts in via `stream_options.include_usage`: empty `choices`
+        // alongside a `usage` object, after the content-bearing deltas.
+        let usage_chunk =
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}";
+        let (resp, deltas) = run_stream(vec![
+            content_line("Hi"),
+            Ok(Some(usage_chunk.to_string())),
+            Ok(Some("data: [DONE]".to_string())),
+            Ok(None),
+        ]);
+        let resp = resp.expect("normal completion with a trailing usage chunk should succeed");
+        assert_eq!(resp.content, "Hi");
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 2,
+                total_tokens: 7,
+            })
+        );
+        assert_eq!(deltas, vec!["Hi".to_string()]);
+    }
+
     fn dummy_provider() -> MonocleProvider {
         MonocleProvider::new("token", "https://router.example")
     }
@@ -628,6 +725,27 @@ mod tests {
         assert_eq!(body["messages"][1]["content"], json!("hello"));
         assert!(body["messages"][1]["content"].is_string());
         assert_eq!(body["max_tokens"], json!(100));
+    }
+
+    #[test]
+    fn build_body_streaming_opts_into_usage() {
+        // Streaming requests must ask for the terminal `usage` chunk (OpenAI-
+        // compatible servers omit it otherwise) so `/diag` can show token
+        // counts on a streamed turn, same as a non-streaming one.
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::user("hello")],
+            ..Default::default()
+        };
+        let streaming_body = provider.build_body(&req, true);
+        assert_eq!(
+            streaming_body["stream_options"],
+            json!({"include_usage": true})
+        );
+
+        let non_streaming_body = provider.build_body(&req, false);
+        assert!(non_streaming_body.get("stream_options").is_none());
     }
 
     #[test]

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -181,11 +181,18 @@ pub struct TokenUsage {
 /// present. Shared by the non-streaming parser and the streaming assembler's
 /// final-chunk handling.
 fn parse_usage(data: &Value) -> Option<TokenUsage> {
+    // `.unwrap_or(0)` handles a missing/non-numeric field; the `u32::try_from`
+    // below handles a present-but-oversized one (e.g. a malformed upstream
+    // payload) by saturating to `u32::MAX` instead of silently wrapping to a
+    // small, wrong number via an `as u32` truncation.
     let usage = data.get("usage")?;
+    let field = |name: &str| -> u32 {
+        u32::try_from(usage[name].as_u64().unwrap_or(0)).unwrap_or(u32::MAX)
+    };
     Some(TokenUsage {
-        prompt_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
-        completion_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
-        total_tokens: usage["total_tokens"].as_u64().unwrap_or(0) as u32,
+        prompt_tokens: field("prompt_tokens"),
+        completion_tokens: field("completion_tokens"),
+        total_tokens: field("total_tokens"),
     })
 }
 
@@ -676,6 +683,30 @@ mod tests {
         });
         let resp = parse_response_value(&data).unwrap();
         assert_eq!(resp.usage, None);
+    }
+
+    #[test]
+    fn oversized_usage_field_saturates_instead_of_wrapping() {
+        // A malformed/oversized upstream value must saturate to `u32::MAX`,
+        // not silently wrap to a small (wrong-looking) number via `as u32`.
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": u64::MAX,
+                "completion_tokens": (u32::MAX as u64) + 1,
+                "total_tokens": 15,
+            },
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: u32::MAX,
+                completion_tokens: u32::MAX,
+                total_tokens: 15,
+            })
+        );
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -217,6 +217,31 @@ fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> 
     true
 }
 
+/// Dispatch a slash-command line to whichever handler recognizes it (shared
+/// by both REPL loops, so the two don't drift out of sync). Returns
+/// `Some(control)` when `trimmed` was consumed as a recognized command — the
+/// caller should return it immediately. `None` means it wasn't a recognized
+/// command and should be treated as ordinary chat input.
+fn dispatch_chat_command(
+    trimmed: &str,
+    model: &mut String,
+    diagnostics: &Option<TurnDiagnostics>,
+) -> Option<LoopControl> {
+    if trimmed == "/quit" || trimmed == "/exit" {
+        eprintln!("Bye.");
+        return Some(LoopControl::Quit);
+    }
+    // `/model` switches the model for subsequent turns — handled before
+    // `/diag` since it carries an argument, same as `monocle agent`'s REPL.
+    if handle_model_command(trimmed, model) {
+        return Some(LoopControl::Continue);
+    }
+    if handle_diag_command(trimmed, diagnostics) {
+        return Some(LoopControl::Continue);
+    }
+    None
+}
+
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     if options.responses {
         run_responses_chat(client, creds, options)
@@ -375,18 +400,8 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     let mut diagnostics: Option<TurnDiagnostics> = None;
 
     run_repl(helper, history_path, "> ", |trimmed| {
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("Bye.");
-            return Ok(LoopControl::Quit);
-        }
-        // `/model` switches the model for subsequent turns — handled before
-        // the general dispatch since it carries an argument, same as
-        // `monocle agent`'s REPL.
-        if handle_model_command(trimmed, &mut model) {
-            return Ok(LoopControl::Continue);
-        }
-        if handle_diag_command(trimmed, &diagnostics) {
-            return Ok(LoopControl::Continue);
+        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+            return Ok(control);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -416,6 +431,12 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             Some(s) => s,
             None => return Ok(LoopControl::Continue),
         };
+        // Captured before `provider.refresh` consumes `session` — the actual
+        // per-turn request goes to whatever router URL THIS session carries,
+        // which can differ from the outer `router_url` after a mid-session
+        // refresh re-discovers a different router. `/diag`'s endpoint must
+        // reflect the request that was actually sent, not the startup value.
+        let turn_router_url = session.router_url.clone();
         provider.refresh(session);
 
         eprintln!();
@@ -438,7 +459,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                 diagnostics = Some(TurnDiagnostics {
                     requested_model: model.clone(),
                     served_model: resp.model.clone(),
-                    endpoint: format!("{router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
                     latency_ms: started.elapsed().as_millis(),
                     usage: resp.usage.clone(),
                 });
@@ -449,6 +470,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             }
             Err(e) => {
                 convo.truncate(mark);
+                // A failed turn must not leave stale diagnostics from an
+                // earlier successful turn silently displayable via `/diag`.
+                diagnostics = None;
                 eprintln!("Error: {e}");
                 if crate::diag::was_logged() {
                     eprintln!("  (details logged to {})", crate::diag::display_path());
@@ -590,18 +614,8 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     }
 
     run_repl(helper, history_path, "> ", |trimmed| {
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("Bye.");
-            return Ok(LoopControl::Quit);
-        }
-        // `/model` switches the model for subsequent turns — handled before
-        // the general dispatch since it carries an argument, same as
-        // `monocle agent`'s REPL.
-        if handle_model_command(trimmed, &mut model) {
-            return Ok(LoopControl::Continue);
-        }
-        if handle_diag_command(trimmed, &diagnostics) {
-            return Ok(LoopControl::Continue);
+        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+            return Ok(control);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -655,6 +669,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                 println!();
             }
             Err(e) => {
+                // A failed turn must not leave stale diagnostics from an
+                // earlier successful turn silently displayable via `/diag`.
+                diagnostics = None;
                 eprintln!("Error: {e}");
                 if crate::diag::was_logged() {
                     eprintln!("  (details logged to {})", crate::diag::display_path());
@@ -723,12 +740,42 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_diag, resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics};
+    use super::{
+        dispatch_chat_command, format_diag, resolve_max_tokens, resolve_repl_attachments,
+        TurnDiagnostics,
+    };
     use crate::agent::providers::TokenUsage;
+    use crate::commands::repl::LoopControl;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is
     // covered there, since that's where its Completer/Hinter impls live.
+
+    // `/model`/`/diag` dispatch through `dispatch_chat_command` isn't
+    // re-tested in detail here — `handle_model_command` and
+    // `handle_diag_command` already have their own coverage; this just
+    // confirms the shared entry point recognizes `/quit`/`/exit` and passes
+    // through anything else as ordinary chat input.
+    #[test]
+    fn dispatch_chat_command_quit_and_exit_stop_the_repl() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(matches!(
+            dispatch_chat_command("/quit", &mut model, &diagnostics),
+            Some(LoopControl::Quit)
+        ));
+        assert!(matches!(
+            dispatch_chat_command("/exit", &mut model, &diagnostics),
+            Some(LoopControl::Quit)
+        ));
+    }
+
+    #[test]
+    fn dispatch_chat_command_unrecognized_line_is_chat_input() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(dispatch_chat_command("hello there", &mut model, &diagnostics).is_none());
+    }
 
     #[test]
     fn absent_flag_omits() {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, TokenUsage,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
@@ -158,9 +158,64 @@ fn resolve_repl_attachments(
 }
 
 /// The slash commands the REPL understands. `/model` mirrors `monocle
-/// agent`'s REPL (switches the model for subsequent turns); chat still has no
-/// `/help`/`/config`/`/status`.
-const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/exit", "/quit"];
+/// agent`'s REPL (switches the model for subsequent turns); `/diag` shows
+/// diagnostics for the last turn; chat still has no `/help`/`/config`/`/status`.
+const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/diag", "/exit", "/quit"];
+
+/// Diagnostics for the most recently completed turn, shown on demand by
+/// `/diag` — REPL-only, overwritten each turn (no history is kept). Built
+/// fresh after every successful turn in both `run_completions_chat` and
+/// `run_responses_chat`; `served_model`/`usage` stay `None` wherever the
+/// backend doesn't report them (the `--responses` path reports neither today
+/// — see module docs on `responses_api::ResponsesReply`).
+struct TurnDiagnostics {
+    requested_model: String,
+    served_model: Option<String>,
+    endpoint: String,
+    latency_ms: u128,
+    usage: Option<TokenUsage>,
+}
+
+/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
+/// `--responses` REPL's prior-history replay). Lines for data the backend
+/// didn't report are omitted entirely — never printed as `None`/`null`.
+fn format_diag(d: &TurnDiagnostics) -> String {
+    let mut lines = vec![
+        "--- diag ---".to_string(),
+        format!("Endpoint: {}", d.endpoint),
+        format!("Requested model: {}", d.requested_model),
+    ];
+    if let Some(served) = &d.served_model {
+        lines.push(format!("Served model: {served}"));
+    }
+    lines.push(format!("Latency: {}ms", d.latency_ms));
+    if let Some(u) = &d.usage {
+        lines.push(format!(
+            "Tokens: {} prompt + {} completion = {} total",
+            u.prompt_tokens, u.completion_tokens, u.total_tokens
+        ));
+    }
+    lines.push("--- end diag ---".to_string());
+    lines.join("\n")
+}
+
+/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
+/// diagnostics (or a "nothing yet" hint before the first turn). Returns
+/// `true` if this input was consumed as `/diag`, mirroring
+/// `model_list::handle_model_command`'s contract.
+fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
+    if trimmed != "/diag" {
+        return false;
+    }
+    match diagnostics {
+        None => eprintln!(
+            "{}",
+            crate::colors::dim("No response yet — send a message first.")
+        ),
+        Some(d) => eprintln!("{}", format_diag(d)),
+    }
+    true
+}
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     if options.responses {
@@ -292,6 +347,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     }
     eprintln!("Type your message. Press Ctrl+D to exit.");
     eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
+    eprintln!(
+        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+    );
     eprintln!("---");
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
@@ -312,6 +370,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     if let Some(sp) = &system_prompt {
         convo.push(Message::system(sp));
     }
+    // Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    // first successful turn.
+    let mut diagnostics: Option<TurnDiagnostics> = None;
 
     run_repl(helper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
@@ -322,6 +383,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // the general dispatch since it carries an argument, same as
         // `monocle agent`'s REPL.
         if handle_model_command(trimmed, &mut model) {
+            return Ok(LoopControl::Continue);
+        }
+        if handle_diag_command(trimmed, &diagnostics) {
             return Ok(LoopControl::Continue);
         }
 
@@ -366,8 +430,18 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // leave a dangling, reply-less user message in the history sent next time.
         let mark = convo.len();
         convo.push(Message::user(text));
+        // Wrapped tightly around the network call itself (not REPL input-wait
+        // time) — this is what `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
         match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
             Ok(resp) => {
+                diagnostics = Some(TurnDiagnostics {
+                    requested_model: model.clone(),
+                    served_model: resp.model.clone(),
+                    endpoint: format!("{router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    latency_ms: started.elapsed().as_millis(),
+                    usage: resp.usage.clone(),
+                });
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -464,6 +538,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     eprintln!("jarvice: {jarvice_url}");
     eprintln!("Type your message. Press Ctrl+D to exit.");
     eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
+    eprintln!("/diag shows diagnostics (endpoint, latency) for the last turn.");
     eprintln!("The server owns this conversation's thread — no local history is resent.");
     eprintln!("---");
 
@@ -479,6 +554,10 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         commands: CHAT_SLASH_COMMANDS,
         models: model_ids,
     };
+    // Last turn's diagnostics, shown on demand by `/diag`. This path never
+    // learns a served model or token usage (see `TurnDiagnostics` docs), so
+    // those fields stay `None` for the life of the session.
+    let mut diagnostics: Option<TurnDiagnostics> = None;
 
     // Replay prior history for an existing thread, REPL-only (never in the
     // one-shot path above, never on stdout — this repo treats stdout as
@@ -521,6 +600,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         if handle_model_command(trimmed, &mut model) {
             return Ok(LoopControl::Continue);
         }
+        if handle_diag_command(trimmed, &diagnostics) {
+            return Ok(LoopControl::Continue);
+        }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
             Ok(v) => v,
@@ -548,8 +630,18 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!();
         crate::diag::reset();
 
+        // Wrapped tightly around the network call itself, same as the
+        // completions path — this is what `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
+                diagnostics = Some(TurnDiagnostics {
+                    requested_model: model.clone(),
+                    served_model: None,
+                    endpoint: format!("{jarvice_url}/api/responses"),
+                    latency_ms: started.elapsed().as_millis(),
+                    usage: None,
+                });
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's
@@ -631,7 +723,8 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_max_tokens, resolve_repl_attachments};
+    use super::{format_diag, resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics};
+    use crate::agent::providers::TokenUsage;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is
@@ -699,6 +792,57 @@ mod tests {
     fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
         let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
         assert!(err.contains("not found"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn format_diag_omits_served_model_and_usage_when_unavailable() {
+        // The `--responses` path: only endpoint/requested-model/latency are
+        // ever known — served model and usage must never render as a literal
+        // "None"/"null", they're just absent lines.
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
+            latency_ms: 842,
+            usage: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://acme.monocle-ai.com/api/responses\n\
+             Requested model: monocle-auto\n\
+             Latency: 842ms\n\
+             --- end diag ---"
+        );
+        assert!(!block.contains("None"));
+        assert!(!block.contains("null"));
+    }
+
+    #[test]
+    fn format_diag_shows_served_model_and_usage_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            latency_ms: 1234,
+            usage: Some(TokenUsage {
+                prompt_tokens: 120,
+                completion_tokens: 45,
+                total_tokens: 165,
+            }),
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 1234ms\n\
+             Tokens: 120 prompt + 45 completion = 165 total\n\
+             --- end diag ---"
+        );
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -54,6 +54,7 @@ pub fn text_response(content: &str) -> ChatResponse {
         model: None,
         finish_reason: Some("stop".to_string()),
         truncated: false,
+        usage: None,
     }
 }
 
@@ -78,6 +79,7 @@ pub fn tool_call_response_raw(id: &str, name: &str, arguments: &str) -> ChatResp
         model: None,
         finish_reason: Some("tool_calls".to_string()),
         truncated: false,
+        usage: None,
     }
 }
 


### PR DESCRIPTION
## 배경

`monocle-auto` 같은 라우터 별칭으로 채팅할 때, 실제로 어떤 모델이 응답했는지 알 방법이 없었음. 매 턴 자동으로 정보를 출력하면 평소 사용에는 노이즈만 될 뿐이라, 필요할 때만 요청하는 `/diag` 명령어로 설계.

## 변경 사항

- `/diag`: 마지막 턴의 endpoint / 요청한 모델 / 실제 응답한 모델 / 지연시간 / 토큰 사용량을 stderr에 출력. 백엔드가 값을 안 주는 필드(`--responses` 경로의 served model/usage)는 생략, `None`/`null`을 그대로 출력하지 않음.
- `src/agent/providers.rs`: `ChatResponse`에 `usage: Option<TokenUsage>` 추가. 스트리밍 응답은 OpenAI 호환 API 특성상 `stream_options.include_usage`를 opt-in해야 마지막 청크에 토큰 사용량이 포함되므로 이를 추가.
- `src/commands/chat.rs`: `TurnDiagnostics`/`format_diag`/`handle_diag_command` + 두 REPL 루프(`run_completions_chat`/`run_responses_chat`) 모두에 배선. `/model`과 동일한 명령어 디스패치 패턴.
- `README.md`: 사용법 + 예시 출력 문서화.

REPL 토큰 자동 갱신 버그 수정(#96)과는 완전히 분리된 별도 PR — 같은 파일을 건드리지만 목적이 다름(기능 vs 버그 수정).

## 검증

- `cargo build --release` / `cargo test` (113개, `/diag` 테스트 포함) / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` 모두 통과
- 원본 대비 diff를 직접 대조해 이 기능에 해당하는 변경만 포함됐는지 확인 (토큰 갱신 관련 코드 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)