### PR TITLE
release: v1.4.3 — 버전 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.4.1"
+version = "1.4.3"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.4.1"
+version = "1.4.3"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"


### PR DESCRIPTION
PR #104(net.rs stale-connection 재시도) 반영 릴리스.

devel의 Cargo.toml이 v1.4.2 릴리스(PR #95, release/v1.4.2 → main 직행) 이후
버전 bump 커밋을 되돌려받지 못해 1.4.1에 머물러 있었음(devel↔main 전체 diff로
확인 — 버전 문자열 외 기능적 차이는 없음, install.ps1 체크섬 수정도 devel에
이미 존재). 그 다음 버전인 1.4.3으로 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)