### PR TITLE
chat/agent REPL 슬래시 커맨드 구성 일치 (/help, /diag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Bye.
 
 The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
 and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
-Tab completes `/model`/`/quit`/`/exit` as a dropdown listing every match (not cycling
-one at a time), with the best match also shown as a dim inline hint as you type; a
+Tab completes `/help`/`/model`/`/diag`/`/quit`/`/exit` as a dropdown listing every
+match (not cycling one at a time), with the best match also shown as a dim inline
+hint as you type; a
 multi-line paste is inserted as a single input (submitted only on Enter, not one turn
 per line). Command history persists across sessions in `~/.monocle/chat_history` (kept
 separate from `monocle agent`'s history). The REPL remembers the conversation — each
@@ -134,6 +135,9 @@ Tokens: 120 prompt + 45 completion = 165 total
 `monocle chat`'s default path; `--responses`, below, reports neither today, so those lines
 are simply omitted rather than printed as empty). Before the first turn, `/diag` just
 prints a hint to send a message first.
+
+`/help` re-prints the REPL's onboarding message (the same lines shown when the
+session starts) — handy if you've scrolled past it.
 
 One-shot via stdin:
 
@@ -383,11 +387,13 @@ persists across sessions in `~/.monocle/agent_history`.
 In the interactive REPL, lines starting with `/` are local management commands (handled
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,
-`/model` shows the current model (or `/model <id>` switches it for later turns), and
-`/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the model ids
-available to your account (fetched once at startup) — e.g. `/model cla<TAB>` narrows to
-matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
-list can't be fetched, completion just offers nothing (typing a full id still works).
+`/diag` shows diagnostics (served model, endpoint, latency, tokens, and step count) for
+the last turn, `/model` shows the current model (or `/model <id>` switches it for later
+turns), and `/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the
+model ids available to your account (fetched once at startup) — e.g. `/model cla<TAB>`
+narrows to matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in
+or the list can't be fetched, completion just offers nothing (typing a full id still
+works).
 
 ```bash
 monocle agent "summarize the TODOs in this repo" --workdir .

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -31,7 +31,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::agent::commands::{
     config_text, help_text, login_view, management_command, status_text, Management,
 };
-use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{
     shell_invocation, FsBackend, ShellExec, ShellResult, ToolContext, ToolOutcome, ToolRegistry,
@@ -39,6 +39,7 @@ use crate::agent::tools::{
 };
 use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
+use crate::commands::repl::{diag_output, TurnDiagnostics};
 use crate::credentials::Credentials;
 use crate::error::{AppError, Result};
 use crate::net::Client;
@@ -93,6 +94,9 @@ struct SessionState {
     /// True while a `prompt()` turn is executing for this session. Guards against
     /// concurrent prompts corrupting the `mem::take`-n conversation (see Fix #8).
     running: bool,
+    /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    /// first successful turn, mirroring `commands::agent::Repl.diagnostics`.
+    diagnostics: Option<TurnDiagnostics>,
 }
 
 /// The model id for a session: the client's `_meta["monocle.model"]` if present
@@ -154,6 +158,14 @@ impl MonocleAgent {
                 let login = login_view(&Credentials::new());
                 status_text(login.as_ref(), &model, DEFAULT_MAX_STEPS, &cwd, Some(key))
             }
+            Management::Diag => {
+                let sessions = self.sessions.borrow();
+                let diagnostics = sessions.get(key).map(|st| &st.diagnostics);
+                match diagnostics {
+                    Some(d) => diag_output(d),
+                    None => diag_output(&None),
+                }
+            }
         }
     }
 }
@@ -168,6 +180,10 @@ fn advertised_commands() -> Vec<acp::AvailableCommand> {
         acp::AvailableCommand::new(
             "config",
             "Show the session config (model, working directory)",
+        ),
+        acp::AvailableCommand::new(
+            "diag",
+            "Show diagnostics for the last turn (served model, endpoint, latency, tokens, and step count)",
         ),
     ]
 }
@@ -207,6 +223,7 @@ impl Agent for MonocleAgent {
                 cancel: Cancel::new(),
                 model: session_model(&args.meta),
                 running: false,
+                diagnostics: None,
             },
         );
         // Advertise the locally-handled management commands so an ACP client can
@@ -298,6 +315,9 @@ impl Agent for MonocleAgent {
             let mut observer = AcpObserver {
                 updates: updates.clone(),
                 sid: sid.clone(),
+                served_model: None,
+                usage: None,
+                steps: 0,
             };
             let mut approver = AcpApprover {
                 calls: updates,
@@ -306,8 +326,17 @@ impl Agent for MonocleAgent {
             };
             let session = match try_access_token(&Client::new(), &Credentials::new()) {
                 Ok(s) => s,
-                Err(e) => return (convo, Err(e)),
+                Err(e) => return (convo, Err(e), None),
             };
+            // Captured before `MonocleProvider::from_session` consumes `session` —
+            // `/diag`'s endpoint must reflect the request this turn actually sent
+            // (the full URL `MonocleProvider` posts to, not just the router base),
+            // mirroring `commands::agent::Repl::run_turn`.
+            let turn_endpoint = format!(
+                "{}{}",
+                session.router_url,
+                crate::endpoints::CHAT_COMPLETIONS
+            );
             convo.push(Message::user(user));
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
@@ -326,9 +355,30 @@ impl Agent for MonocleAgent {
                     cancel: cancel.clone(),
                 }));
             }
+            // Wrapped tightly around the agent-core loop itself — this is what
+            // `/diag`'s `Latency:` line reports.
+            let started = std::time::Instant::now();
+            let requested_model = model.clone();
             let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
-            (convo, result)
+            // A hard error (e.g. a network failure) must not leave stale
+            // diagnostics from an earlier successful turn silently displayable
+            // via `/diag` — mirroring `commands::agent::Repl::run_turn`. A
+            // cancelled or step-budget-exhausted turn is NOT an error
+            // (`Ok(RunStop::Cancelled | RunStop::MaxSteps)`) and still gets
+            // diagnostics, exactly like the CLI REPL.
+            let diagnostics = match &result {
+                Ok(_) => Some(TurnDiagnostics::for_agent(
+                    requested_model,
+                    observer.served_model.clone(),
+                    turn_endpoint,
+                    started.elapsed().as_millis(),
+                    observer.usage.clone(),
+                    observer.steps,
+                )),
+                Err(_) => None,
+            };
+            (convo, result, diagnostics)
         })
         .await
         .map_err(|_| acp::Error::internal_error())?;
@@ -336,10 +386,13 @@ impl Agent for MonocleAgent {
         // ALWAYS write the (possibly partial) conversation back and release the
         // running guard — for BOTH Ok and Err — so tools already executed this
         // turn are not replayed on the client's retry (Fix #1). Then propagate.
-        let (updated_convo, result) = joined;
+        // `diagnostics` is unconditionally overwritten too (`None` on error), so
+        // a failed turn never leaves stale `/diag` output from an earlier turn.
+        let (updated_convo, result, diagnostics) = joined;
         if let Some(st) = self.sessions.borrow_mut().get_mut(&key) {
             st.convo = updated_convo;
             st.running = false;
+            st.diagnostics = diagnostics;
         }
 
         // The loop reports the real stop reason — a cancel landing on the final
@@ -378,6 +431,13 @@ fn tool_kind(name: &str) -> acp::ToolKind {
 struct AcpObserver {
     updates: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
+    /// Turn-scoped accumulator for `/diag`, mirroring
+    /// `commands::agent::CliObserver`: `Agent::run`'s tool-use loop can call
+    /// the LLM several times per turn (each a "step"), and these collect the
+    /// last-known served model plus a running token total across all of them.
+    served_model: Option<String>,
+    usage: Option<TokenUsage>,
+    steps: u32,
 }
 
 impl AcpObserver {
@@ -426,6 +486,27 @@ impl Observer for AcpObserver {
         self.send(acp::SessionUpdate::AgentThoughtChunk(
             acp::ContentChunk::new(acp::ContentBlock::from(msg.to_string())),
         ));
+    }
+    fn on_turn_step(&mut self, resp: &ChatResponse) {
+        self.steps += 1;
+        if let Some(model) = &resp.model {
+            self.served_model = Some(model.clone());
+        }
+        if let Some(u) = &resp.usage {
+            // Each step's `usage.prompt_tokens` reflects that step's *entire*
+            // re-sent conversation, so summing across steps overcounts
+            // "distinct prompt content" — but it's still the right number for
+            // "total tokens this turn billed across all its LLM calls", the
+            // practically useful DX/cost question, so it's summed anyway.
+            let acc = self.usage.get_or_insert(TokenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            });
+            acc.prompt_tokens = acc.prompt_tokens.saturating_add(u.prompt_tokens);
+            acc.completion_tokens = acc.completion_tokens.saturating_add(u.completion_tokens);
+            acc.total_tokens = acc.total_tokens.saturating_add(u.total_tokens);
+        }
     }
 }
 
@@ -976,6 +1057,9 @@ mod tests {
         let observer = AcpObserver {
             updates: tx,
             sid: acp::SessionId::new("s"),
+            served_model: None,
+            usage: None,
+            steps: 0,
         };
         (observer, rx)
     }
@@ -1226,18 +1310,18 @@ mod tests {
     }
 
     #[test]
-    fn advertised_commands_names_help_status_config() {
+    fn advertised_commands_names_help_status_config_diag() {
         let names: Vec<String> = advertised_commands()
             .iter()
             .map(|c| c.name.clone())
             .collect();
-        assert_eq!(names, vec!["help", "status", "config"]);
+        assert_eq!(names, vec!["help", "status", "config", "diag"]);
     }
 
     #[test]
     fn new_session_advertises_management_commands() {
         // Drive the real `new_session` and drain the updates channel to confirm it
-        // enqueues an AvailableCommandsUpdate naming help/status/config.
+        // enqueues an AvailableCommandsUpdate naming help/status/config/diag.
         let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
         let agent = MonocleAgent::new(tx);
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1260,9 +1344,62 @@ mod tests {
             }
         }
         let names = names.expect("expected an AvailableCommandsUpdate notification");
-        for cmd in ["help", "status", "config"] {
+        for cmd in ["help", "status", "config", "diag"] {
             assert!(names.iter().any(|n| n == cmd), "missing {cmd} in {names:?}");
         }
+    }
+
+    /// Build a real session via `new_session` and return its key, so
+    /// `management_response`/session-state tests exercise the production
+    /// dispatch path instead of hand-rolling a `SessionState`.
+    fn new_session_key(agent: &MonocleAgent) -> String {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let resp = rt
+            .block_on(agent.new_session(acp::NewSessionRequest::new("/work")))
+            .expect("new_session");
+        resp.session_id.0.to_string()
+    }
+
+    #[test]
+    fn management_response_diag_shows_nothing_yet_before_first_turn() {
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let agent = MonocleAgent::new(tx);
+        let key = new_session_key(&agent);
+
+        let out = agent.management_response(&key, Management::Diag);
+        assert!(out.contains("No response yet"), "{out}");
+    }
+
+    /// `/diag` (ACP's `Management::Diag` arm) must render the same
+    /// `TurnDiagnostics` shape the CLI REPL's `/diag` does — this drives
+    /// `management_response` against a session whose `diagnostics` was
+    /// populated (as `prompt()`'s turn-execution path does on a successful
+    /// turn), confirming the wiring reaches `diag_output`/`format_diag`.
+    #[test]
+    fn management_response_diag_shows_stored_diagnostics() {
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let agent = MonocleAgent::new(tx);
+        let key = new_session_key(&agent);
+
+        {
+            let mut sessions = agent.sessions.borrow_mut();
+            let st = sessions.get_mut(&key).expect("session exists");
+            st.diagnostics = Some(TurnDiagnostics::for_agent(
+                DEFAULT_MODEL.to_string(),
+                Some("claude-sonnet-4-6".to_string()),
+                "https://api.example.com/v1/chat/completions".to_string(),
+                42,
+                None,
+                2,
+            ));
+        }
+
+        let out = agent.management_response(&key, Management::Diag);
+        assert!(out.contains("Steps: 2"), "{out}");
+        assert!(out.contains("claude-sonnet-4-6"), "{out}");
+        assert!(out.contains("42ms"), "{out}");
     }
 
     #[test]

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -69,6 +69,7 @@ pub(crate) fn help_text() -> String {
         "  /help    show this help",
         "  /config  show session config (model, max-steps, workdir, session)",
         "  /status  show login status and session config",
+        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens)",
         "  /model   show the current model, or `/model <id>` to switch it",
         "  /exit    quit the REPL (also /quit, Ctrl-D)",
     ]
@@ -146,7 +147,7 @@ mod tests {
     #[test]
     fn help_text_lists_each_command() {
         let h = help_text();
-        for cmd in ["/help", "/config", "/status", "/model", "/exit"] {
+        for cmd in ["/help", "/config", "/status", "/diag", "/model", "/exit"] {
             assert!(h.contains(cmd), "help missing {cmd}: {h}");
         }
     }

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -1,4 +1,5 @@
-//! Shared management commands (`help`/`status`/`config`) for the agent surfaces.
+//! Shared management commands (`help`/`status`/`config`/`diag`) for the agent
+//! surfaces.
 //!
 //! These are handled **locally** — never sent to the agent/LLM — by BOTH the
 //! interactive REPL (`crate::commands::agent`) and the ACP server (`crate::acp`).
@@ -18,6 +19,7 @@ pub(crate) enum Management {
     Help,
     Status,
     Config,
+    Diag,
 }
 
 /// Recognize a management-command invocation. The leading `/` is REQUIRED so a
@@ -31,6 +33,7 @@ pub(crate) fn management_command(input: &str) -> Option<Management> {
         "/help" => Some(Management::Help),
         "/status" => Some(Management::Status),
         "/config" => Some(Management::Config),
+        "/diag" => Some(Management::Diag),
         _ => None,
     }
 }
@@ -69,7 +72,7 @@ pub(crate) fn help_text() -> String {
         "  /help    show this help",
         "  /config  show session config (model, max-steps, workdir, session)",
         "  /status  show login status and session config",
-        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens)",
+        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens, and step count)",
         "  /model   show the current model, or `/model <id>` to switch it",
         "  /exit    quit the REPL (also /quit, Ctrl-D)",
     ]
@@ -124,6 +127,7 @@ mod tests {
         assert_eq!(management_command("/help"), Some(Management::Help));
         assert_eq!(management_command("/status"), Some(Management::Status));
         assert_eq!(management_command("/config"), Some(Management::Config));
+        assert_eq!(management_command("/diag"), Some(Management::Diag));
     }
 
     #[test]
@@ -137,6 +141,7 @@ mod tests {
         assert_eq!(management_command("help"), None);
         assert_eq!(management_command("status"), None);
         assert_eq!(management_command("config"), None);
+        assert_eq!(management_command("diag"), None);
         assert_eq!(management_command("hello"), None);
         assert_eq!(management_command(""), None);
         assert_eq!(management_command("/bogus"), None);

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
-use crate::agent::providers::{ChatRequest, LlmProvider, Message};
+use crate::agent::providers::{ChatRequest, ChatResponse, LlmProvider, Message};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::error::Result;
 
@@ -62,6 +62,12 @@ pub trait Observer {
     /// A meta/control notice (stopped, cancelled) — NOT model answer text, so the
     /// CLI keeps it off the stdout answer channel.
     fn on_notice(&mut self, _msg: &str) {}
+    /// Called once per LLM call this turn makes (a turn can be several steps
+    /// when tool calls happen) — carries whatever metadata this step's response
+    /// reported (served model, token usage), so a caller can accumulate turn-level
+    /// diagnostics. Default no-op; `Silent` and any observer that doesn't care
+    /// about diagnostics need no changes.
+    fn on_turn_step(&mut self, _resp: &ChatResponse) {}
 }
 
 pub struct Silent;
@@ -164,6 +170,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             let resp = self
                 .provider
                 .chat_stream(&req, &mut |delta| observer.on_text_delta(delta))?;
+            observer.on_turn_step(&resp);
 
             // A mid-stream drop was salvaged into a truncated response
             // (monocle-cli#59): tool_calls are already dropped, so this falls

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -188,8 +188,9 @@ impl Repl<'_> {
         // Fresh token each turn (get_access_token refreshes if near expiry).
         let auth = get_access_token(self.client, self.creds);
         // Captured before `MonocleProvider::from_session` consumes `auth` —
-        // `/diag`'s endpoint must reflect the request this turn actually sent.
-        let turn_endpoint = auth.router_url.clone();
+        // `/diag`'s endpoint must reflect the request this turn actually sent
+        // (the full URL `MonocleProvider` posts to, not just the router base).
+        let turn_endpoint = format!("{}{}", auth.router_url, crate::endpoints::CHAT_COMPLETIONS);
         let provider = MonocleProvider::from_session(auth);
         let agent = Agent::with_max_steps(
             &provider,
@@ -231,14 +232,14 @@ impl Repl<'_> {
         out.write_all(b"\n")?;
         out.flush()?;
 
-        self.diagnostics = Some(TurnDiagnostics {
-            requested_model: self.model.clone(),
-            served_model: observer.served_model.clone(),
-            endpoint: turn_endpoint,
-            latency_ms: started.elapsed().as_millis(),
-            usage: observer.usage.clone(),
-            steps: Some(observer.steps),
-        });
+        self.diagnostics = Some(TurnDiagnostics::for_agent(
+            self.model.clone(),
+            observer.served_model.clone(),
+            turn_endpoint,
+            started.elapsed().as_millis(),
+            observer.usage.clone(),
+            observer.steps,
+        ));
 
         // Persist this turn's new messages (append-only).
         if let Some(store) = &self.session {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
-use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent, AllowAll, Approver, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
@@ -18,7 +18,9 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{
+    diag_output, mode_banner, run_repl, LoopControl, ModelReplHelper, TurnDiagnostics, PROMPT,
+};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -35,7 +37,15 @@ pub struct AgentOptions {
     pub auto_approve: bool,
 }
 
-struct CliObserver;
+/// Turn-scoped accumulator for `/diag`: `Agent::run`'s tool-use loop can call
+/// the LLM several times per turn (each a "step"), and this collects the
+/// last-known served model plus a running token total across all of them.
+#[derive(Default)]
+struct CliObserver {
+    served_model: Option<String>,
+    usage: Option<TokenUsage>,
+    steps: u32,
+}
 impl Observer for CliObserver {
     fn on_text_delta(&mut self, delta: &str) {
         // Stream assistant text to stdout as it arrives (tool progress goes to stderr).
@@ -63,12 +73,35 @@ impl Observer for CliObserver {
         // Control notices go to stderr — stdout stays the clean answer channel.
         eprintln!("\n{}", c::dim(msg));
     }
+    fn on_turn_step(&mut self, resp: &ChatResponse) {
+        self.steps += 1;
+        if let Some(model) = &resp.model {
+            self.served_model = Some(model.clone());
+        }
+        if let Some(u) = &resp.usage {
+            // Each step's `usage.prompt_tokens` reflects that step's *entire*
+            // re-sent conversation, so summing across steps overcounts
+            // "distinct prompt content" — but it's still the right number for
+            // "total tokens this turn billed across all its LLM calls", the
+            // practically useful DX/cost question, so it's summed anyway.
+            let acc = self.usage.get_or_insert(TokenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            });
+            acc.prompt_tokens = acc.prompt_tokens.saturating_add(u.prompt_tokens);
+            acc.completion_tokens = acc.completion_tokens.saturating_add(u.completion_tokens);
+            acc.total_tokens = acc.total_tokens.saturating_add(u.total_tokens);
+        }
+    }
 }
 
 /// The slash commands the REPL understands, offered by the completer and shown
 /// by `/help`. Kept here (next to the dispatcher) so completion never drifts from
 /// what `dispatch_command` / `parse_model_command` actually handle.
-const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
+const SLASH_COMMANDS: &[&str] = &[
+    "/help", "/config", "/status", "/model", "/diag", "/exit", "/quit",
+];
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
 /// tool call and reads a y/N answer from stdin. Default (empty / non-y / EOF) is
@@ -136,6 +169,9 @@ struct Repl<'a> {
     auto_approve: bool,
     /// Whether this session runs on an interactive TTY (can prompt for approval).
     interactive: bool,
+    /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    /// first successful turn, mirroring `monocle chat`'s REPL.
+    diagnostics: Option<TurnDiagnostics>,
 }
 
 impl Repl<'_> {
@@ -151,6 +187,9 @@ impl Repl<'_> {
     fn run_turn(&mut self, user: String) -> Result<()> {
         // Fresh token each turn (get_access_token refreshes if near expiry).
         let auth = get_access_token(self.client, self.creds);
+        // Captured before `MonocleProvider::from_session` consumes `auth` —
+        // `/diag`'s endpoint must reflect the request this turn actually sent.
+        let turn_endpoint = auth.router_url.clone();
         let provider = MonocleProvider::from_session(auth);
         let agent = Agent::with_max_steps(
             &provider,
@@ -174,9 +213,16 @@ impl Repl<'_> {
             } else {
                 &mut allow
             };
-        if let Err(e) = agent.run(&mut self.convo, approver, &mut CliObserver, &self.cancel) {
+        // Wrapped tightly around the agent-core loop itself — this is what
+        // `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
+        let mut observer = CliObserver::default();
+        if let Err(e) = agent.run(&mut self.convo, approver, &mut observer, &self.cancel) {
             // Roll back this failed turn's (partial) messages so a retry — and the
-            // persisted session — stay well-formed.
+            // persisted session — stay well-formed. A failed turn must not leave
+            // stale diagnostics from an earlier successful turn silently
+            // displayable via `/diag`, mirroring `monocle chat`'s REPL.
+            self.diagnostics = None;
             self.convo.truncate(mark);
             return Err(e);
         }
