### PR TITLE
fix: chat --responses 모드에서 tool_calls 조용히 드롭되는 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,12 @@ Notes:
 - **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
   endpoint has no equivalent fields (a warning is printed if you pass them).
 - **Tool calls aren't executed** — this mode doesn't run a tool loop yet; if a
-  tool-calling model requests one, a warning is printed to stderr naming it
-  instead of silently dropping it (see
+  tool-calling model requests one, a warning is printed to stderr — naming it
+  when its shape parses, or noting the count when it doesn't — instead of
+  silently dropping it (see
   [monocle-cli#101](https://github.com/warmblood-kr/monocle-cli/issues/101)).
+  `monocle agent` executes tools client-side today, if that's what you need
+  right now.
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ Notes:
   it's fully generated, unlike the plain chat path's live token stream.
 - **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
   endpoint has no equivalent fields (a warning is printed if you pass them).
+- **Tool calls aren't executed** — this mode doesn't run a tool loop yet; if a
+  tool-calling model requests one, a warning is printed to stderr naming it
+  instead of silently dropping it (see
+  [monocle-cli#101](https://github.com/warmblood-kr/monocle-cli/issues/101)).
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -200,7 +200,11 @@ fn parse_usage(data: &Value) -> Option<TokenUsage> {
 /// `call_{i}` from position when the wire delivered an empty one. Downstream (ACP)
 /// correlates `ToolCall` / permission / `ToolCallUpdate` by this id, so an empty id
 /// would silently break that correlation. Non-empty ids are left untouched.
-fn ensure_tool_call_ids(tool_calls: &mut [ToolCall]) {
+///
+/// `pub(crate)`: also called by `responses_api::parse_tool_calls` (monocle-cli#101),
+/// which parses `tool_calls` off jarvice's `/api/responses` reply against this same
+/// `ToolCall` type and must not silently diverge on id-normalization from this path.
+pub(crate) fn ensure_tool_call_ids(tool_calls: &mut [ToolCall]) {
     for (i, tc) in tool_calls.iter_mut().enumerate() {
         if tc.id.is_empty() {
             tc.id = format!("call_{i}");

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -494,6 +494,29 @@ pub fn chat_list_command(client: &Client, creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
+/// Surface (never silently drop) any `tool_calls` a `--responses` turn came
+/// back with (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only
+/// runs its MCP tool-execution loop on the streaming branch, and this client
+/// always sends `"stream": false`, so a tool-calling model's request goes
+/// unexecuted here. Actually executing tools in this mode is out of scope
+/// (tracked separately, monocle#274) — this just makes the drop visible
+/// instead of silent, on stderr like every other warning in this path, and
+/// degrades gracefully rather than erroring the turn.
+fn warn_dropped_tool_calls(reply: &crate::responses_api::ResponsesReply) {
+    if reply.tool_calls.is_empty() {
+        return;
+    }
+    let names = reply
+        .tool_calls
+        .iter()
+        .map(|tc| tc.function.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    eprintln!(
+        "⚠ model requested tool call(s) ({names}) but --responses mode does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101"
+    );
+}
+
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
 /// docs). The server owns the conversation thread — this REPL only tracks
 /// the `thread_id` to pass on the next turn, never a local message history.
@@ -534,6 +557,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!("jarvice: {jarvice_url}");
         let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
+        warn_dropped_tool_calls(&reply);
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
@@ -640,6 +664,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     started.elapsed().as_millis(),
                     None,
                 ));
+                warn_dropped_tool_calls(&reply);
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, ToolCall,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
@@ -337,7 +337,10 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             messages.push(Message::system(sp));
         }
         messages.push(Message::user(&text));
-        call_chat(&provider, &model, messages, max_tokens, &images)?;
+        let resp = call_chat(&provider, &model, messages, max_tokens, &images)?;
+        if let Some(msg) = dropped_tool_calls_message(&resp.tool_calls, 0, "monocle chat") {
+            eprintln!("{msg}");
+        }
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
         out.flush()?;
@@ -447,6 +450,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                     started.elapsed().as_millis(),
                     resp.usage.clone(),
                 ));
+                if let Some(msg) = dropped_tool_calls_message(&resp.tool_calls, 0, "monocle chat") {
+                    eprintln!("{msg}");
+                }
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -494,27 +500,42 @@ pub fn chat_list_command(client: &Client, creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
-/// Surface (never silently drop) any `tool_calls` a `--responses` turn came
-/// back with (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only
-/// runs its MCP tool-execution loop on the streaming branch, and this client
-/// always sends `"stream": false`, so a tool-calling model's request goes
-/// unexecuted here. Actually executing tools in this mode is out of scope
-/// (tracked separately, monocle#274) — this just makes the drop visible
-/// instead of silent, on stderr like every other warning in this path, and
-/// degrades gracefully rather than erroring the turn.
-fn warn_dropped_tool_calls(reply: &crate::responses_api::ResponsesReply) {
-    if reply.tool_calls.is_empty() {
-        return;
+/// Build a warning about tool call(s) a turn couldn't act on, or `None` if
+/// there's nothing to report (monocle-cli#101 / monocle#275 — see
+/// `responses_api::ResponsesReply::tool_calls` for the canonical explanation
+/// of why `--responses` mode can't execute them). Pure — no I/O — so it's
+/// directly unit-testable; the call site does the actual `eprintln!`, same as
+/// this path's other warnings degrading gracefully rather than erroring the
+/// turn. `unparsed` additionally reports tool_calls whose shape didn't even
+/// deserialize (see `responses_api::parse_tool_calls`) — those must be
+/// mentioned too, or a shape mismatch is just as silent as never reading the
+/// field at all. Shared by both `run_responses_chat` and `run_completions_chat`
+/// so plain `monocle chat` gets the same non-silent behavior, not just
+/// `--responses` mode (monocle-cli#101 code review).
+fn dropped_tool_calls_message(
+    tool_calls: &[ToolCall],
+    unparsed: usize,
+    mode: &str,
+) -> Option<String> {
+    if tool_calls.is_empty() && unparsed == 0 {
+        return None;
     }
-    let names = reply
-        .tool_calls
-        .iter()
-        .map(|tc| tc.function.name.as_str())
-        .collect::<Vec<_>>()
-        .join(", ");
-    eprintln!(
-        "⚠ model requested tool call(s) ({names}) but --responses mode does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101"
-    );
+    let mut reasons = Vec::new();
+    if !tool_calls.is_empty() {
+        let names = tool_calls
+            .iter()
+            .map(|tc| tc.function.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        reasons.push(format!("tool call(s) ({names})"));
+    }
+    if unparsed > 0 {
+        reasons.push(format!("{unparsed} tool call(s) in an unrecognized shape"));
+    }
+    Some(format!(
+        "⚠ model requested {} but {mode} does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101 (try `monocle agent` for local tool execution today)",
+        reasons.join(" and ")
+    ))
 }
 
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
@@ -557,7 +578,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!("jarvice: {jarvice_url}");
         let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
-        warn_dropped_tool_calls(&reply);
+        if let Some(msg) = dropped_tool_calls_message(
+            &reply.tool_calls,
+            reply.unparsed_tool_calls,
+            "--responses mode",
+        ) {
+            eprintln!("{msg}");
+        }
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
@@ -664,7 +691,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     started.elapsed().as_millis(),
                     None,
                 ));
-                warn_dropped_tool_calls(&reply);
+                if let Some(msg) = dropped_tool_calls_message(
+                    &reply.tool_calls,
+                    reply.unparsed_tool_calls,
+                    "--responses mode",
+                ) {
+                    eprintln!("{msg}");
+                }
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's
@@ -750,10 +783,56 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 #[cfg(test)]
 mod tests {
     use super::{
-        chat_help_text, dispatch_chat_command, handle_help_command, resolve_max_tokens,
-        resolve_repl_attachments, TurnDiagnostics,
+        chat_help_text, dispatch_chat_command, dropped_tool_calls_message, handle_help_command,
+        resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics,
     };
+    use crate::agent::providers::{FunctionCall, ToolCall};
     use crate::commands::repl::LoopControl;
+
+    fn tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            kind: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_none_when_nothing_to_report() {
+        assert_eq!(dropped_tool_calls_message(&[], 0, "--responses mode"), None);
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_names_the_call_and_the_mode() {
+        // monocle-cli#101 code review: the pairing between obtaining a reply
+        // and warning about it was previously enforced by convention only,
+        // with no test ever exercising the warning text itself. This locks
+        // it down directly, against the pure (non-eprintln!) builder.
+        let msg = dropped_tool_calls_message(&[tool_call("generate_image")], 0, "--responses mode")
+            .expect("should produce a message");
+        assert!(msg.contains("generate_image"), "{msg}");
+        assert!(msg.contains("--responses mode"), "{msg}");
+        assert!(msg.contains("monocle agent"), "{msg}");
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_reports_unparsed_count_even_with_no_named_calls() {
+        let msg = dropped_tool_calls_message(&[], 3, "--responses mode").expect("should report");
+        assert!(msg.contains('3'), "{msg}");
+        assert!(msg.contains("unrecognized shape"), "{msg}");
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_reports_both_named_and_unparsed() {
+        let msg = dropped_tool_calls_message(&[tool_call("read_file")], 1, "monocle chat")
+            .expect("should report");
+        assert!(msg.contains("read_file"), "{msg}");
+        assert!(msg.contains('1'), "{msg}");
+        assert!(msg.contains("monocle chat"), "{msg}");
+    }
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -24,7 +24,7 @@
 
 use serde_json::{json, Value};
 
-use crate::agent::providers::ImageAttachment;
+use crate::agent::providers::{ImageAttachment, ToolCall};
 use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::auth_headers;
@@ -37,6 +37,14 @@ use crate::origin::auth_headers;
 pub struct ResponsesReply {
     pub content: String,
     pub thread_id: Option<String>,
+    /// Tool calls the model requested, surfaced but NOT executed
+    /// (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only runs
+    /// its MCP tool-execution loop on the streaming branch, and this client
+    /// always sends `"stream": false` (see the module docs), so a non-empty
+    /// `tool_calls` here means the model's request went unexecuted. Callers
+    /// must warn rather than silently drop it — actually executing tools in
+    /// this mode is out of scope (tracked separately, monocle#274).
+    pub tool_calls: Vec<ToolCall>,
 }
 
 /// Build the `input` field: a plain string when there's no attachment (the
@@ -118,18 +126,30 @@ impl<'a> ResponsesClient<'a> {
             )));
         }
         let data: Value = resp.json()?;
-        if data.get("choices").and_then(|c| c.get(0)).is_none() {
-            return Err(AppError::new(format!(
-                "unexpected /api/responses reply (no choices): {data}"
-            )));
-        }
-        let content = data["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
         let thread_id = resp.header("x-thread-id").map(str::to_string);
-        Ok(ResponsesReply { content, thread_id })
+        parse_reply(&data, thread_id)
     }
+}
+
+/// Parse a `/api/responses` JSON body into a `ResponsesReply`. Split out from
+/// `respond` so the parsing — including the `tool_calls` extraction
+/// (monocle-cli#101) — can be exercised directly against fixture JSON in
+/// tests, without an HTTP round-trip.
+fn parse_reply(data: &Value, thread_id: Option<String>) -> Result<ResponsesReply> {
+    if data.get("choices").and_then(|c| c.get(0)).is_none() {
+        return Err(AppError::new(format!(
+            "unexpected /api/responses reply (no choices): {data}"
+        )));
+    }
+    let message = &data["choices"][0]["message"];
+    let content = message["content"].as_str().unwrap_or_default().to_string();
+    let tool_calls: Vec<ToolCall> =
+        serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    Ok(ResponsesReply {
+        content,
+        thread_id,
+        tool_calls,
+    })
 }
 
 #[cfg(test)]
@@ -165,6 +185,51 @@ mod tests {
         assert_eq!(
             build_input("", &images),
             json!([{"type": "input_image", "image_url": "https://example.com/a.png"}])
+        );
+    }
+
+    /// Build a minimal `/api/responses`-shaped body, optionally with a
+    /// `tool_calls` array on `choices[0].message`.
+    fn responses_body(content: &str, tool_calls: Option<Value>) -> Value {
+        let mut message = json!({"content": content});
+        if let Some(tc) = tool_calls {
+            message["tool_calls"] = tc;
+        }
+        json!({"choices": [{"message": message}]})
+    }
+
+    #[test]
+    fn tool_calls_empty_when_absent() {
+        // The common, no-tool-calls case: `tool_calls` must come back empty,
+        // not error, when the field is simply missing from the message.
+        let data = responses_body("hello", None);
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.content, "hello");
+        assert!(reply.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn tool_calls_populated_when_present() {
+        // monocle-cli#101: a non-streaming /api/responses reply can legitimately
+        // carry an unexecuted tool_calls array — it must round-trip intact into
+        // `ResponsesReply.tool_calls` so the caller can warn instead of
+        // silently dropping it.
+        let data = responses_body(
+            "",
+            Some(json!([{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"a.txt\"}"},
+            }])),
+        );
+        let reply = parse_reply(&data, Some("thread_1".to_string())).unwrap();
+        assert_eq!(reply.thread_id.as_deref(), Some("thread_1"));
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].id, "call_1");
+        assert_eq!(reply.tool_calls[0].function.name, "read_file");
+        assert_eq!(
+            reply.tool_calls[0].function.arguments,
+            "{\"path\":\"a.txt\"}"
         );
     }
 

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -24,7 +24,7 @@
 
 use serde_json::{json, Value};
 
-use crate::agent::providers::{ImageAttachment, ToolCall};
+use crate::agent::providers::{ensure_tool_call_ids, ImageAttachment, ToolCall};
 use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::auth_headers;
@@ -38,13 +38,23 @@ pub struct ResponsesReply {
     pub content: String,
     pub thread_id: Option<String>,
     /// Tool calls the model requested, surfaced but NOT executed
-    /// (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only runs
-    /// its MCP tool-execution loop on the streaming branch, and this client
-    /// always sends `"stream": false` (see the module docs), so a non-empty
-    /// `tool_calls` here means the model's request went unexecuted. Callers
-    /// must warn rather than silently drop it — actually executing tools in
-    /// this mode is out of scope (tracked separately, monocle#274).
+    /// (monocle-cli#101 / monocle#275) — **this is the canonical explanation,
+    /// referenced rather than repeated elsewhere**: jarvice's `/api/responses`
+    /// only runs its MCP tool-execution loop on the streaming branch, and this
+    /// client always sends `"stream": false` (see the module docs), so a
+    /// non-empty `tool_calls` here means the model's request went unexecuted.
+    /// Callers must warn rather than silently drop it — actually executing
+    /// tools in this mode is out of scope (tracked separately, monocle#274).
     pub tool_calls: Vec<ToolCall>,
+    /// Count of `tool_calls` entries jarvice sent whose JSON shape didn't
+    /// deserialize into `ToolCall` (e.g. a missing `id`, or `function.arguments`
+    /// sent as a parsed object rather than a JSON-encoded string). Parsed
+    /// per-entry (see `parse_tool_calls`) specifically so ONE malformed entry
+    /// can't silently discard every OTHER, well-formed entry alongside it —
+    /// the all-or-nothing failure mode a single `Vec<ToolCall>` deserialize
+    /// would have. Callers should mention this count too, not just `tool_calls`,
+    /// so a shape mismatch is never silent either (monocle-cli#101).
+    pub unparsed_tool_calls: usize,
 }
 
 /// Build the `input` field: a plain string when there's no attachment (the
@@ -143,13 +153,37 @@ fn parse_reply(data: &Value, thread_id: Option<String>) -> Result<ResponsesReply
     }
     let message = &data["choices"][0]["message"];
     let content = message["content"].as_str().unwrap_or_default().to_string();
-    let tool_calls: Vec<ToolCall> =
-        serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    let (tool_calls, unparsed_tool_calls) = parse_tool_calls(&message["tool_calls"]);
     Ok(ResponsesReply {
         content,
         thread_id,
         tool_calls,
+        unparsed_tool_calls,
     })
+}
+
+/// Deserialize a `message.tool_calls` JSON value entry-by-entry rather than as
+/// one `Vec<ToolCall>` (monocle-cli#101): `serde`'s derived `Vec<T>` decode
+/// fails the WHOLE sequence if a single element doesn't match `ToolCall`'s
+/// shape, which would silently discard every other, well-formed tool call
+/// alongside it — reproducing the exact silent-drop bug this fix exists for,
+/// just one layer deeper. Returns the entries that parsed (ids normalized via
+/// `ensure_tool_call_ids`, same as the chat-proxy path) plus a count of the
+/// ones that didn't, so a caller can report both instead of neither.
+fn parse_tool_calls(value: &Value) -> (Vec<ToolCall>, usize) {
+    let Some(entries) = value.as_array() else {
+        return (Vec::new(), 0);
+    };
+    let mut tool_calls = Vec::new();
+    let mut unparsed = 0usize;
+    for entry in entries {
+        match serde_json::from_value::<ToolCall>(entry.clone()) {
+            Ok(tc) => tool_calls.push(tc),
+            Err(_) => unparsed += 1,
+        }
+    }
+    ensure_tool_call_ids(&mut tool_calls);
+    (tool_calls, unparsed)
 }
 
 #[cfg(test)]
@@ -206,6 +240,7 @@ mod tests {
         let reply = parse_reply(&data, None).unwrap();
         assert_eq!(reply.content, "hello");
         assert!(reply.tool_calls.is_empty());
+        assert_eq!(reply.unparsed_tool_calls, 0);
     }
 
     #[test]
@@ -231,6 +266,55 @@ mod tests {
             reply.tool_calls[0].function.arguments,
             "{\"path\":\"a.txt\"}"
         );
+        assert_eq!(reply.unparsed_tool_calls, 0);
+    }
+
+    #[test]
+    fn one_malformed_tool_call_no_longer_discards_its_well_formed_sibling() {
+        // The regression this fix closes (monocle-cli#101 code review): a
+        // naive `Vec<ToolCall>` deserialize fails the WHOLE array on one bad
+        // element. `parse_tool_calls` must parse per-entry instead, so the
+        // well-formed `read_file` call survives even though the second entry
+        // is missing `function` entirely.
+        let data = responses_body(
+            "",
+            Some(json!([
+                {"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "call_2", "type": "function"},
+            ])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].function.name, "read_file");
+        // The malformed entry is counted, not silently dropped with zero trace.
+        assert_eq!(reply.unparsed_tool_calls, 1);
+    }
+
+    #[test]
+    fn all_malformed_tool_calls_are_counted_not_silently_dropped() {
+        let data = responses_body("", Some(json!([{"id": "call_1"}, {"id": "call_2"}])));
+        let reply = parse_reply(&data, None).unwrap();
+        assert!(reply.tool_calls.is_empty());
+        assert_eq!(reply.unparsed_tool_calls, 2);
+    }
+
+    #[test]
+    fn tool_call_missing_id_gets_normalized_like_the_chat_proxy_path() {
+        // monocle-cli#101 code review: `parse_reply` must normalize an
+        // empty/missing `id` the same way `agent::providers::parse_response_value`
+        // already does for the chat-proxy path (`ensure_tool_call_ids`), so the
+        // two `ToolCall`-producing parsers don't quietly diverge on the same type.
+        let data = responses_body(
+            "",
+            Some(json!([{
+                "id": "",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].id, "call_0");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

`monocle chat --responses` 모드가 모델이 요청한 `tool_calls`를 조용히 버리던 문제를 수정합니다.

**원인**: jarvice의 `/api/responses`는 MCP 툴 실행 루프를 streaming 응답 분기에서만
실행합니다. `ResponsesClient::respond`는 항상 `"stream": false`로 보내 그 루프를
우회하고, 응답의 `choices[0].message.content`만 읽고 `tool_calls`는 무시했습니다.
그 결과 tool-calling 가능한 모델을 `--responses`로 쓸 때 원인불명의 빈/부분 응답이
나왔습니다.

**수정 범위 (이번 PR, 최소)**:
- `ResponsesReply`에 `tool_calls: Vec<ToolCall>` 필드 추가 — `agent::providers::ToolCall`을
  그대로 재사용 (새 타입 발명 없음)
- 파싱 로직을 `parse_reply()`로 분리해 HTTP 없이 유닛 테스트 가능하게 함
- `chat.rs`의 두 `rc.respond(...)` 호출부(one-shot, REPL) 모두에서 `tool_calls`가
  비어있지 않으면 stderr에 경고 출력 (기존 `⚠ ...` 스타일과 일치), 에러 없이 정상 진행
- README `--responses` 섹션에 이 동작 한 줄 추가

**스코프 아웃**: 실제 tool 실행/처리 (`monocle#274`에서 별도 설계 예정).

## 테스트

- `cargo build --release` ✅
- `cargo test` ✅ (신규: `tool_calls_empty_when_absent`, `tool_calls_populated_when_present`)
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes #101