### PR TITLE
Agent tool-permission config and AGENTS.md guide files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # IDE
 .idea/
 
+# Per-workdir tool-permission settings written by `monocle agent`
+# (created when the CLI is run from inside this repo).
+.monocle/
+
 # Audio artifacts from `monocle audio …` experiments
 *.mp3
 *.wav

--- a/README.md
+++ b/README.md
@@ -407,10 +407,63 @@ monocle agent "summarize the TODOs in this repo" --workdir .
 ```
 
 > ⚠️ In an interactive session, each side-effecting tool call (write/edit + shell) asks
-> for a `[y/N]` confirmation before it runs; anything but `y` denies it. Pass
-> `--auto-approve` to skip the prompt (dangerous). Non-interactive runs (a prompt
-> argument or piped stdin) have no TTY to prompt on and run tools unattended, so run
-> those only in a directory you trust.
+> for confirmation before it runs, with four choices — **`y`** (allow once),
+> **`s`** (allow for the rest of this session), **`a`** (allow always), or **`N`**
+> (deny, the default; anything unrecognized also denies). Choosing `s` or `a` means
+> that tool won't be asked about again — `s` for the current session only, `a`
+> persisted to `.monocle/settings.json` in the working directory so future sessions
+> skip it too. Granularity is per tool, except the shell, which is remembered per
+> command (allowing `npm test` doesn't green-light every shell command). Pass
+> `--auto-approve` to skip the prompt entirely (dangerous). Non-interactive runs (a
+> prompt argument or piped stdin) have no TTY to prompt on and run tools unattended,
+> so run those only in a directory you trust.
+>
+> `.monocle/settings.json` is a plain JSON file you can hand-edit; `allowedTools`
+> is a list of rules like `"write_file"`, `"edit_file"`, `"bash(npm test)"`, or a
+> `*`-suffixed prefix `"bash(cargo *)"` to allow a whole command family:
+>
+> ```json
+> { "allowedTools": ["edit_file", "bash(cargo *)"] }
+> ```
+
+**Guide files (`AGENTS.md`).** At startup `monocle agent` reads a guide file and
+appends it to the system prompt, so personal- and project-level instructions steer
+the agent. Two locations load in order — your personal `~/.monocle/` (applies
+everywhere), then the working directory (project-specific, loaded last so it wins
+on conflict). Each loaded guide is noted on stderr. This seeds a fresh session; a
+resumed `--session` replays its own saved prompt.
+
+In each location the **first** of these names that exists is used — at most one
+file per directory:
+
+| Priority | File | Why |
+|---|---|---|
+| 1 | `AGENTS.md` | the cross-tool open convention (Codex, Cursor, Amp, Jules, …) |
+| 2 | `AGENT.md` | Amp's fallback spelling |
+| 3 | `CLAUDE.md` | Claude Code |
+| 4 | `GEMINI.md` | Gemini CLI |
+
+So a repo that already has any of these works with no new file. (There is no
+`CODEX.md` — Codex reads `AGENTS.md`.)
+
+**Imports.** `AGENTS.md` itself is plain Markdown with no preprocessing, but
+`@path` imports are a common extension; we follow [Claude Code's
+semantics](https://code.claude.com/docs/en/memory), the most precisely specified:
+
+```markdown
+See @docs/style.md for conventions and @~/.monocle/shared-rules.md for mine.
+```
+
+- `@path/to/file` is expanded anywhere **outside** code spans and fenced blocks
+- relative paths resolve against **the importing file's own directory**; `~/` is
+  home; absolute paths work
+- imported files may import further, up to **4 hops** deep
+- backtick-wrap to escape: `` `@README` `` stays literal
+- a missing import is left in place as written
+
+Guide files support **no command execution** — imports are the only
+preprocessing (same as Claude Code's CLAUDE.md; `!`-style bash execution is a
+slash-command feature, not a memory-file one).
 
 **`monocle acp`** runs Monocle as an **[Agent Client Protocol](https://agentclientprotocol.com)**
 agent over stdio (JSON-RPC) — an editor, the Monocle desktop app, or Craft spawns it and

--- a/src/agent/guide.rs
+++ b/src/agent/guide.rs
@@ -1,0 +1,360 @@
+//! Agent guide files — user instructions layered into the system prompt.
+//!
+//! When `monocle agent` starts it reads a guide file from two locations, in order,
+//! and appends them to the system prompt so personal- and project-level
+//! instructions steer the agent:
+//!
+//! 1. **personal** — `~/.monocle/` (applies to every project)
+//! 2. **project** — `<workdir>/` (the directory the agent runs in)
+//!
+//! Loaded in that order so the project guide comes last (more specific — by
+//! convention it wins on conflict). Home and workdir are passed in explicitly
+//! (never resolved here) so tests can thread temp dirs.
+//!
+//! ## Which file
+//!
+//! In each location the first existing, non-blank name in [`GUIDE_FILENAMES`]
+//! wins — **at most one file per directory**, matching Codex's rule. `AGENTS.md`
+//! is the cross-tool open convention (Codex, Cursor, Amp, Jules, Gemini, …, now
+//! stewarded by the Linux Foundation's Agentic AI Foundation); the rest are
+//! honored so an existing repo works with no new file. Note there is no
+//! `CODEX.md` — Codex reads `AGENTS.md`.
+//!
+//! ## Imports (`@path`)
+//!
+//! The AGENTS.md convention itself defines no preprocessing — it is plain
+//! Markdown. `@path` imports are an extension that Claude Code, Gemini CLI, and
+//! Amp each invented independently; we follow **Claude Code's semantics**, the
+//! most precisely specified of the three:
+//!
+//! - `@path/to/file` anywhere outside code spans and fenced code blocks
+//! - relative paths resolve against **the directory of the file containing the
+//!   import**, not the working directory; `~/` means home; absolute paths work
+//! - imported files may themselves import, to a depth of [`MAX_IMPORT_DEPTH`]
+//! - backtick-wrapping escapes it: `` `@README` `` stays literal
+//! - a missing / unreadable import is left in place as literal text
+//!
+//! Unlike slash-command files, guide files support **no command execution** —
+//! imports are the only preprocessing, exactly as in Claude Code's CLAUDE.md.
+
+use std::path::{Path, PathBuf};
+
+/// Guide filenames tried in each location, highest priority first.
+pub const GUIDE_FILENAMES: &[&str] = &["AGENTS.md", "AGENT.md", "CLAUDE.md", "GEMINI.md"];
+
+/// Import recursion limit — matches Claude Code's documented 4 hops.
+pub const MAX_IMPORT_DEPTH: usize = 4;
+
+/// One loaded guide file, ready to append to the system prompt.
+pub struct Guide {
+    /// Human label for logs and the prompt header, e.g. `project (AGENTS.md)`.
+    pub label: String,
+    /// File contents, with `@path` imports already expanded.
+    pub text: String,
+}
+
+/// Read the guide files that exist, in load order (personal, then project).
+pub fn load_guides(home: &Path, workdir: &Path) -> Vec<Guide> {
+    let locations = [
+        ("personal", home.join(".monocle")),
+        ("project", workdir.to_path_buf()),
+    ];
+    let mut seen: Vec<PathBuf> = Vec::new();
+    let mut out = Vec::new();
+    for (scope, dir) in locations {
+        let Some((path, text)) = first_guide(&dir) else {
+            continue;
+        };
+        // Guard the case where both locations resolve to the same file.
+        if seen.contains(&path) {
+            continue;
+        }
+        seen.push(path.clone());
+
+        let expanded = expand_imports(&text, &dir, home, 0);
+        let trimmed = expanded.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        out.push(Guide {
+            label: format!("{scope} ({name})"),
+            text: trimmed.to_string(),
+        });
+    }
+    out
+}
+
+/// Append the loaded `guides` to `base`, each under a labeled header so the model
+/// can tell instruction sources apart. With no guides, `base` is returned as-is.
+pub fn augment_system_prompt(base: &str, guides: &[Guide]) -> String {
+    let mut s = String::from(base);
+    for g in guides {
+        s.push_str(&format!("\n\n# Instructions from {}\n{}", g.label, g.text));
+    }
+    s
+}
+
+/// The first existing, non-blank guide file in `dir`, by [`GUIDE_FILENAMES`] priority.
+fn first_guide(dir: &Path) -> Option<(PathBuf, String)> {
+    GUIDE_FILENAMES.iter().find_map(|name| {
+        let path = dir.join(name);
+        let text = std::fs::read_to_string(&path).ok()?;
+        (!text.trim().is_empty()).then_some((path, text))
+    })
+}
+
+/// Expand `@path` imports in `text`. `base_dir` is the directory of the file the
+/// text came from — relative imports resolve against it. Code fences are copied
+/// through untouched, and recursion stops at [`MAX_IMPORT_DEPTH`].
+fn expand_imports(text: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    let mut in_fence = false;
+    for line in text.lines() {
+        let t = line.trim_start();
+        if t.starts_with("```") || t.starts_with("~~~") {
+            in_fence = !in_fence;
+        } else if !in_fence && depth < MAX_IMPORT_DEPTH {
+            out.push_str(&expand_line(line, base_dir, home, depth));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Expand imports in one line, leaving inline code spans (`` `…` ``) literal.
+fn expand_line(line: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    for (i, seg) in line.split('`').enumerate() {
+        if i > 0 {
+            out.push('`');
+        }
+        if i % 2 == 1 {
+            out.push_str(seg); // inside a code span — literal
+        } else {
+            out.push_str(&expand_segment(seg, base_dir, home, depth));
+        }
+    }
+    out
+}
+
+/// Expand every `@path` token in a stretch of non-code text.
+fn expand_segment(seg: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    let mut cursor = 0; // start of not-yet-copied text
+    let mut search = 0;
+    while let Some(rel) = seg[search..].find('@') {
+        let at = search + rel;
+        // `@` must start a token (segment start or after whitespace) so an email
+        // address like `a@b.com` is never mistaken for an import.
+        let boundary = at == 0
+            || seg[..at]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let end = seg[at + 1..]
+            .find(char::is_whitespace)
+            .map(|p| at + 1 + p)
+            .unwrap_or(seg.len());
+        let raw = &seg[at + 1..end];
+        if !boundary || raw.is_empty() {
+            search = at + 1;
+            continue;
+        }
+        match read_import(raw, base_dir, home) {
+            Some((content, dir)) => {
+                out.push_str(&seg[cursor..at]);
+                out.push_str(expand_imports(&content, &dir, home, depth + 1).trim_end());
+                cursor = end;
+                search = end;
+            }
+            // Missing / unreadable import: leave the text exactly as written.
+            None => search = at + 1,
+        }
+    }
+    out.push_str(&seg[cursor..]);
+    out
+}
+
+/// Resolve an import path (`~/…` = home, relative = against the importing file's
+/// directory, absolute as-is) and read it. Also returns the directory that file's
+/// own imports resolve against.
+fn read_import(raw: &str, base_dir: &Path, home: &Path) -> Option<(String, PathBuf)> {
+    let path = match raw.strip_prefix("~/") {
+        Some(rest) => home.join(rest),
+        None => {
+            let p = Path::new(raw);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                base_dir.join(p)
+            }
+        }
+    };
+    let text = std::fs::read_to_string(&path).ok()?;
+    let dir = path.parent().unwrap_or(base_dir).to_path_buf();
+    Some((text, dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn no_guides_leaves_prompt_unchanged() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let guides = load_guides(home.path(), work.path());
+        assert!(guides.is_empty());
+        assert_eq!(augment_system_prompt("BASE", &guides), "BASE");
+    }
+
+    #[test]
+    fn loads_personal_then_project_in_order() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&home.path().join(".monocle").join("AGENTS.md"), "be terse");
+        write(&work.path().join("AGENTS.md"), "use tabs");
+        let guides = load_guides(home.path(), work.path());
+        assert_eq!(guides.len(), 2);
+        assert!(guides[0].label.starts_with("personal"));
+        assert!(guides[1].label.starts_with("project"));
+        let prompt = augment_system_prompt("BASE", &guides);
+        assert!(prompt.starts_with("BASE"));
+        assert!(prompt.find("be terse").unwrap() < prompt.find("use tabs").unwrap());
+    }
+
+    #[test]
+    fn skips_missing_and_blank_files() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "   \n  ");
+        assert!(load_guides(home.path(), work.path()).is_empty());
+    }
+
+    #[test]
+    fn agents_md_wins_over_lower_priority_names() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "from agents");
+        write(&work.path().join("CLAUDE.md"), "from claude");
+        write(&work.path().join("GEMINI.md"), "from gemini");
+        let guides = load_guides(home.path(), work.path());
+        assert_eq!(guides.len(), 1, "at most one file per directory");
+        assert_eq!(guides[0].text, "from agents");
+        assert_eq!(guides[0].label, "project (AGENTS.md)");
+    }
+
+    #[test]
+    fn falls_back_through_the_filename_chain() {
+        for (present, expected) in [
+            ("AGENT.md", "project (AGENT.md)"),
+            ("CLAUDE.md", "project (CLAUDE.md)"),
+            ("GEMINI.md", "project (GEMINI.md)"),
+        ] {
+            let home = tempfile::tempdir().unwrap();
+            let work = tempfile::tempdir().unwrap();
+            write(&work.path().join(present), "hello");
+            let guides = load_guides(home.path(), work.path());
+            assert_eq!(guides.len(), 1, "{present} should be picked up");
+            assert_eq!(guides[0].label, expected);
+        }
+    }
+
+    #[test]
+    fn expands_imports_relative_to_the_importing_file() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "top\n@docs/style.md\nend");
+        write(&work.path().join("docs").join("style.md"), "STYLE RULES");
+        let guides = load_guides(home.path(), work.path());
+        assert!(guides[0].text.contains("STYLE RULES"));
+        assert!(!guides[0].text.contains("@docs/style.md"));
+    }
+
+    #[test]
+    fn nested_imports_resolve_against_their_own_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "@docs/a.md");
+        // `b.md` is referenced relative to docs/, not the workdir.
+        write(&work.path().join("docs").join("a.md"), "A\n@b.md");
+        write(&work.path().join("docs").join("b.md"), "B");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert!(text.contains('A') && text.contains('B'));
+    }
+
+    #[test]
+    fn home_import_expands_tilde() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "@~/shared/rules.md");
+        write(&home.path().join("shared").join("rules.md"), "SHARED");
+        assert!(load_guides(home.path(), work.path())[0]
+            .text
+            .contains("SHARED"));
+    }
+
+    #[test]
+    fn imports_inside_code_are_left_literal() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(
+            &work.path().join("AGENTS.md"),
+            "escaped `@secret.md` here\n```\n@secret.md\n```",
+        );
+        write(&work.path().join("secret.md"), "LEAKED");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert!(
+            !text.contains("LEAKED"),
+            "code spans/fences must not import"
+        );
+        assert!(text.contains("`@secret.md`"));
+    }
+
+    #[test]
+    fn missing_import_is_left_as_written() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "see @nope.md ok");
+        assert_eq!(
+            load_guides(home.path(), work.path())[0].text,
+            "see @nope.md ok"
+        );
+    }
+
+    #[test]
+    fn email_like_text_is_not_an_import() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(
+            &work.path().join("AGENTS.md"),
+            "ask jeongsoo@warmblood.kr ok",
+        );
+        assert_eq!(
+            load_guides(home.path(), work.path())[0].text,
+            "ask jeongsoo@warmblood.kr ok"
+        );
+    }
+
+    #[test]
+    fn import_recursion_stops_at_max_depth() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        // A self-importing file must terminate rather than recurse forever.
+        write(&work.path().join("AGENTS.md"), "LOOP\n@AGENTS.md");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert_eq!(text.matches("LOOP").count(), MAX_IMPORT_DEPTH + 1);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -23,7 +23,7 @@ pub const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provi
 session's working directory. Take minimal, verified steps. When finished, give a brief summary.";
 
 /// Default model id (routed/validated by monocle chat-proxy — we only pass it through).
-pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+pub const DEFAULT_MODEL: &str = "claude-sonnet-5";
 
 /// Default agent-loop step budget before giving up.
 pub const DEFAULT_MAX_STEPS: usize = 20;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,8 @@
 //! tools, permission/sandboxing, session, and ACP surface come later.
 
 pub mod commands;
+pub mod guide;
+pub mod permission;
 pub mod providers;
 pub mod runner;
 pub mod session;

--- a/src/agent/permission.rs
+++ b/src/agent/permission.rs
@@ -1,0 +1,225 @@
+//! Per-session / persisted tool-permission decisions for the interactive agent.
+//!
+//! The agent loop gates side-effecting tools behind an `Approver` (runner.rs).
+//! On its own the interactive approver has no memory, so the user re-answers the
+//! same prompt every time. This module gives it one: a decision can be remembered
+//! for **this session** (in-memory) or **always** — persisted to a working-dir
+//! `.monocle/settings.json` so future sessions don't re-prompt.
+//!
+//! Granularity is **per tool name**, except the shell tool (`bash`/`powershell`)
+//! which is **per command string**, so allowing `npm test` never green-lights
+//! every shell command. Persisted rules live under `allowedTools`:
+//!
+//! ```json
+//! { "allowedTools": ["write_file", "bash(npm test)", "bash(cargo *)"] }
+//! ```
+//!
+//! A `bash(...)` pattern matches a command exactly, or as a prefix when it ends
+//! with `*` (`bash(cargo *)` allows `cargo build`, `cargo test`, …). Users can
+//! hand-edit the file to add such wildcards.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+/// The command string for a shell tool call, if present. Its presence is what
+/// makes a call *command-scoped* (only the shell tool takes a `command` arg).
+fn command_arg(args: &Value) -> Option<&str> {
+    args.get("command").and_then(Value::as_str)
+}
+
+/// The rule string to remember for a given tool call: the tool name, or
+/// `name(command)` for a shell call.
+pub fn rule_for(tool_name: &str, args: &Value) -> String {
+    match command_arg(args) {
+        Some(cmd) => format!("{tool_name}({})", cmd.trim()),
+        None => tool_name.to_string(),
+    }
+}
+
+/// Whether a stored `rule` authorizes this tool call. Plain rules match by tool
+/// name; `name(pattern)` rules also require the command to match `pattern`
+/// (exact, or prefix when `pattern` ends with `*`).
+pub fn rule_matches(rule: &str, tool_name: &str, args: &Value) -> bool {
+    match rule.strip_suffix(')').and_then(|r| r.split_once('(')) {
+        Some((name, pat)) => {
+            name == tool_name
+                && command_arg(args).is_some_and(|cmd| command_matches(pat, cmd.trim()))
+        }
+        None => rule == tool_name,
+    }
+}
+
+fn command_matches(pat: &str, cmd: &str) -> bool {
+    match pat.strip_suffix('*') {
+        Some(prefix) => cmd.starts_with(prefix),
+        None => cmd == pat,
+    }
+}
+
+/// A session's remembered tool-permission decisions: the in-memory allow-set
+/// (session + rules loaded from disk) plus where "always" decisions persist.
+pub struct PermissionStore {
+    rules: Vec<String>,
+    settings_path: PathBuf,
+}
+
+impl PermissionStore {
+    /// Load allow-rules from `<workdir>/.monocle/settings.json`. A missing or
+    /// invalid file yields an empty allow-set (nothing is pre-authorized).
+    pub fn load(workdir: &Path) -> Self {
+        let settings_path = workdir.join(".monocle").join("settings.json");
+        let rules = read_allowed_tools(&settings_path);
+        Self {
+            rules,
+            settings_path,
+        }
+    }
+
+    /// Whether this call is already authorized by a remembered rule.
+    pub fn is_allowed(&self, tool_name: &str, args: &Value) -> bool {
+        self.rules.iter().any(|r| rule_matches(r, tool_name, args))
+    }
+
+    /// Remember this call for the rest of the session only (not persisted).
+    pub fn allow_session(&mut self, tool_name: &str, args: &Value) {
+        self.remember(rule_for(tool_name, args));
+    }
+
+    /// Remember this call for the session AND persist it to
+    /// `.monocle/settings.json` so future sessions skip the prompt.
+    pub fn allow_always(&mut self, tool_name: &str, args: &Value) -> std::io::Result<()> {
+        let rule = rule_for(tool_name, args);
+        self.remember(rule.clone());
+        persist_allowed_tool(&self.settings_path, &rule)
+    }
+
+    fn remember(&mut self, rule: String) {
+        if !self.rules.contains(&rule) {
+            self.rules.push(rule);
+        }
+    }
+}
+
+/// Read the `allowedTools` string array from a settings file (missing/invalid → empty).
+fn read_allowed_tools(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+        .and_then(|v| v.get("allowedTools").and_then(Value::as_array).cloned())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Append `rule` to `allowedTools`, preserving any other keys the user hand-added
+/// (read-modify-write, matching `commands::setup`'s treatment of settings files).
+fn persist_allowed_tool(path: &Path, rule: &str) -> std::io::Result<()> {
+    let mut settings: Map<String, Value> = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+
+    let list = settings
+        .entry("allowedTools".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !list.is_array() {
+        *list = Value::Array(Vec::new());
+    }
+    let arr = list.as_array_mut().unwrap();
+    if !arr.iter().any(|x| x.as_str() == Some(rule)) {
+        arr.push(Value::String(rule.to_string()));
+    }
+
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let body =
+        serde_json::to_string_pretty(&Value::Object(settings)).map_err(std::io::Error::other)?;
+    std::fs::write(path, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn plain_tool_rule_matches_by_name() {
+        assert!(rule_matches(
+            "write_file",
+            "write_file",
+            &json!({ "path": "a" })
+        ));
+        assert!(!rule_matches("write_file", "edit_file", &json!({})));
+    }
+
+    #[test]
+    fn shell_rule_is_command_scoped() {
+        let rule = rule_for("bash", &json!({ "command": "npm test" }));
+        assert_eq!(rule, "bash(npm test)");
+        assert!(rule_matches(
+            &rule,
+            "bash",
+            &json!({ "command": "npm test" })
+        ));
+        assert!(!rule_matches(
+            &rule,
+            "bash",
+            &json!({ "command": "rm -rf /" })
+        ));
+    }
+
+    #[test]
+    fn shell_wildcard_prefix_matches() {
+        assert!(rule_matches(
+            "bash(cargo *)",
+            "bash",
+            &json!({ "command": "cargo build" })
+        ));
+        assert!(!rule_matches(
+            "bash(cargo *)",
+            "bash",
+            &json!({ "command": "npm run" })
+        ));
+    }
+
+    #[test]
+    fn store_persists_and_reloads_always_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = PermissionStore::load(dir.path());
+        assert!(!store.is_allowed("write_file", &json!({})));
+        store.allow_always("write_file", &json!({})).unwrap();
+        assert!(store.is_allowed("write_file", &json!({})));
+        // A fresh load sees the persisted rule.
+        assert!(PermissionStore::load(dir.path()).is_allowed("write_file", &json!({})));
+    }
+
+    #[test]
+    fn session_rules_are_not_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = PermissionStore::load(dir.path());
+        store.allow_session("bash", &json!({ "command": "ls" }));
+        assert!(store.is_allowed("bash", &json!({ "command": "ls" })));
+        // Session-only decisions do not survive into a fresh load.
+        assert!(!PermissionStore::load(dir.path()).is_allowed("bash", &json!({ "command": "ls" })));
+    }
+
+    #[test]
+    fn persist_preserves_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".monocle").join("settings.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{ "model": "claude-sonnet-4-6" }"#).unwrap();
+        PermissionStore::load(dir.path())
+            .allow_always("edit_file", &json!({}))
+            .unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["model"], "claude-sonnet-4-6");
+        assert_eq!(v["allowedTools"][0], "edit_file");
+    }
+}

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
+use crate::agent::permission::PermissionStore;
 use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent, AllowAll, Approver, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