@@ -184,6 +230,15 @@ impl Repl<'_> {
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
         out.flush()?;
+
+        self.diagnostics = Some(TurnDiagnostics {
+            requested_model: self.model.clone(),
+            served_model: observer.served_model.clone(),
+            endpoint: turn_endpoint,
+            latency_ms: started.elapsed().as_millis(),
+            usage: observer.usage.clone(),
+            steps: Some(observer.steps),
+        });
 
         // Persist this turn's new messages (append-only).
         if let Some(store) = &self.session {
@@ -201,6 +256,7 @@ enum Command {
     Help,
     Config,
     Status,
+    Diag,
     Quit,
     Unknown(String),
     /// Not a slash command — send it to the agent as a normal turn.
@@ -217,6 +273,7 @@ fn dispatch_command(input: &str) -> Command {
         "/help" => Command::Help,
         "/config" => Command::Config,
         "/status" => Command::Status,
+        "/diag" => Command::Diag,
         "/exit" | "/quit" => Command::Quit,
         other => Command::Unknown(other.to_string()),
     }
@@ -287,6 +344,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         persisted,
         auto_approve: opts.auto_approve,
         interactive,
+        diagnostics: None,
     };
 
     // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
@@ -398,6 +456,10 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                 );
                 Ok(LoopControl::Continue)
             }
