### PR TITLE
chat/agent REPL 프롬프트 통일, 모드 배너 색상 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ Monocle Chat (model: claude-sonnet-4-6)
 Router: https://api.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> Hello
+▸ chat
+❯ Hello
 Hello! How can I help you today?
 
-> /quit
+❯ /quit
 Bye.
 ```
 
@@ -119,7 +120,7 @@ after a reply, it's opt-in on demand. Handy with a router alias (e.g. `monocle-a
 see which concrete model actually served the response:
 
 ```console
-> /diag
+❯ /diag
 --- diag ---
 Endpoint: https://api.monocle-ai.com/v1/chat/completions
 Requested model: monocle-auto
@@ -223,11 +224,12 @@ Monocle Chat — Responses API (model: claude-sonnet-4-6)
 jarvice: https://acme.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> Hello
+▸ chat
+❯ Hello
 Hello! How can I help you today?
 Thread: 3fa3b2c1-...
 
-> /quit
+❯ /quit
 Bye.
 ```
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -85,10 +85,11 @@ Monocle Chat (model: claude-sonnet-4-6)
 Router: https://api.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> 안녕하세요
+▸ chat
+❯ 안녕하세요
 안녕하세요! 무엇을 도와드릴까요?
 
-> /quit
+❯ /quit
 Bye.
 ```
 

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -45,10 +45,12 @@ pub fn red(s: &str) -> String {
 }
 
 /// Monocle brand orange (#f97316, DESIGN.md §2 Primary/Orange/500) via
-/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints
-/// (see agent.rs/chat.rs mode banners) — NOT a general-purpose accent color;
-/// the rest of this CLI intentionally stays muted/cyan (gh/brew convention)
-/// so it never fights the user's terminal theme.
+/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints —
+/// today, just `monocle agent`'s "▸ agent" mode banner (`monocle chat`'s "▸
+/// chat" banner deliberately stays cyan, see `commands::repl::mode_banner`) —
+/// NOT a general-purpose accent color; the rest of this CLI intentionally
+/// stays muted/cyan (gh/brew convention) so it never fights the user's
+/// terminal theme.
 pub fn orange(s: &str) -> String {
     wrap("38;2;249;115;22", "39", s)
 }
@@ -57,9 +59,17 @@ pub fn orange(s: &str) -> String {
 mod tests {
     use super::orange;
     use std::env;
+    use std::sync::Mutex;
+
+    // `FORCE_COLOR` is process-wide state and `cargo test` runs unit tests on
+    // parallel threads within one process — guard the mutation so a future
+    // test that reads/sets NO_COLOR/FORCE_COLOR (or asserts exact-equality on
+    // colored output) can't race with this one.
+    static COLOR_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn orange_wraps_with_truecolor_sgr_when_forced() {
+        let _guard = COLOR_ENV_LOCK.lock().unwrap();
         env::set_var("FORCE_COLOR", "1");
         let out = orange("agent");
         env::remove_var("FORCE_COLOR");

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -43,3 +43,26 @@ pub fn cyan(s: &str) -> String {
 pub fn red(s: &str) -> String {
     wrap("31", "39", s)
 }
+
+/// Monocle brand orange (#f97316, DESIGN.md §2 Primary/Orange/500) via
+/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints
+/// (see agent.rs/chat.rs mode banners) — NOT a general-purpose accent color;
+/// the rest of this CLI intentionally stays muted/cyan (gh/brew convention)
+/// so it never fights the user's terminal theme.
+pub fn orange(s: &str) -> String {
+    wrap("38;2;249;115;22", "39", s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::orange;
+    use std::env;
+
+    #[test]
+    fn orange_wraps_with_truecolor_sgr_when_forced() {
+        env::set_var("FORCE_COLOR", "1");
+        let out = orange("agent");
+        env::remove_var("FORCE_COLOR");
+        assert!(out.contains("38;2;249;115;22"));
+    }
+}

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -18,7 +18,7 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -232,7 +232,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
 
     eprintln!(
         "{} {}",
-        c::orange("\u{25B8} agent"),
+        mode_banner("agent", c::orange),
         c::dim(&workdir.display().to_string())
     );
     // Interactive sessions gate side-effecting tools behind a y/N prompt (unless

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -18,7 +18,7 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -232,7 +232,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
 
     eprintln!(
         "{} {}",
-        c::dim("agent · workdir"),
+        c::orange("\u{25B8} agent"),
         c::dim(&workdir.display().to_string())
     );
     // Interactive sessions gate side-effecting tools behind a y/N prompt (unless
@@ -355,7 +355,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     };
     let history_path = home_dir().join(".monocle").join("agent_history");
 
-    run_repl(helper, history_path, "» ", |msg| {
+    run_repl(helper, history_path, PROMPT, |msg| {
         // `/model` switches the model for subsequent turns (handled before
         // the general dispatch since it carries an argument).
         if handle_model_command(msg, &mut repl.model) {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -11,7 +11,7 @@ use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -376,7 +376,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
     );
     eprintln!("---");
-    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+    eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
     // stay independent. The Editor build, bracketed-paste config, history
@@ -614,7 +614,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         }
     }
 
-    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+    eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
     run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -11,7 +11,7 @@ use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -376,6 +376,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
     );
     eprintln!("---");
+    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
     // stay independent. The Editor build, bracketed-paste config, history
@@ -399,7 +400,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     // first successful turn.
     let mut diagnostics: Option<TurnDiagnostics> = None;
 
-    run_repl(helper, history_path, "> ", |trimmed| {
+    run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
             return Ok(control);
         }
@@ -613,7 +614,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         }
     }
 
-    run_repl(helper, history_path, "> ", |trimmed| {
+    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+
+    run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
             return Ok(control);
         }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -29,6 +29,17 @@ use crate::error::Result;
 /// this prompt.
 pub const PROMPT: &str = "\u{276F} "; // ❯ — the modern CLI prompt glyph (Starship/Spaceship convention), replacing the old "$"/">" default.
 
+/// Renders this REPL's mode-identity marker ("▸ <label>") in the given color
+/// — shared so `monocle chat`'s and `monocle agent`'s banners (and any future
+/// REPL mode's) can't drift on the glyph or format the way the prompt caret
+/// itself briefly did before `PROMPT` was unified. Callers still choose their
+/// own color (agent: orange, "the active/acting mode" per DESIGN.md; chat:
+/// cyan, informational) and print it themselves, since some banners (agent's)
+/// append extra context (the workdir) that isn't part of this shared shape.
+pub fn mode_banner(label: &str, colorize: impl Fn(&str) -> String) -> String {
+    colorize(&format!("\u{25B8} {label}"))
+}
+
 /// What the per-line callback wants the loop to do next.
 pub enum LoopControl {
     Continue,

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -19,6 +19,16 @@ use crate::colors as c;
 use crate::commands::model_list::fuzzy_model_candidates;
 use crate::error::Result;
 
+/// Shared REPL prompt for both `monocle chat` and `monocle agent` — unifies
+/// what were previously two different carets ("> " and "» "). Plain ASCII-
+/// safe text only: rustyline computes prompt width by skipping recognized
+/// ANSI escapes, but on Windows consoles without VT processing enabled those
+/// escapes print as literal bytes instead, desyncing the cursor column from
+/// what rustyline thinks it is. Mode identity is signaled by a colored line
+/// printed BEFORE the REPL starts (see chat.rs/agent.rs), not by coloring
+/// this prompt.
+pub const PROMPT: &str = "\u{276F} "; // ❯ — the modern CLI prompt glyph (Starship/Spaceship convention), replacing the old "$"/">" default.
+
 /// What the per-line callback wants the loop to do next.
 pub enum LoopControl {
     Continue,


### PR DESCRIPTION
## 요약
- chat과 agent REPL이 서로 다른, 딱히 설계 의도 없이 다른 프롬프트 캐럿("> " vs "» ")을 쓰고 있었음 — repl.rs로 공용 엔진이 통합되기 전 각각 독립적으로 만들어진 흔적. 이제 하나의 `PROMPT` 상수로 통일: `❯ ` (Starship/Spaceship가 대중화시킨 현대적 CLI 프롬프트 글리프). 플레인 텍스트 유지 — 프롬프트 문자열에 색상을 넣으면 VT 프로세싱이 비활성화된 Windows 콘솔에서 rustyline의 커서 컬럼 계산이 깨짐.
- 모드 식별은 각 REPL 시작 전 한 줄 컬러 배너로 대체: agent는 orange `▸ agent` 마커(agent 모드는 사용자를 대신해 행동하는 모드 — DESIGN.md의 "orange = active state" 시맨틱과 일치), chat은 cyan `▸ chat` 마커(정보 제공용, 부작용 없음).
- `colors::orange()` 추가 — Monocle 브랜드 hex(`#f97316`)를 트루컬러 ANSI로 표현, 이 소수의 의도된 지점에만 한정 사용.
- `README.md`/`docs/README.ko.md`의 트랜스크립트 예제 업데이트.
- (코드 리뷰 피드백 반영) `colors::orange()` 문서 주석 오류 수정, 배너 리터럴을 `repl.rs`의 공용 `mode_banner()` 함수로 통합, 새 테스트의 `FORCE_COLOR` 환경변수 레이스 가드 추가.

후속 작업(별도 PR): 슬래시 커맨드 구성 일치 — chat에 `/help`, agent에 `/diag` (PR #99).

## 테스트 계획
- [x] `cargo build --release`
- [x] `cargo test` (새 `colors::tests::orange_wraps_with_truecolor_sgr_when_forced` 포함)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)