@@ -103,45 +104,83 @@ const SLASH_COMMANDS: &[&str] = &[
     "/help", "/config", "/status", "/model", "/diag", "/exit", "/quit",
 ];
 
-/// Interactive approver: prompts the user (stderr) before each side-effecting
-/// tool call and reads a y/N answer from stdin. Default (empty / non-y / EOF) is
-/// deny — the safe choice. Only ever constructed on an interactive TTY, where the
-/// terminal is in cooked mode during a turn so a plain `read_line` works.
-struct PromptApprover;
-impl Approver for PromptApprover {
+/// Interactive approver with a memory. Before each side-effecting tool call it
+/// consults the session's [`PermissionStore`]; if the call is already authorized
+/// (allowed earlier this session, or persisted in `.monocle/settings.json`) it
+/// runs with no prompt. Otherwise it prompts on stderr with four choices —
+/// **[y]** once, **[s]** this session, **[a]** always (persist), **[N]** deny —
+/// and records `s`/`a` in the store. Default (empty / unknown / EOF) is deny.
+/// Only ever constructed on an interactive TTY, where the terminal is in cooked
+/// mode during a turn so a plain `read_line` works.
+struct PromptApprover<'a> {
+    store: &'a mut PermissionStore,
+}
+impl Approver for PromptApprover<'_> {
     fn approve(&mut self, _id: &str, name: &str, args: &Value) -> bool {
-        // For `shell`, the interesting thing is the command; else show the JSON.
-        let summary = if name == "shell" {
-            args.get("command")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .unwrap_or_else(|| args.to_string())
-        } else {
-            args.to_string()
-        };
+        // A prior session/persisted decision skips the prompt entirely.
+        if self.store.is_allowed(name, args) {
+            return true;
+        }
+        // For the shell tool the interesting thing is the command; else the JSON.
+        let summary = args
+            .get("command")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| args.to_string());
         eprint!(
             "{} {} {}: {}  {} ",
             c::yellow("⚠"),
             c::dim("run"),
             c::bold(name),
             c::dim(&one_line(&summary, 120)),
-            c::yellow("[y/N]"),
+            c::yellow("[y]es once / [s]ession / [a]lways / [N]o"),
         );
         let _ = std::io::stderr().flush();
         let mut line = String::new();