+            Command::Diag => {
+                eprintln!("{}", diag_output(&repl.diagnostics));
+                Ok(LoopControl::Continue)
+            }
             Command::Unknown(cmd) => {
                 eprintln!("unknown command: {cmd} (try /help)");
                 Ok(LoopControl::Continue)
@@ -446,6 +508,7 @@ mod tests {
         assert_eq!(dispatch_command("/help"), Command::Help);
         assert_eq!(dispatch_command("/config"), Command::Config);
         assert_eq!(dispatch_command("/status"), Command::Status);
+        assert_eq!(dispatch_command("/diag"), Command::Diag);
         assert_eq!(dispatch_command("/quit"), Command::Quit);
         assert_eq!(dispatch_command("/exit"), Command::Quit);
     }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,13 +5,16 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, TokenUsage,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{
+    handle_diag_command, mode_banner, run_repl, LoopControl, ModelReplHelper, TurnDiagnostics,
+    PROMPT,
+};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -159,61 +162,34 @@ fn resolve_repl_attachments(
 
 /// The slash commands the REPL understands. `/model` mirrors `monocle
 /// agent`'s REPL (switches the model for subsequent turns); `/diag` shows
-/// diagnostics for the last turn; chat still has no `/help`/`/config`/`/status`.
-const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/diag", "/exit", "/quit"];
+/// diagnostics for the last turn; `/help` (re-)prints the onboarding block
+/// shown at REPL startup — chat still has no `/config`/`/status` (those are
+/// agent-specific session state with no chat equivalent).
+const CHAT_SLASH_COMMANDS: &[&str] = &["/help", "/model", "/diag", "/exit", "/quit"];
 
-/// Diagnostics for the most recently completed turn, shown on demand by
-/// `/diag` — REPL-only, overwritten each turn (no history is kept). Built
-/// fresh after every successful turn in both `run_completions_chat` and
-/// `run_responses_chat`; `served_model`/`usage` stay `None` wherever the
-/// backend doesn't report them (the `--responses` path reports neither today
-/// — see module docs on `responses_api::ResponsesReply`).
-struct TurnDiagnostics {
-    requested_model: String,
-    served_model: Option<String>,
-    endpoint: String,
-    latency_ms: u128,
-    usage: Option<TokenUsage>,
+/// The onboarding block printed once at REPL startup (both `run_completions_chat`
+/// and `run_responses_chat`) and re-printed on demand by `/help` — one string,
+/// two call sites, so the two never drift.
+fn chat_help_text() -> String {
+    [
+        "Type your message. Press Ctrl+D to exit.".to_string(),
+        "↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input."
+            .to_string(),
+        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+            .to_string(),
+        "/help shows this message again.".to_string(),
+    ]
+    .join("\n")
 }
 
-/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
-/// `--responses` REPL's prior-history replay). Lines for data the backend
-/// didn't report are omitted entirely — never printed as `None`/`null`.
-fn format_diag(d: &TurnDiagnostics) -> String {
-    let mut lines = vec![
-        "--- diag ---".to_string(),
-        format!("Endpoint: {}", d.endpoint),
-        format!("Requested model: {}", d.requested_model),
-    ];
-    if let Some(served) = &d.served_model {
-        lines.push(format!("Served model: {served}"));
-    }
-    lines.push(format!("Latency: {}ms", d.latency_ms));
-    if let Some(u) = &d.usage {
-        lines.push(format!(
-            "Tokens: {} prompt + {} completion = {} total",
-            u.prompt_tokens, u.completion_tokens, u.total_tokens
-        ));
-    }
-    lines.push("--- end diag ---".to_string());
-    lines.join("\n")
-}
-
-/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
-/// diagnostics (or a "nothing yet" hint before the first turn). Returns
-/// `true` if this input was consumed as `/diag`, mirroring
-/// `model_list::handle_model_command`'s contract.
-fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
-    if trimmed != "/diag" {
+/// Handle a `/help` line if `trimmed` is one: (re-)prints the onboarding
+/// block. Returns `true` if this input was consumed as `/help`, mirroring
+/// `handle_diag_command`'s contract.
+fn handle_help_command(trimmed: &str) -> bool {
+    if trimmed != "/help" {
         return false;
     }
-    match diagnostics {
-        None => eprintln!(
-            "{}",
-            crate::colors::dim("No response yet — send a message first.")
-        ),
-        Some(d) => eprintln!("{}", format_diag(d)),
-    }
+    eprintln!("{}", chat_help_text());
     true
 }
 
@@ -237,6 +213,9 @@ fn dispatch_chat_command(
         return Some(LoopControl::Continue);
     }
     if handle_diag_command(trimmed, diagnostics) {
+        return Some(LoopControl::Continue);
+    }
+    if handle_help_command(trimmed) {
         return Some(LoopControl::Continue);
     }
     None
@@ -370,11 +349,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     if let Some(sp) = &system_prompt {
         eprintln!("System prompt loaded ({} chars)", sp.chars().count());
     }
-    eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
-    eprintln!(
-        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
-    );
+    eprintln!("{}", chat_help_text());
     eprintln!("---");
     eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
@@ -463,6 +438,8 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                     endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
                     latency_ms: started.elapsed().as_millis(),
                     usage: resp.usage.clone(),
+                    // A chat turn is always exactly one LLM call.
+                    steps: None,
                 });
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
@@ -561,9 +538,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     // Interactive REPL.
     eprintln!("Monocle Chat — Responses API (model: {model})");
     eprintln!("jarvice: {jarvice_url}");
-    eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
-    eprintln!("/diag shows diagnostics (endpoint, latency) for the last turn.");
+    eprintln!("{}", chat_help_text());
     eprintln!("The server owns this conversation's thread — no local history is resent.");
     eprintln!("---");
 
@@ -658,6 +633,8 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     endpoint: format!("{jarvice_url}/api/responses"),
                     latency_ms: started.elapsed().as_millis(),
                     usage: None,
+                    // A chat turn is always exactly one LLM call.
+                    steps: None,
                 });
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
@@ -744,10 +721,9 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 #[cfg(test)]
 mod tests {
     use super::{
-        dispatch_chat_command, format_diag, resolve_max_tokens, resolve_repl_attachments,
-        TurnDiagnostics,
+        chat_help_text, dispatch_chat_command, handle_help_command, resolve_max_tokens,
+        resolve_repl_attachments, TurnDiagnostics,
     };
-    use crate::agent::providers::TokenUsage;
     use crate::commands::repl::LoopControl;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
@@ -778,6 +754,30 @@ mod tests {
         let mut model = "monocle-auto".to_string();
         let diagnostics: Option<TurnDiagnostics> = None;
         assert!(dispatch_chat_command("hello there", &mut model, &diagnostics).is_none());
+    }
+
+    #[test]
+    fn dispatch_chat_command_recognizes_help() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(matches!(
+            dispatch_chat_command("/help", &mut model, &diagnostics),
+            Some(LoopControl::Continue)
+        ));
+    }
+
+    #[test]
+    fn handle_help_command_only_consumes_exact_slash_help() {
+        assert!(!handle_help_command("not help"));
+        assert!(handle_help_command("/help"));
+    }
+
+    #[test]
+    fn chat_help_text_mentions_the_documented_commands() {
+        let text = chat_help_text();
+        for cmd in ["/model", "/diag", "/help", "/quit", "/exit"] {
+            assert!(text.contains(cmd), "help text missing {cmd}: {text}");
+        }
     }
 
     #[test]
@@ -842,57 +842,6 @@ mod tests {
     fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
         let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
         assert!(err.contains("not found"), "unexpected message: {err}");
-    }
-
-    #[test]
-    fn format_diag_omits_served_model_and_usage_when_unavailable() {
-        // The `--responses` path: only endpoint/requested-model/latency are
-        // ever known — served model and usage must never render as a literal
-        // "None"/"null", they're just absent lines.
-        let d = TurnDiagnostics {
-            requested_model: "monocle-auto".to_string(),
-            served_model: None,
-            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
-            latency_ms: 842,
-            usage: None,
-        };
-        let block = format_diag(&d);
-        assert_eq!(
-            block,
-            "--- diag ---\n\
-             Endpoint: https://acme.monocle-ai.com/api/responses\n\
-             Requested model: monocle-auto\n\
-             Latency: 842ms\n\
-             --- end diag ---"
-        );
-        assert!(!block.contains("None"));
-        assert!(!block.contains("null"));
-    }
-
-    #[test]
-    fn format_diag_shows_served_model_and_usage_when_present() {
-        let d = TurnDiagnostics {
-            requested_model: "monocle-auto".to_string(),
-            served_model: Some("claude-sonnet-4-6".to_string()),
-            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
-            latency_ms: 1234,
-            usage: Some(TokenUsage {
-                prompt_tokens: 120,
-                completion_tokens: 45,
-                total_tokens: 165,
-            }),
-        };
-        let block = format_diag(&d);
-        assert_eq!(
-            block,
-            "--- diag ---\n\
-             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
-             Requested model: monocle-auto\n\
-             Served model: claude-sonnet-4-6\n\
-             Latency: 1234ms\n\
-             Tokens: 120 prompt + 45 completion = 165 total\n\
-             --- end diag ---"
-        );
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -169,13 +169,21 @@ const CHAT_SLASH_COMMANDS: &[&str] = &["/help", "/model", "/diag", "/exit", "/qu
 
 /// The onboarding block printed once at REPL startup (both `run_completions_chat`
 /// and `run_responses_chat`) and re-printed on demand by `/help` — one string,
-/// two call sites, so the two never drift.
+/// two call sites, so the two never drift. The Tab-completion line is built
+/// from `CHAT_SLASH_COMMANDS` itself (not hand-typed) so it can't silently
+/// under-report a command again the way it previously did. The `/diag` line
+/// deliberately doesn't itemize which fields it shows — `run_responses_chat`
+/// never learns a served model or token usage (see `TurnDiagnostics` docs),
+/// so a shared, itemized promise would overclaim for that path; `format_diag`
+/// already self-describes by omitting whatever the backend didn't report.
 fn chat_help_text() -> String {
     [
         "Type your message. Press Ctrl+D to exit.".to_string(),
-        "↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input."
-            .to_string(),
-        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+        format!(
+            "↑/↓ history, Tab completes {} — a multi-line paste is one input.",
+            CHAT_SLASH_COMMANDS.join(", ")
+        ),
+        "/diag shows diagnostics for the last turn (only what the backend reports is shown)."
             .to_string(),
         "/help shows this message again.".to_string(),
     ]
@@ -432,15 +440,13 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         let started = std::time::Instant::now();
         match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
             Ok(resp) => {
-                diagnostics = Some(TurnDiagnostics {
-                    requested_model: model.clone(),
-                    served_model: resp.model.clone(),
-                    endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
-                    latency_ms: started.elapsed().as_millis(),
-                    usage: resp.usage.clone(),
-                    // A chat turn is always exactly one LLM call.
-                    steps: None,
-                });
+                diagnostics = Some(TurnDiagnostics::for_chat(
+                    model.clone(),
+                    resp.model.clone(),
+                    format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    started.elapsed().as_millis(),
+                    resp.usage.clone(),
+                ));
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -627,15 +633,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         let started = std::time::Instant::now();
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
-                diagnostics = Some(TurnDiagnostics {
-                    requested_model: model.clone(),
-                    served_model: None,
-                    endpoint: format!("{jarvice_url}/api/responses"),
-                    latency_ms: started.elapsed().as_millis(),
-                    usage: None,
-                    // A chat turn is always exactly one LLM call.
-                    steps: None,
-                });
+                diagnostics = Some(TurnDiagnostics::for_chat(
+                    model.clone(),
+                    None,
+                    format!("{jarvice_url}/api/responses"),
+                    started.elapsed().as_millis(),
+                    None,
+                ));
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -15,6 +15,7 @@ use rustyline::{CompletionType, Config, Context, Editor, Helper, Validator};
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+use crate::agent::providers::TokenUsage;
 use crate::colors as c;
 use crate::commands::model_list::fuzzy_model_candidates;
 use crate::error::Result;
@@ -44,6 +45,76 @@ pub fn mode_banner(label: &str, colorize: impl Fn(&str) -> String) -> String {
 pub enum LoopControl {
     Continue,
     Quit,
+}
+
+/// Diagnostics for the most recently completed turn, shown on demand by
+/// `/diag` — REPL-only, overwritten each turn (no history is kept). Shared by
+/// `monocle chat` (built fresh after every successful turn in both
+/// `run_completions_chat` and `run_responses_chat`, `steps` always `None`
+/// since a chat turn is exactly one LLM call) and `monocle agent` (`steps`
+/// accumulated across the agent-core loop's tool-use steps, since one turn
+/// can make several LLM calls). `served_model`/`usage` stay `None` wherever
+/// the backend doesn't report them (the `--responses` path reports neither
+/// today — see module docs on `responses_api::ResponsesReply`).
+pub struct TurnDiagnostics {
+    pub requested_model: String,
+    pub served_model: Option<String>,
+    pub endpoint: String,
+    pub latency_ms: u128,
+    pub usage: Option<TokenUsage>,
+    /// How many LLM calls this turn made. `None` for chat (always exactly
+    /// one); `Some(n)` for agent, whose tool-use loop can call the LLM
+    /// multiple times per turn.
+    pub steps: Option<u32>,
+}
+
+/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
+/// `--responses` REPL's prior-history replay). Lines for data the backend
+/// didn't report are omitted entirely — never printed as `None`/`null`.
+pub fn format_diag(d: &TurnDiagnostics) -> String {
+    let mut lines = vec![
+        "--- diag ---".to_string(),
+        format!("Endpoint: {}", d.endpoint),
+        format!("Requested model: {}", d.requested_model),
+    ];
+    if let Some(served) = &d.served_model {
+        lines.push(format!("Served model: {served}"));
+    }
+    lines.push(format!("Latency: {}ms", d.latency_ms));
+    if let Some(steps) = d.steps {
+        lines.push(format!("Steps: {steps}"));
+    }
+    if let Some(u) = &d.usage {
+        lines.push(format!(
+            "Tokens: {} prompt + {} completion = {} total",
+            u.prompt_tokens, u.completion_tokens, u.total_tokens
+        ));
+    }
+    lines.push("--- end diag ---".to_string());
+    lines.join("\n")
+}
+
+/// Renders `/diag` output for either REPL: the last turn's diagnostics, or
+/// a dim "nothing yet" hint before the first turn.
+pub fn diag_output(diagnostics: &Option<TurnDiagnostics>) -> String {
+    match diagnostics {
+        None => crate::colors::dim("No response yet — send a message first."),
+        Some(d) => format_diag(d),
+    }
+}
+
+/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
+/// diagnostics (or a "nothing yet" hint before the first turn). Returns
+/// `true` if this input was consumed as `/diag`, mirroring
+/// `model_list::handle_model_command`'s contract. `monocle chat`'s dispatch
+/// is a plain boolean chain, so this keeps that contract; `monocle agent`'s
+/// `Command`-enum dispatch calls `diag_output` directly instead.
+pub fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
+    if trimmed != "/diag" {
+        return false;
+    }
+    eprintln!("{}", diag_output(diagnostics));
+    true
 }
 
 /// Ghost-text hint shared by both REPL helpers' `Hinter` impls: given the
@@ -432,5 +503,115 @@ mod tests {
 
         let line = "/model sonnet";
         assert_eq!(h.hint(line, line.len(), &ctx), None);
+    }
+
+    #[test]
+    fn format_diag_omits_served_model_and_usage_when_unavailable() {
+        // The `--responses` path: only endpoint/requested-model/latency are
+        // ever known — served model and usage must never render as a literal
+        // "None"/"null", they're just absent lines.
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
+            latency_ms: 842,
+            usage: None,
+            steps: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://acme.monocle-ai.com/api/responses\n\
+             Requested model: monocle-auto\n\
+             Latency: 842ms\n\
+             --- end diag ---"
+        );
+        assert!(!block.contains("None"));
+        assert!(!block.contains("null"));
+    }
+
+    #[test]
+    fn format_diag_shows_served_model_and_usage_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            latency_ms: 1234,
+            usage: Some(TokenUsage {
+                prompt_tokens: 120,
+                completion_tokens: 45,
+                total_tokens: 165,
+            }),
+            steps: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 1234ms\n\
+             Tokens: 120 prompt + 45 completion = 165 total\n\
+             --- end diag ---"
+        );
+    }
+
+    /// `steps` is agent-only — when present it renders between "Latency" and
+    /// "Tokens", since an agent turn's step count is a fact about the turn as
+    /// a whole (like latency), not part of the token accounting.
+    #[test]
+    fn format_diag_shows_steps_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            latency_ms: 2500,
+            usage: Some(TokenUsage {
+                prompt_tokens: 300,
+                completion_tokens: 80,
+                total_tokens: 380,
+            }),
+            steps: Some(3),
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/agent\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 2500ms\n\
+             Steps: 3\n\
+             Tokens: 300 prompt + 80 completion = 380 total\n\
+             --- end diag ---"
+        );
+    }
+
+    #[test]
+    fn diag_output_shows_nothing_yet_hint_before_first_turn() {
+        let out = diag_output(&None);
+        assert!(out.contains("No response yet"));
+    }
+
+    #[test]
+    fn diag_output_renders_format_diag_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            latency_ms: 10,
+            usage: None,
+            steps: Some(1),
+        };
+        assert!(diag_output(&Some(d)).contains("Steps: 1"));
+    }
+
+    #[test]
+    fn handle_diag_command_only_consumes_exact_slash_diag() {
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(!handle_diag_command("not diag", &diagnostics));
+        assert!(handle_diag_command("/diag", &diagnostics));
     }
 }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -68,6 +68,48 @@ pub struct TurnDiagnostics {
     pub steps: Option<u32>,
 }
 