-        match std::io::stdin().read_line(&mut line) {
-            Ok(0) => false, // EOF → deny
+        let answer = match std::io::stdin().read_line(&mut line) {
+            Ok(0) => ApprovalAnswer::Deny, // EOF → deny
             Ok(_) => approve_answer(&line),
-            Err(_) => false,
+            Err(_) => ApprovalAnswer::Deny,
+        };
+        match answer {
+            ApprovalAnswer::Once => true,
+            ApprovalAnswer::Session => {
+                self.store.allow_session(name, args);
+                true
+            }
+            ApprovalAnswer::Always => {
+                if let Err(e) = self.store.allow_always(name, args) {
+                    eprintln!("{} 권한을 저장하지 못했습니다: {e}", c::yellow("⚠"));
+                }
+                true
+            }
+            ApprovalAnswer::Deny => false,
         }
     }
 }
 
-/// Pure y/N decision for an approval prompt: an answer counts as "yes" only if,
-/// after leading whitespace, it starts with `y`/`Y`. Everything else (empty,
-/// `n`, a stray word) is "no" — the safe default.
-fn approve_answer(input: &str) -> bool {
-    matches!(input.trim_start().chars().next(), Some('y') | Some('Y'))
+/// A four-way approval decision. Anything but a leading `y`/`s`/`a` is `Deny` —
+/// the safe default (empty, `n`, EOF, a stray word).
+#[derive(Debug, PartialEq, Eq)]
+enum ApprovalAnswer {
+    /// `y` — allow this one call only.
+    Once,
+    /// `s` — allow for the rest of this session (in-memory).
+    Session,
+    /// `a` — allow always; persist to `.monocle/settings.json`.
+    Always,
+    /// `n` / empty / unknown / EOF — deny.
+    Deny,
+}
+
+/// Pure decision for an approval prompt, keyed on the first non-space character.
+fn approve_answer(input: &str) -> ApprovalAnswer {
+    match input.trim_start().chars().next() {
+        Some('y') | Some('Y') => ApprovalAnswer::Once,
+        Some('s') | Some('S') => ApprovalAnswer::Session,
+        Some('a') | Some('A') => ApprovalAnswer::Always,
+        _ => ApprovalAnswer::Deny,
+    }
 }
 
 /// Approver-selection policy: use the interactive [`PromptApprover`] only on an
@@ -169,6 +208,9 @@ struct Repl<'a> {
     auto_approve: bool,
     /// Whether this session runs on an interactive TTY (can prompt for approval).
     interactive: bool,
+    /// Remembered tool-permission decisions (session + `.monocle/settings.json`),
+    /// so an allowed tool isn't re-prompted for the life of the session.
+    permissions: PermissionStore,
     /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
     /// first successful turn, mirroring `monocle chat`'s REPL.
     diagnostics: Option<TurnDiagnostics>,
@@ -207,7 +249,9 @@ impl Repl<'_> {
         // Gate side-effecting tools behind the user in interactive mode; scripts
         // / one-shot / `--auto-approve` keep the unattended `AllowAll` behavior.
         let mut allow = AllowAll;
-        let mut prompt = PromptApprover;
+        let mut prompt = PromptApprover {
+            store: &mut self.permissions,
+        };
         let approver: &mut dyn Approver =
             if use_prompt_approver(self.auto_approve, self.interactive) {
                 &mut prompt
@@ -310,6 +354,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         move || c.cancel()
     });
 