+impl TurnDiagnostics {
+    /// A chat turn is always exactly one LLM call — `steps` is never
+    /// meaningful here, so callers don't set it themselves (and can't get it
+    /// wrong the way a bare struct literal would let them).
+    pub fn for_chat(
+        requested_model: String,
+        served_model: Option<String>,
+        endpoint: String,
+        latency_ms: u128,
+        usage: Option<TokenUsage>,
+    ) -> Self {
+        Self {
+            requested_model,
+            served_model,
+            endpoint,
+            latency_ms,
+            usage,
+            steps: None,
+        }
+    }
+
+    /// An agent turn's tool-use loop can call the LLM several times —
+    /// `steps` records how many this turn actually took.
+    pub fn for_agent(
+        requested_model: String,
+        served_model: Option<String>,
+        endpoint: String,
+        latency_ms: u128,
+        usage: Option<TokenUsage>,
+        steps: u32,
+    ) -> Self {
+        Self {
+            requested_model,
+            served_model,
+            endpoint,
+            latency_ms,
+            usage,
+            steps: Some(steps),
+        }
+    }
+}
+
 /// Render `/diag`'s bordered block (same `--- ... ---` framing as the
 /// `--responses` REPL's prior-history replay). Lines for data the backend
 /// didn't report are omitted entirely — never printed as `None`/`null`.

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -77,6 +77,42 @@ fn loop_executes_tool_then_returns_final_answer() {
 }
 
 #[test]
+fn on_turn_step_fires_once_per_llm_call_in_a_multi_step_turn() {
+    // Same tool-call-then-final-answer script as
+    // `loop_executes_tool_then_returns_final_answer`: the fake provider is
+    // called twice (once for the tool-call step, once for the final-answer
+    // step) — `on_turn_step` must fire exactly once per LLM call, i.e. twice.
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("done")
+        } else {
+            tool_call_response(
+                "call_1",
+                "write_file",
+                json!({"path":"out.txt","content":"hi"}),
+            )
+        }
+    });
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = agent(&provider, &tools, dir.path(), 20);
+
+    let mut rec = RecordingObserver::new();
+    let stop = agent
+        .run(
+            &mut vec![Message::user("write out.txt")],
+            &mut AllowAll,
+            &mut rec,
+            &Cancel::new(),
+        )
+        .unwrap();
+
+    assert!(matches!(stop, RunStop::EndTurn));
+    let steps: Vec<String> = rec.events().into_iter().filter(|e| e == "step").collect();
+    assert_eq!(steps.len(), 2, "expected one on_turn_step per LLM call");
+}
+
+#[test]
 fn denied_side_effecting_tool_is_not_executed() {
     let provider = FakeProvider::new(|req| {
         if has_tool_result(req) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -289,7 +289,8 @@ impl FsBackend for InMemoryFs {
 /// can assert exactly which tool calls the agent made and in what order:
 /// - `call:<name>:<args-compact-json>`
 /// - `result:<name>:<is_error>`
-/// - `text:<delta>` · `notice:<msg>`
+/// - `text:<delta>` · `notice:<msg>` · `step` (one per `on_turn_step` call — once
+///   per LLM call the turn makes)
 #[derive(Default)]
 pub struct RecordingObserver {
     events: Vec<String>,
@@ -319,5 +320,8 @@ impl Observer for RecordingObserver {
     }
     fn on_notice(&mut self, msg: &str) {
         self.events.push(format!("notice:{msg}"));
+    }
+    fn on_turn_step(&mut self, _resp: &ChatResponse) {
+        self.events.push("step".to_string());
     }
 }


### PR DESCRIPTION
## 요약
#98 위에 리베이스됨 (base를 그에 맞춰 설정 — #98의 `PROMPT`/모드 배너 변경에 의존).

- chat엔 `/diag`가 있지만 `/help`가 없었고, agent엔 `/help`/`/config`/`/status`가 있지만 `/diag`가 없었음. 이제 공통 베이스라인(`/help`, `/diag`, `/model`, `/exit`, `/quit`)을 양쪽 다 지원 — agent는 `/config`/`/status`를 agent 전용으로 유지(chat엔 대응 개념이 없는 agent 고유 세션 상태이므로).
- agent 모드에서 `/diag`가 동작하려면 agent-core의 tool-use 루프가 각 LLM 호출의 served model/token usage를 노출할 방법이 필요했음(chat은 항상 호출 1회지만 agent는 tool 사용 시 여러 번 호출 가능). `Observer::on_turn_step`(기본 no-op, 기존 observer는 변경 불필요) 추가, `Agent::run`의 각 `chat_stream` 호출 직후에 연결. `CliObserver`가 이제 턴 전체에 걸쳐 served model/token usage 합계/step 수를 누적하고, `TurnDiagnostics`의 새 `Steps: N` 줄로 노출(chat은 `None`, agent는 `Some(n)`).
- `TurnDiagnostics`/`format_diag`/`diag_output`을 `chat.rs`에서 공유 `repl.rs`로 이동 — 두 REPL이 `/diag`를 동일하게 렌더링.
- chat의 `/help`는 REPL 시작 시 이미 출력하던 온보딩 텍스트를 재사용(중복 없이).

## 코드 리뷰 피드백 반영 (7건)
- agent `/diag`의 Endpoint가 실제 요청 URL이 아닌 라우터 base URL만 표시하던 버그 수정.
- `chat_help_text()`가 `--responses` 경로에서 절대 없는 served model/tokens을 보여준다고 과도하게 약속하던 문제 수정.
- `chat_help_text()`의 Tab-completion 안내가 5개 명령어 중 3개만 나열하던 문제 — 상수에서 동적 생성하도록 수정.
- agent `/help` 텍스트가 "step count"를 누락하던 문제 수정.
- `TurnDiagnostics::for_chat()`/`::for_agent()` 생성자 추가 — `steps` 필드의 의미를 타입으로 명확히.
- ACP 표면(`monocle acp`)이 `/diag`를 광고하면서도 미지원이던 문제 — `Management::Diag`, `AcpObserver::on_turn_step`, 세션별 `diagnostics` 상태 추가로 실제 지원.
- (#98) `colors::orange()` 문서 오류, 배너 중복, 테스트 레이스 — 별도 커밋으로 #98에 반영됨.

## 테스트 계획
- [x] `cargo build --release`
- [x] `cargo test` (126 lib tests, ACP `/diag` 왕복 테스트 포함)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] #98 리베이스 후 import 충돌 2건 해결, 재검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)