+    // Layer any guide files (personal ~/.monocle, then the workdir) onto the
+    // system prompt so user/project instructions steer the agent. Only seeds a
+    // *new* conversation; a resumed session replays its own persisted system turn.
+    let guides = crate::agent::guide::load_guides(&home_dir(), &workdir);
+    for g in &guides {
+        eprintln!("{}", c::dim(&format!("loaded guide — {}", g.label)));
+    }
+    let system_prompt = crate::agent::guide::augment_system_prompt(SYSTEM_PROMPT, &guides);
+
     // Optional named session: resume by replaying the persisted conversation.
     let session: Option<SessionStore> = opts
         .session
@@ -319,7 +372,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         Some(store) => {
             let loaded = store.load()?;
             if loaded.is_empty() {
-                (vec![Message::system(SYSTEM_PROMPT)], 0)
+                (vec![Message::system(system_prompt)], 0)
             } else {
                 eprintln!(
                     "{}",
@@ -329,8 +382,12 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                 (loaded, n)
             }
         }
-        None => (vec![Message::system(SYSTEM_PROMPT)], 0),
+        None => (vec![Message::system(system_prompt)], 0),
     };
+
+    // Load any previously-persisted tool permissions for this working directory
+    // so allowed tools run without re-prompting.
+    let permissions = PermissionStore::load(&workdir);
 
     let mut repl = Repl {
         client,
@@ -345,6 +402,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         persisted,
         auto_approve: opts.auto_approve,
         interactive,
+        permissions,
         diagnostics: None,
     };
 
@@ -529,16 +587,26 @@ mod tests {
     }
 
     #[test]
-    fn approve_answer_treats_y_prefix_as_yes() {
+    fn approve_answer_treats_y_prefix_as_once() {
         for yes in ["y", "yes", "Y", "YES", "yeah", "  y", "y\n"] {
-            assert!(approve_answer(yes), "expected yes for {yes:?}");
+            assert_eq!(approve_answer(yes), ApprovalAnswer::Once, "for {yes:?}");
         }
     }
 
     #[test]
-    fn approve_answer_defaults_to_no() {
-        for no in ["", "n", "no", "N", "find", "\n", "  ", "1", "sure"] {
-            assert!(!approve_answer(no), "expected no for {no:?}");
+    fn approve_answer_maps_session_and_always() {
+        for s in ["s", "session", "S", "  s"] {
+            assert_eq!(approve_answer(s), ApprovalAnswer::Session, "for {s:?}");
+        }
+        for a in ["a", "always", "A", "a\n"] {
+            assert_eq!(approve_answer(a), ApprovalAnswer::Always, "for {a:?}");
+        }
+    }
+
+    #[test]
+    fn approve_answer_defaults_to_deny() {
+        for no in ["", "n", "no", "N", "find", "\n", "  ", "1"] {
+            assert_eq!(approve_answer(no), ApprovalAnswer::Deny, "for {no:?}");
         }
     }
 


### PR DESCRIPTION
## Why

Two friction points in `monocle agent`:

1. **Every side-effecting tool call re-asked for approval.** The prompt was a binary `[y/N]` with no memory, so the same `write_file` or shell command had to be approved over and over.
2. **No way to give the agent standing instructions.** Other agent CLIs read a guide file (`AGENTS.md`, `CLAUDE.md`, …); we read nothing.

## What changed

### 1. Tool-permission configuration (`src/agent/permission.rs`)

The approval prompt becomes four-way:

```
⚠ run bash: npm test  [y]es once / [s]ession / [a]lways / [N]o
```

- `y` — allow this call only
- `s` — allow for the rest of the session (in-memory)
- `a` — allow always → persisted to `.monocle/settings.json` in the working directory
- `N` (default) — deny; anything unrecognized also denies

Persisted rules load at startup, so a previously-allowed tool never prompts again.

**Granularity is per tool name, except the shell, which is per command** — allowing `bash(npm test)` does not green-light every shell command. Rules support a `*` suffix for prefix matching, so the file can be hand-edited:

```json
{ "allowedTools": ["write_file", "bash(npm test)", "bash(cargo *)"] }
```

The settings file uses the same read-modify-write treatment as `commands::setup`, preserving any other keys the user added.

Drive-by fix: `PromptApprover` selected its shell summary with `name == "shell"`, but the tool is registered as `bash`/`powershell` — the branch was dead and shell commands always rendered as raw JSON. It now keys on the presence of a `command` argument.

### 2. Guide files (`src/agent/guide.rs`)

At startup the agent reads a guide file and appends it to the system prompt. Two locations load in order — personal `~/.monocle/`, then the project `<workdir>/` (last, so it wins on conflict). In each location the **first** of these names wins, at most one file per directory (matching Codex's rule):

| Priority | File | Used by |
|---|---|---|
| 1 | `AGENTS.md` | the cross-tool open convention — Codex, Cursor, Amp, Jules, … |
| 2 | `AGENT.md` | Amp's fallback spelling |
| 3 | `CLAUDE.md` | Claude Code |
| 4 | `GEMINI.md` | Gemini CLI |

So a repo that already carries any of these works with no new file. Note there is **no `CODEX.md`** — Codex reads `AGENTS.md`.

**Imports.** The AGENTS.md convention is plain Markdown and defines no preprocessing; `@path` imports are an extension that Claude Code, Gemini CLI, and Amp each invented independently. We follow [Claude Code's semantics](https://code.claude.com/docs/en/memory), the most precisely specified of the three:

- expanded anywhere **outside** code spans and fenced blocks
- relative paths resolve against **the importing file's own directory**, not the cwd; `~/` is home; absolute paths work
- imported files may import further, up to **4 hops**
- backtick-wrapping escapes: `` `@README` `` stays literal
- a missing import is left in place as written

There is **no command execution** — imports are the only preprocessing, matching CLAUDE.md (the `!`-style bash execution people remember is a slash-command feature, not a memory-file one).

Guides seed a fresh session only; a resumed `--session` replays its own persisted system turn.

### 3. Default model → `claude-sonnet-5`

`DEFAULT_MODEL` was pinned to `claude-sonnet-4-6`. Separate commit.

## Testing

21 new unit tests (6 permission, 12 guide, 3 prompt parsing); 154 lib tests pass. `cargo clippy --all-targets` and `cargo fmt --check` are clean.

Guide coverage includes the awkward cases: filename priority and fallback chain, nested imports resolving against their own directory, code-fence and backtick escaping, `~/` expansion, missing imports, an email address (`a@b.com`) not being mistaken for an import, and a self-importing file terminating at the depth limit.

## Notes for the reviewer

- **`claude-sonnet-5` must exist in chat-proxy's catalog.** The CLI only passes the id through; please confirm the router resolves it before merging, or the default breaks for everyone.
- `.monocle/` is gitignored here. Whether allowed-tool lists should be shareable (committed) or personal is a project decision — currently personal.
- ACP is untouched: it delegates permission to the client, which owns its own UI and memory.
- Claude Code's block-level HTML-comment stripping is deliberately not implemented (needs code-block-aware handling for little gain). Easy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)