### PR TITLE
Release v1.4.3: devel → main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # IDE
 .idea/
 
+# Per-workdir tool-permission settings written by `monocle agent`
+# (created when the CLI is run from inside this repo).
+.monocle/
+
 # Audio artifacts from `monocle audio …` experiments
 *.mp3
 *.wav

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "monocle-cli"
-version = "1.4.1"
+version = "1.4.3"
 dependencies = [
  "agent-client-protocol",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle-cli"
-version = "1.4.1"
+version = "1.4.3"
 edition = "2021"
 description = "Control and use Monocle AI from your terminal: log in, chat with models, run the agent, or integrate Claude Code."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Bye.
 
 The interactive REPL has full line editing — arrow keys (←/→ to move, ↑/↓ for history),
 and Emacs bindings (Ctrl-A/E to jump to line start/end, Ctrl-K to kill, Ctrl-Y to yank).
-Tab completes `/model`/`/quit`/`/exit` as a dropdown listing every match (not cycling
-one at a time), with the best match also shown as a dim inline hint as you type; a
+Tab completes `/help`/`/model`/`/diag`/`/quit`/`/exit` as a dropdown listing every
+match (not cycling one at a time), with the best match also shown as a dim inline
+hint as you type; a
 multi-line paste is inserted as a single input (submitted only on Enter, not one turn
 per line). Command history persists across sessions in `~/.monocle/chat_history` (kept
 separate from `monocle agent`'s history). The REPL remembers the conversation — each
@@ -134,6 +135,9 @@ Tokens: 120 prompt + 45 completion = 165 total
 `monocle chat`'s default path; `--responses`, below, reports neither today, so those lines
 are simply omitted rather than printed as empty). Before the first turn, `/diag` just
 prints a hint to send a message first.
+
+`/help` re-prints the REPL's onboarding message (the same lines shown when the
+session starts) — handy if you've scrolled past it.
 
 One-shot via stdin:
 
@@ -383,11 +387,13 @@ persists across sessions in `~/.monocle/agent_history`.
 In the interactive REPL, lines starting with `/` are local management commands (handled
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,
-`/model` shows the current model (or `/model <id>` switches it for later turns), and
-`/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the model ids
-available to your account (fetched once at startup) — e.g. `/model cla<TAB>` narrows to
-matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
-list can't be fetched, completion just offers nothing (typing a full id still works).
+`/diag` shows diagnostics (served model, endpoint, latency, tokens, and step count) for
+the last turn, `/model` shows the current model (or `/model <id>` switches it for later
+turns), and `/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the
+model ids available to your account (fetched once at startup) — e.g. `/model cla<TAB>`
+narrows to matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in
+or the list can't be fetched, completion just offers nothing (typing a full id still
+works).
 
 ```bash
 monocle agent "summarize the TODOs in this repo" --workdir .

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ Monocle Chat (model: claude-sonnet-4-6)
 Router: https://api.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> Hello
+▸ chat
+❯ Hello
 Hello! How can I help you today?
 
-> /quit
+❯ /quit
 Bye.
 ```
 
@@ -119,7 +120,7 @@ after a reply, it's opt-in on demand. Handy with a router alias (e.g. `monocle-a
 see which concrete model actually served the response:
 
 ```console
-> /diag
+❯ /diag
 --- diag ---
 Endpoint: https://api.monocle-ai.com/v1/chat/completions
 Requested model: monocle-auto
@@ -223,11 +224,12 @@ Monocle Chat — Responses API (model: claude-sonnet-4-6)
 jarvice: https://acme.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> Hello
+▸ chat
+❯ Hello
 Hello! How can I help you today?
 Thread: 3fa3b2c1-...
 
-> /quit
+❯ /quit
 Bye.
 ```
 

--- a/README.md
+++ b/README.md
@@ -270,9 +270,12 @@ Notes:
 - **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
   endpoint has no equivalent fields (a warning is printed if you pass them).
 - **Tool calls aren't executed** — this mode doesn't run a tool loop yet; if a
-  tool-calling model requests one, a warning is printed to stderr naming it
-  instead of silently dropping it (see
+  tool-calling model requests one, a warning is printed to stderr — naming it
+  when its shape parses, or noting the count when it doesn't — instead of
+  silently dropping it (see
   [monocle-cli#101](https://github.com/warmblood-kr/monocle-cli/issues/101)).
+  `monocle agent` executes tools client-side today, if that's what you need
+  right now.
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ available to your account (fetched once at startup) — e.g. `/model cla<TAB>` n
 matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in or the
 list can't be fetched, completion just offers nothing (typing a full id still works).
 
+`/diag` shows diagnostics for the **last** turn only — nothing is printed automatically
+after a reply, it's opt-in on demand. Handy with a router alias (e.g. `monocle-auto`) to
+see which concrete model actually served the response:
+
+```console
+> /diag
+--- diag ---
+Endpoint: https://api.monocle-ai.com/v1/chat/completions
+Requested model: monocle-auto
+Served model: claude-sonnet-4-6
+Latency: 842ms
+Tokens: 120 prompt + 45 completion = 165 total
+--- end diag ---
+```
+
+`Served model` and `Tokens` are only shown when the backend reports them (always true for
+`monocle chat`'s default path; `--responses`, below, reports neither today, so those lines
+are simply omitted rather than printed as empty). Before the first turn, `/diag` just
+prints a hint to send a message first.
+
 One-shot via stdin:
 
 ```console
@@ -217,6 +237,10 @@ Continue a specific thread later (one-shot or REPL) with `--resume <id>`
 ```bash
 echo "and in Python?" | monocle chat --responses --resume 3fa3b2c1-...
 ```
+
+`/diag` also works in this REPL, but the Responses API doesn't echo back a served
+model or token usage, so those lines are omitted — only `Endpoint`/`Requested
+model`/`Latency` are shown.
 
 List your existing threads (including ones started in jarvice's own web UI —
 both share the same storage) with the `list` subcommand:

--- a/README.md
+++ b/README.md
@@ -407,10 +407,63 @@ monocle agent "summarize the TODOs in this repo" --workdir .
 ```
 
 > ⚠️ In an interactive session, each side-effecting tool call (write/edit + shell) asks
-> for a `[y/N]` confirmation before it runs; anything but `y` denies it. Pass
-> `--auto-approve` to skip the prompt (dangerous). Non-interactive runs (a prompt
-> argument or piped stdin) have no TTY to prompt on and run tools unattended, so run
-> those only in a directory you trust.
+> for confirmation before it runs, with four choices — **`y`** (allow once),
+> **`s`** (allow for the rest of this session), **`a`** (allow always), or **`N`**
+> (deny, the default; anything unrecognized also denies). Choosing `s` or `a` means
+> that tool won't be asked about again — `s` for the current session only, `a`
+> persisted to `.monocle/settings.json` in the working directory so future sessions
+> skip it too. Granularity is per tool, except the shell, which is remembered per
+> command (allowing `npm test` doesn't green-light every shell command). Pass
+> `--auto-approve` to skip the prompt entirely (dangerous). Non-interactive runs (a
+> prompt argument or piped stdin) have no TTY to prompt on and run tools unattended,
+> so run those only in a directory you trust.
+>
+> `.monocle/settings.json` is a plain JSON file you can hand-edit; `allowedTools`
+> is a list of rules like `"write_file"`, `"edit_file"`, `"bash(npm test)"`, or a
+> `*`-suffixed prefix `"bash(cargo *)"` to allow a whole command family:
+>
+> ```json
+> { "allowedTools": ["edit_file", "bash(cargo *)"] }
+> ```
+
+**Guide files (`AGENTS.md`).** At startup `monocle agent` reads a guide file and
+appends it to the system prompt, so personal- and project-level instructions steer
+the agent. Two locations load in order — your personal `~/.monocle/` (applies
+everywhere), then the working directory (project-specific, loaded last so it wins
+on conflict). Each loaded guide is noted on stderr. This seeds a fresh session; a
+resumed `--session` replays its own saved prompt.
+
+In each location the **first** of these names that exists is used — at most one
+file per directory:
+
+| Priority | File | Why |
+|---|---|---|
+| 1 | `AGENTS.md` | the cross-tool open convention (Codex, Cursor, Amp, Jules, …) |
+| 2 | `AGENT.md` | Amp's fallback spelling |
+| 3 | `CLAUDE.md` | Claude Code |
+| 4 | `GEMINI.md` | Gemini CLI |
+
+So a repo that already has any of these works with no new file. (There is no
+`CODEX.md` — Codex reads `AGENTS.md`.)
+
+**Imports.** `AGENTS.md` itself is plain Markdown with no preprocessing, but
+`@path` imports are a common extension; we follow [Claude Code's
+semantics](https://code.claude.com/docs/en/memory), the most precisely specified:
+
+```markdown
+See @docs/style.md for conventions and @~/.monocle/shared-rules.md for mine.
+```
+
+- `@path/to/file` is expanded anywhere **outside** code spans and fenced blocks
+- relative paths resolve against **the importing file's own directory**; `~/` is
+  home; absolute paths work
+- imported files may import further, up to **4 hops** deep
+- backtick-wrap to escape: `` `@README` `` stays literal
+- a missing import is left in place as written
+
+Guide files support **no command execution** — imports are the only
+preprocessing (same as Claude Code's CLAUDE.md; `!`-style bash execution is a
+slash-command feature, not a memory-file one).
 
 **`monocle acp`** runs Monocle as an **[Agent Client Protocol](https://agentclientprotocol.com)**
 agent over stdio (JSON-RPC) — an editor, the Monocle desktop app, or Craft spawns it and

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ Notes:
   it's fully generated, unlike the plain chat path's live token stream.
 - **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
   endpoint has no equivalent fields (a warning is printed if you pass them).
+- **Tool calls aren't executed** — this mode doesn't run a tool loop yet; if a
+  tool-calling model requests one, a warning is printed to stderr naming it
+  instead of silently dropping it (see
+  [monocle-cli#101](https://github.com/warmblood-kr/monocle-cli/issues/101)).
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -85,10 +85,11 @@ Monocle Chat (model: claude-sonnet-4-6)
 Router: https://api.monocle-ai.com
 Type your message. Press Ctrl+D to exit.
 ---
-> 안녕하세요
+▸ chat
+❯ 안녕하세요
 안녕하세요! 무엇을 도와드릴까요?
 
-> /quit
+❯ /quit
 Bye.
 ```
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -31,7 +31,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::agent::commands::{
     config_text, help_text, login_view, management_command, status_text, Management,
 };
-use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent as CoreAgent, Approver, Cancel, Observer, RunStop};
 use crate::agent::tools::{
     shell_invocation, FsBackend, ShellExec, ShellResult, ToolContext, ToolOutcome, ToolRegistry,
@@ -39,6 +39,7 @@ use crate::agent::tools::{
 };
 use crate::agent::{DEFAULT_MAX_STEPS, DEFAULT_MODEL, SYSTEM_PROMPT};
 use crate::auth::try_access_token;
+use crate::commands::repl::{diag_output, TurnDiagnostics};
 use crate::credentials::Credentials;
 use crate::error::{AppError, Result};
 use crate::net::Client;
@@ -93,6 +94,9 @@ struct SessionState {
     /// True while a `prompt()` turn is executing for this session. Guards against
     /// concurrent prompts corrupting the `mem::take`-n conversation (see Fix #8).
     running: bool,
+    /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    /// first successful turn, mirroring `commands::agent::Repl.diagnostics`.
+    diagnostics: Option<TurnDiagnostics>,
 }
 
 /// The model id for a session: the client's `_meta["monocle.model"]` if present
@@ -154,6 +158,14 @@ impl MonocleAgent {
                 let login = login_view(&Credentials::new());
                 status_text(login.as_ref(), &model, DEFAULT_MAX_STEPS, &cwd, Some(key))
             }
+            Management::Diag => {
+                let sessions = self.sessions.borrow();
+                let diagnostics = sessions.get(key).map(|st| &st.diagnostics);
+                match diagnostics {
+                    Some(d) => diag_output(d),
+                    None => diag_output(&None),
+                }
+            }
         }
     }
 }
@@ -168,6 +180,10 @@ fn advertised_commands() -> Vec<acp::AvailableCommand> {
         acp::AvailableCommand::new(
             "config",
             "Show the session config (model, working directory)",
+        ),
+        acp::AvailableCommand::new(
+            "diag",
+            "Show diagnostics for the last turn (served model, endpoint, latency, tokens, and step count)",
         ),
     ]
 }
@@ -207,6 +223,7 @@ impl Agent for MonocleAgent {
                 cancel: Cancel::new(),
                 model: session_model(&args.meta),
                 running: false,
+                diagnostics: None,
             },
         );
         // Advertise the locally-handled management commands so an ACP client can
@@ -298,6 +315,9 @@ impl Agent for MonocleAgent {
             let mut observer = AcpObserver {
                 updates: updates.clone(),
                 sid: sid.clone(),
+                served_model: None,
+                usage: None,
+                steps: 0,
             };
             let mut approver = AcpApprover {
                 calls: updates,
@@ -306,8 +326,17 @@ impl Agent for MonocleAgent {
             };
             let session = match try_access_token(&Client::new(), &Credentials::new()) {
                 Ok(s) => s,
-                Err(e) => return (convo, Err(e)),
+                Err(e) => return (convo, Err(e), None),
             };
+            // Captured before `MonocleProvider::from_session` consumes `session` —
+            // `/diag`'s endpoint must reflect the request this turn actually sent
+            // (the full URL `MonocleProvider` posts to, not just the router base),
+            // mirroring `commands::agent::Repl::run_turn`.
+            let turn_endpoint = format!(
+                "{}{}",
+                session.router_url,
+                crate::endpoints::CHAT_COMPLETIONS
+            );
             convo.push(Message::user(user));
             let provider = MonocleProvider::from_session(session);
             let tools = ToolRegistry::with_defaults();
@@ -326,9 +355,30 @@ impl Agent for MonocleAgent {
                     cancel: cancel.clone(),
                 }));
             }
+            // Wrapped tightly around the agent-core loop itself — this is what
+            // `/diag`'s `Latency:` line reports.
+            let started = std::time::Instant::now();
+            let requested_model = model.clone();
             let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
             let result = agent.run(&mut convo, &mut approver, &mut observer, &cancel);
-            (convo, result)
+            // A hard error (e.g. a network failure) must not leave stale
+            // diagnostics from an earlier successful turn silently displayable
+            // via `/diag` — mirroring `commands::agent::Repl::run_turn`. A
+            // cancelled or step-budget-exhausted turn is NOT an error
+            // (`Ok(RunStop::Cancelled | RunStop::MaxSteps)`) and still gets
+            // diagnostics, exactly like the CLI REPL.
+            let diagnostics = match &result {
+                Ok(_) => Some(TurnDiagnostics::for_agent(
+                    requested_model,
+                    observer.served_model.clone(),
+                    turn_endpoint,
+                    started.elapsed().as_millis(),
+                    observer.usage.clone(),
+                    observer.steps,
+                )),
+                Err(_) => None,
+            };
+            (convo, result, diagnostics)
         })
         .await
         .map_err(|_| acp::Error::internal_error())?;
@@ -336,10 +386,13 @@ impl Agent for MonocleAgent {
         // ALWAYS write the (possibly partial) conversation back and release the
         // running guard — for BOTH Ok and Err — so tools already executed this
         // turn are not replayed on the client's retry (Fix #1). Then propagate.
-        let (updated_convo, result) = joined;
+        // `diagnostics` is unconditionally overwritten too (`None` on error), so
+        // a failed turn never leaves stale `/diag` output from an earlier turn.
+        let (updated_convo, result, diagnostics) = joined;
         if let Some(st) = self.sessions.borrow_mut().get_mut(&key) {
             st.convo = updated_convo;
             st.running = false;
+            st.diagnostics = diagnostics;
         }
 
         // The loop reports the real stop reason — a cancel landing on the final
@@ -378,6 +431,13 @@ fn tool_kind(name: &str) -> acp::ToolKind {
 struct AcpObserver {
     updates: mpsc::UnboundedSender<ClientCall>,
     sid: acp::SessionId,
+    /// Turn-scoped accumulator for `/diag`, mirroring
+    /// `commands::agent::CliObserver`: `Agent::run`'s tool-use loop can call
+    /// the LLM several times per turn (each a "step"), and these collect the
+    /// last-known served model plus a running token total across all of them.
+    served_model: Option<String>,
+    usage: Option<TokenUsage>,
+    steps: u32,
 }
 
 impl AcpObserver {
@@ -426,6 +486,27 @@ impl Observer for AcpObserver {
         self.send(acp::SessionUpdate::AgentThoughtChunk(
             acp::ContentChunk::new(acp::ContentBlock::from(msg.to_string())),
         ));
+    }
+    fn on_turn_step(&mut self, resp: &ChatResponse) {
+        self.steps += 1;
+        if let Some(model) = &resp.model {
+            self.served_model = Some(model.clone());
+        }
+        if let Some(u) = &resp.usage {
+            // Each step's `usage.prompt_tokens` reflects that step's *entire*
+            // re-sent conversation, so summing across steps overcounts
+            // "distinct prompt content" — but it's still the right number for
+            // "total tokens this turn billed across all its LLM calls", the
+            // practically useful DX/cost question, so it's summed anyway.
+            let acc = self.usage.get_or_insert(TokenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            });
+            acc.prompt_tokens = acc.prompt_tokens.saturating_add(u.prompt_tokens);
+            acc.completion_tokens = acc.completion_tokens.saturating_add(u.completion_tokens);
+            acc.total_tokens = acc.total_tokens.saturating_add(u.total_tokens);
+        }
     }
 }
 
@@ -976,6 +1057,9 @@ mod tests {
         let observer = AcpObserver {
             updates: tx,
             sid: acp::SessionId::new("s"),
+            served_model: None,
+            usage: None,
+            steps: 0,
         };
         (observer, rx)
     }
@@ -1226,18 +1310,18 @@ mod tests {
     }
 
     #[test]
-    fn advertised_commands_names_help_status_config() {
+    fn advertised_commands_names_help_status_config_diag() {
         let names: Vec<String> = advertised_commands()
             .iter()
             .map(|c| c.name.clone())
             .collect();
-        assert_eq!(names, vec!["help", "status", "config"]);
+        assert_eq!(names, vec!["help", "status", "config", "diag"]);
     }
 
     #[test]
     fn new_session_advertises_management_commands() {
         // Drive the real `new_session` and drain the updates channel to confirm it
-        // enqueues an AvailableCommandsUpdate naming help/status/config.
+        // enqueues an AvailableCommandsUpdate naming help/status/config/diag.
         let (tx, mut rx) = mpsc::unbounded_channel::<ClientCall>();
         let agent = MonocleAgent::new(tx);
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1260,9 +1344,62 @@ mod tests {
             }
         }
         let names = names.expect("expected an AvailableCommandsUpdate notification");
-        for cmd in ["help", "status", "config"] {
+        for cmd in ["help", "status", "config", "diag"] {
             assert!(names.iter().any(|n| n == cmd), "missing {cmd} in {names:?}");
         }
+    }
+
+    /// Build a real session via `new_session` and return its key, so
+    /// `management_response`/session-state tests exercise the production
+    /// dispatch path instead of hand-rolling a `SessionState`.
+    fn new_session_key(agent: &MonocleAgent) -> String {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let resp = rt
+            .block_on(agent.new_session(acp::NewSessionRequest::new("/work")))
+            .expect("new_session");
+        resp.session_id.0.to_string()
+    }
+
+    #[test]
+    fn management_response_diag_shows_nothing_yet_before_first_turn() {
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let agent = MonocleAgent::new(tx);
+        let key = new_session_key(&agent);
+
+        let out = agent.management_response(&key, Management::Diag);
+        assert!(out.contains("No response yet"), "{out}");
+    }
+
+    /// `/diag` (ACP's `Management::Diag` arm) must render the same
+    /// `TurnDiagnostics` shape the CLI REPL's `/diag` does — this drives
+    /// `management_response` against a session whose `diagnostics` was
+    /// populated (as `prompt()`'s turn-execution path does on a successful
+    /// turn), confirming the wiring reaches `diag_output`/`format_diag`.
+    #[test]
+    fn management_response_diag_shows_stored_diagnostics() {
+        let (tx, _rx) = mpsc::unbounded_channel::<ClientCall>();
+        let agent = MonocleAgent::new(tx);
+        let key = new_session_key(&agent);
+
+        {
+            let mut sessions = agent.sessions.borrow_mut();
+            let st = sessions.get_mut(&key).expect("session exists");
+            st.diagnostics = Some(TurnDiagnostics::for_agent(
+                DEFAULT_MODEL.to_string(),
+                Some("claude-sonnet-4-6".to_string()),
+                "https://api.example.com/v1/chat/completions".to_string(),
+                42,
+                None,
+                2,
+            ));
+        }
+
+        let out = agent.management_response(&key, Management::Diag);
+        assert!(out.contains("Steps: 2"), "{out}");
+        assert!(out.contains("claude-sonnet-4-6"), "{out}");
+        assert!(out.contains("42ms"), "{out}");
     }
 
     #[test]

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -69,6 +69,7 @@ pub(crate) fn help_text() -> String {
         "  /help    show this help",
         "  /config  show session config (model, max-steps, workdir, session)",
         "  /status  show login status and session config",
+        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens)",
         "  /model   show the current model, or `/model <id>` to switch it",
         "  /exit    quit the REPL (also /quit, Ctrl-D)",
     ]
@@ -146,7 +147,7 @@ mod tests {
     #[test]
     fn help_text_lists_each_command() {
         let h = help_text();
-        for cmd in ["/help", "/config", "/status", "/model", "/exit"] {
+        for cmd in ["/help", "/config", "/status", "/diag", "/model", "/exit"] {
             assert!(h.contains(cmd), "help missing {cmd}: {h}");
         }
     }

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -1,4 +1,5 @@
-//! Shared management commands (`help`/`status`/`config`) for the agent surfaces.
+//! Shared management commands (`help`/`status`/`config`/`diag`) for the agent
+//! surfaces.
 //!
 //! These are handled **locally** — never sent to the agent/LLM — by BOTH the
 //! interactive REPL (`crate::commands::agent`) and the ACP server (`crate::acp`).
@@ -18,6 +19,7 @@ pub(crate) enum Management {
     Help,
     Status,
     Config,
+    Diag,
 }
 
 /// Recognize a management-command invocation. The leading `/` is REQUIRED so a
@@ -31,6 +33,7 @@ pub(crate) fn management_command(input: &str) -> Option<Management> {
         "/help" => Some(Management::Help),
         "/status" => Some(Management::Status),
         "/config" => Some(Management::Config),
+        "/diag" => Some(Management::Diag),
         _ => None,
     }
 }
@@ -69,7 +72,7 @@ pub(crate) fn help_text() -> String {
         "  /help    show this help",
         "  /config  show session config (model, max-steps, workdir, session)",
         "  /status  show login status and session config",
-        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens)",
+        "  /diag    show diagnostics for the last turn (served model, endpoint, latency, tokens, and step count)",
         "  /model   show the current model, or `/model <id>` to switch it",
         "  /exit    quit the REPL (also /quit, Ctrl-D)",
     ]
@@ -124,6 +127,7 @@ mod tests {
         assert_eq!(management_command("/help"), Some(Management::Help));
         assert_eq!(management_command("/status"), Some(Management::Status));
         assert_eq!(management_command("/config"), Some(Management::Config));
+        assert_eq!(management_command("/diag"), Some(Management::Diag));
     }
 
     #[test]
@@ -137,6 +141,7 @@ mod tests {
         assert_eq!(management_command("help"), None);
         assert_eq!(management_command("status"), None);
         assert_eq!(management_command("config"), None);
+        assert_eq!(management_command("diag"), None);
         assert_eq!(management_command("hello"), None);
         assert_eq!(management_command(""), None);
         assert_eq!(management_command("/bogus"), None);

--- a/src/agent/guide.rs
+++ b/src/agent/guide.rs
@@ -1,0 +1,360 @@
+//! Agent guide files — user instructions layered into the system prompt.
+//!
+//! When `monocle agent` starts it reads a guide file from two locations, in order,
+//! and appends them to the system prompt so personal- and project-level
+//! instructions steer the agent:
+//!
+//! 1. **personal** — `~/.monocle/` (applies to every project)
+//! 2. **project** — `<workdir>/` (the directory the agent runs in)
+//!
+//! Loaded in that order so the project guide comes last (more specific — by
+//! convention it wins on conflict). Home and workdir are passed in explicitly
+//! (never resolved here) so tests can thread temp dirs.
+//!
+//! ## Which file
+//!
+//! In each location the first existing, non-blank name in [`GUIDE_FILENAMES`]
+//! wins — **at most one file per directory**, matching Codex's rule. `AGENTS.md`
+//! is the cross-tool open convention (Codex, Cursor, Amp, Jules, Gemini, …, now
+//! stewarded by the Linux Foundation's Agentic AI Foundation); the rest are
+//! honored so an existing repo works with no new file. Note there is no
+//! `CODEX.md` — Codex reads `AGENTS.md`.
+//!
+//! ## Imports (`@path`)
+//!
+//! The AGENTS.md convention itself defines no preprocessing — it is plain
+//! Markdown. `@path` imports are an extension that Claude Code, Gemini CLI, and
+//! Amp each invented independently; we follow **Claude Code's semantics**, the
+//! most precisely specified of the three:
+//!
+//! - `@path/to/file` anywhere outside code spans and fenced code blocks
+//! - relative paths resolve against **the directory of the file containing the
+//!   import**, not the working directory; `~/` means home; absolute paths work
+//! - imported files may themselves import, to a depth of [`MAX_IMPORT_DEPTH`]
+//! - backtick-wrapping escapes it: `` `@README` `` stays literal
+//! - a missing / unreadable import is left in place as literal text
+//!
+//! Unlike slash-command files, guide files support **no command execution** —
+//! imports are the only preprocessing, exactly as in Claude Code's CLAUDE.md.
+
+use std::path::{Path, PathBuf};
+
+/// Guide filenames tried in each location, highest priority first.
+pub const GUIDE_FILENAMES: &[&str] = &["AGENTS.md", "AGENT.md", "CLAUDE.md", "GEMINI.md"];
+
+/// Import recursion limit — matches Claude Code's documented 4 hops.
+pub const MAX_IMPORT_DEPTH: usize = 4;
+
+/// One loaded guide file, ready to append to the system prompt.
+pub struct Guide {
+    /// Human label for logs and the prompt header, e.g. `project (AGENTS.md)`.
+    pub label: String,
+    /// File contents, with `@path` imports already expanded.
+    pub text: String,
+}
+
+/// Read the guide files that exist, in load order (personal, then project).
+pub fn load_guides(home: &Path, workdir: &Path) -> Vec<Guide> {
+    let locations = [
+        ("personal", home.join(".monocle")),
+        ("project", workdir.to_path_buf()),
+    ];
+    let mut seen: Vec<PathBuf> = Vec::new();
+    let mut out = Vec::new();
+    for (scope, dir) in locations {
+        let Some((path, text)) = first_guide(&dir) else {
+            continue;
+        };
+        // Guard the case where both locations resolve to the same file.
+        if seen.contains(&path) {
+            continue;
+        }
+        seen.push(path.clone());
+
+        let expanded = expand_imports(&text, &dir, home, 0);
+        let trimmed = expanded.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        out.push(Guide {
+            label: format!("{scope} ({name})"),
+            text: trimmed.to_string(),
+        });
+    }
+    out
+}
+
+/// Append the loaded `guides` to `base`, each under a labeled header so the model
+/// can tell instruction sources apart. With no guides, `base` is returned as-is.
+pub fn augment_system_prompt(base: &str, guides: &[Guide]) -> String {
+    let mut s = String::from(base);
+    for g in guides {
+        s.push_str(&format!("\n\n# Instructions from {}\n{}", g.label, g.text));
+    }
+    s
+}
+
+/// The first existing, non-blank guide file in `dir`, by [`GUIDE_FILENAMES`] priority.
+fn first_guide(dir: &Path) -> Option<(PathBuf, String)> {
+    GUIDE_FILENAMES.iter().find_map(|name| {
+        let path = dir.join(name);
+        let text = std::fs::read_to_string(&path).ok()?;
+        (!text.trim().is_empty()).then_some((path, text))
+    })
+}
+
+/// Expand `@path` imports in `text`. `base_dir` is the directory of the file the
+/// text came from — relative imports resolve against it. Code fences are copied
+/// through untouched, and recursion stops at [`MAX_IMPORT_DEPTH`].
+fn expand_imports(text: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    let mut in_fence = false;
+    for line in text.lines() {
+        let t = line.trim_start();
+        if t.starts_with("```") || t.starts_with("~~~") {
+            in_fence = !in_fence;
+        } else if !in_fence && depth < MAX_IMPORT_DEPTH {
+            out.push_str(&expand_line(line, base_dir, home, depth));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Expand imports in one line, leaving inline code spans (`` `…` ``) literal.
+fn expand_line(line: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    for (i, seg) in line.split('`').enumerate() {
+        if i > 0 {
+            out.push('`');
+        }
+        if i % 2 == 1 {
+            out.push_str(seg); // inside a code span — literal
+        } else {
+            out.push_str(&expand_segment(seg, base_dir, home, depth));
+        }
+    }
+    out
+}
+
+/// Expand every `@path` token in a stretch of non-code text.
+fn expand_segment(seg: &str, base_dir: &Path, home: &Path, depth: usize) -> String {
+    let mut out = String::new();
+    let mut cursor = 0; // start of not-yet-copied text
+    let mut search = 0;
+    while let Some(rel) = seg[search..].find('@') {
+        let at = search + rel;
+        // `@` must start a token (segment start or after whitespace) so an email
+        // address like `a@b.com` is never mistaken for an import.
+        let boundary = at == 0
+            || seg[..at]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let end = seg[at + 1..]
+            .find(char::is_whitespace)
+            .map(|p| at + 1 + p)
+            .unwrap_or(seg.len());
+        let raw = &seg[at + 1..end];
+        if !boundary || raw.is_empty() {
+            search = at + 1;
+            continue;
+        }
+        match read_import(raw, base_dir, home) {
+            Some((content, dir)) => {
+                out.push_str(&seg[cursor..at]);
+                out.push_str(expand_imports(&content, &dir, home, depth + 1).trim_end());
+                cursor = end;
+                search = end;
+            }
+            // Missing / unreadable import: leave the text exactly as written.
+            None => search = at + 1,
+        }
+    }
+    out.push_str(&seg[cursor..]);
+    out
+}
+
+/// Resolve an import path (`~/…` = home, relative = against the importing file's
+/// directory, absolute as-is) and read it. Also returns the directory that file's
+/// own imports resolve against.
+fn read_import(raw: &str, base_dir: &Path, home: &Path) -> Option<(String, PathBuf)> {
+    let path = match raw.strip_prefix("~/") {
+        Some(rest) => home.join(rest),
+        None => {
+            let p = Path::new(raw);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                base_dir.join(p)
+            }
+        }
+    };
+    let text = std::fs::read_to_string(&path).ok()?;
+    let dir = path.parent().unwrap_or(base_dir).to_path_buf();
+    Some((text, dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn no_guides_leaves_prompt_unchanged() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let guides = load_guides(home.path(), work.path());
+        assert!(guides.is_empty());
+        assert_eq!(augment_system_prompt("BASE", &guides), "BASE");
+    }
+
+    #[test]
+    fn loads_personal_then_project_in_order() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&home.path().join(".monocle").join("AGENTS.md"), "be terse");
+        write(&work.path().join("AGENTS.md"), "use tabs");
+        let guides = load_guides(home.path(), work.path());
+        assert_eq!(guides.len(), 2);
+        assert!(guides[0].label.starts_with("personal"));
+        assert!(guides[1].label.starts_with("project"));
+        let prompt = augment_system_prompt("BASE", &guides);
+        assert!(prompt.starts_with("BASE"));
+        assert!(prompt.find("be terse").unwrap() < prompt.find("use tabs").unwrap());
+    }
+
+    #[test]
+    fn skips_missing_and_blank_files() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "   \n  ");
+        assert!(load_guides(home.path(), work.path()).is_empty());
+    }
+
+    #[test]
+    fn agents_md_wins_over_lower_priority_names() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "from agents");
+        write(&work.path().join("CLAUDE.md"), "from claude");
+        write(&work.path().join("GEMINI.md"), "from gemini");
+        let guides = load_guides(home.path(), work.path());
+        assert_eq!(guides.len(), 1, "at most one file per directory");
+        assert_eq!(guides[0].text, "from agents");
+        assert_eq!(guides[0].label, "project (AGENTS.md)");
+    }
+
+    #[test]
+    fn falls_back_through_the_filename_chain() {
+        for (present, expected) in [
+            ("AGENT.md", "project (AGENT.md)"),
+            ("CLAUDE.md", "project (CLAUDE.md)"),
+            ("GEMINI.md", "project (GEMINI.md)"),
+        ] {
+            let home = tempfile::tempdir().unwrap();
+            let work = tempfile::tempdir().unwrap();
+            write(&work.path().join(present), "hello");
+            let guides = load_guides(home.path(), work.path());
+            assert_eq!(guides.len(), 1, "{present} should be picked up");
+            assert_eq!(guides[0].label, expected);
+        }
+    }
+
+    #[test]
+    fn expands_imports_relative_to_the_importing_file() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "top\n@docs/style.md\nend");
+        write(&work.path().join("docs").join("style.md"), "STYLE RULES");
+        let guides = load_guides(home.path(), work.path());
+        assert!(guides[0].text.contains("STYLE RULES"));
+        assert!(!guides[0].text.contains("@docs/style.md"));
+    }
+
+    #[test]
+    fn nested_imports_resolve_against_their_own_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "@docs/a.md");
+        // `b.md` is referenced relative to docs/, not the workdir.
+        write(&work.path().join("docs").join("a.md"), "A\n@b.md");
+        write(&work.path().join("docs").join("b.md"), "B");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert!(text.contains('A') && text.contains('B'));
+    }
+
+    #[test]
+    fn home_import_expands_tilde() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "@~/shared/rules.md");
+        write(&home.path().join("shared").join("rules.md"), "SHARED");
+        assert!(load_guides(home.path(), work.path())[0]
+            .text
+            .contains("SHARED"));
+    }
+
+    #[test]
+    fn imports_inside_code_are_left_literal() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(
+            &work.path().join("AGENTS.md"),
+            "escaped `@secret.md` here\n```\n@secret.md\n```",
+        );
+        write(&work.path().join("secret.md"), "LEAKED");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert!(
+            !text.contains("LEAKED"),
+            "code spans/fences must not import"
+        );
+        assert!(text.contains("`@secret.md`"));
+    }
+
+    #[test]
+    fn missing_import_is_left_as_written() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(&work.path().join("AGENTS.md"), "see @nope.md ok");
+        assert_eq!(
+            load_guides(home.path(), work.path())[0].text,
+            "see @nope.md ok"
+        );
+    }
+
+    #[test]
+    fn email_like_text_is_not_an_import() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        write(
+            &work.path().join("AGENTS.md"),
+            "ask jeongsoo@warmblood.kr ok",
+        );
+        assert_eq!(
+            load_guides(home.path(), work.path())[0].text,
+            "ask jeongsoo@warmblood.kr ok"
+        );
+    }
+
+    #[test]
+    fn import_recursion_stops_at_max_depth() {
+        let home = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        // A self-importing file must terminate rather than recurse forever.
+        write(&work.path().join("AGENTS.md"), "LOOP\n@AGENTS.md");
+        let text = &load_guides(home.path(), work.path())[0].text;
+        assert_eq!(text.matches("LOOP").count(), MAX_IMPORT_DEPTH + 1);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -23,7 +23,7 @@ pub const SYSTEM_PROMPT: &str = "You are Monocle's headless agent. Use the provi
 session's working directory. Take minimal, verified steps. When finished, give a brief summary.";
 
 /// Default model id (routed/validated by monocle chat-proxy — we only pass it through).
-pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+pub const DEFAULT_MODEL: &str = "claude-sonnet-5";
 
 /// Default agent-loop step budget before giving up.
 pub const DEFAULT_MAX_STEPS: usize = 20;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,8 @@
 //! tools, permission/sandboxing, session, and ACP surface come later.
 
 pub mod commands;
+pub mod guide;
+pub mod permission;
 pub mod providers;
 pub mod runner;
 pub mod session;

--- a/src/agent/permission.rs
+++ b/src/agent/permission.rs
@@ -1,0 +1,225 @@
+//! Per-session / persisted tool-permission decisions for the interactive agent.
+//!
+//! The agent loop gates side-effecting tools behind an `Approver` (runner.rs).
+//! On its own the interactive approver has no memory, so the user re-answers the
+//! same prompt every time. This module gives it one: a decision can be remembered
+//! for **this session** (in-memory) or **always** — persisted to a working-dir
+//! `.monocle/settings.json` so future sessions don't re-prompt.
+//!
+//! Granularity is **per tool name**, except the shell tool (`bash`/`powershell`)
+//! which is **per command string**, so allowing `npm test` never green-lights
+//! every shell command. Persisted rules live under `allowedTools`:
+//!
+//! ```json
+//! { "allowedTools": ["write_file", "bash(npm test)", "bash(cargo *)"] }
+//! ```
+//!
+//! A `bash(...)` pattern matches a command exactly, or as a prefix when it ends
+//! with `*` (`bash(cargo *)` allows `cargo build`, `cargo test`, …). Users can
+//! hand-edit the file to add such wildcards.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+/// The command string for a shell tool call, if present. Its presence is what
+/// makes a call *command-scoped* (only the shell tool takes a `command` arg).
+fn command_arg(args: &Value) -> Option<&str> {
+    args.get("command").and_then(Value::as_str)
+}
+
+/// The rule string to remember for a given tool call: the tool name, or
+/// `name(command)` for a shell call.
+pub fn rule_for(tool_name: &str, args: &Value) -> String {
+    match command_arg(args) {
+        Some(cmd) => format!("{tool_name}({})", cmd.trim()),
+        None => tool_name.to_string(),
+    }
+}
+
+/// Whether a stored `rule` authorizes this tool call. Plain rules match by tool
+/// name; `name(pattern)` rules also require the command to match `pattern`
+/// (exact, or prefix when `pattern` ends with `*`).
+pub fn rule_matches(rule: &str, tool_name: &str, args: &Value) -> bool {
+    match rule.strip_suffix(')').and_then(|r| r.split_once('(')) {
+        Some((name, pat)) => {
+            name == tool_name
+                && command_arg(args).is_some_and(|cmd| command_matches(pat, cmd.trim()))
+        }
+        None => rule == tool_name,
+    }
+}
+
+fn command_matches(pat: &str, cmd: &str) -> bool {
+    match pat.strip_suffix('*') {
+        Some(prefix) => cmd.starts_with(prefix),
+        None => cmd == pat,
+    }
+}
+
+/// A session's remembered tool-permission decisions: the in-memory allow-set
+/// (session + rules loaded from disk) plus where "always" decisions persist.
+pub struct PermissionStore {
+    rules: Vec<String>,
+    settings_path: PathBuf,
+}
+
+impl PermissionStore {
+    /// Load allow-rules from `<workdir>/.monocle/settings.json`. A missing or
+    /// invalid file yields an empty allow-set (nothing is pre-authorized).
+    pub fn load(workdir: &Path) -> Self {
+        let settings_path = workdir.join(".monocle").join("settings.json");
+        let rules = read_allowed_tools(&settings_path);
+        Self {
+            rules,
+            settings_path,
+        }
+    }
+
+    /// Whether this call is already authorized by a remembered rule.
+    pub fn is_allowed(&self, tool_name: &str, args: &Value) -> bool {
+        self.rules.iter().any(|r| rule_matches(r, tool_name, args))
+    }
+
+    /// Remember this call for the rest of the session only (not persisted).
+    pub fn allow_session(&mut self, tool_name: &str, args: &Value) {
+        self.remember(rule_for(tool_name, args));
+    }
+
+    /// Remember this call for the session AND persist it to
+    /// `.monocle/settings.json` so future sessions skip the prompt.
+    pub fn allow_always(&mut self, tool_name: &str, args: &Value) -> std::io::Result<()> {
+        let rule = rule_for(tool_name, args);
+        self.remember(rule.clone());
+        persist_allowed_tool(&self.settings_path, &rule)
+    }
+
+    fn remember(&mut self, rule: String) {
+        if !self.rules.contains(&rule) {
+            self.rules.push(rule);
+        }
+    }
+}
+
+/// Read the `allowedTools` string array from a settings file (missing/invalid → empty).
+fn read_allowed_tools(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+        .and_then(|v| v.get("allowedTools").and_then(Value::as_array).cloned())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Append `rule` to `allowedTools`, preserving any other keys the user hand-added
+/// (read-modify-write, matching `commands::setup`'s treatment of settings files).
+fn persist_allowed_tool(path: &Path, rule: &str) -> std::io::Result<()> {
+    let mut settings: Map<String, Value> = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+
+    let list = settings
+        .entry("allowedTools".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !list.is_array() {
+        *list = Value::Array(Vec::new());
+    }
+    let arr = list.as_array_mut().unwrap();
+    if !arr.iter().any(|x| x.as_str() == Some(rule)) {
+        arr.push(Value::String(rule.to_string()));
+    }
+
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let body =
+        serde_json::to_string_pretty(&Value::Object(settings)).map_err(std::io::Error::other)?;
+    std::fs::write(path, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn plain_tool_rule_matches_by_name() {
+        assert!(rule_matches(
+            "write_file",
+            "write_file",
+            &json!({ "path": "a" })
+        ));
+        assert!(!rule_matches("write_file", "edit_file", &json!({})));
+    }
+
+    #[test]
+    fn shell_rule_is_command_scoped() {
+        let rule = rule_for("bash", &json!({ "command": "npm test" }));
+        assert_eq!(rule, "bash(npm test)");
+        assert!(rule_matches(
+            &rule,
+            "bash",
+            &json!({ "command": "npm test" })
+        ));
+        assert!(!rule_matches(
+            &rule,
+            "bash",
+            &json!({ "command": "rm -rf /" })
+        ));
+    }
+
+    #[test]
+    fn shell_wildcard_prefix_matches() {
+        assert!(rule_matches(
+            "bash(cargo *)",
+            "bash",
+            &json!({ "command": "cargo build" })
+        ));
+        assert!(!rule_matches(
+            "bash(cargo *)",
+            "bash",
+            &json!({ "command": "npm run" })
+        ));
+    }
+
+    #[test]
+    fn store_persists_and_reloads_always_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = PermissionStore::load(dir.path());
+        assert!(!store.is_allowed("write_file", &json!({})));
+        store.allow_always("write_file", &json!({})).unwrap();
+        assert!(store.is_allowed("write_file", &json!({})));
+        // A fresh load sees the persisted rule.
+        assert!(PermissionStore::load(dir.path()).is_allowed("write_file", &json!({})));
+    }
+
+    #[test]
+    fn session_rules_are_not_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = PermissionStore::load(dir.path());
+        store.allow_session("bash", &json!({ "command": "ls" }));
+        assert!(store.is_allowed("bash", &json!({ "command": "ls" })));
+        // Session-only decisions do not survive into a fresh load.
+        assert!(!PermissionStore::load(dir.path()).is_allowed("bash", &json!({ "command": "ls" })));
+    }
+
+    #[test]
+    fn persist_preserves_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".monocle").join("settings.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{ "model": "claude-sonnet-4-6" }"#).unwrap();
+        PermissionStore::load(dir.path())
+            .allow_always("edit_file", &json!({}))
+            .unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["model"], "claude-sonnet-4-6");
+        assert_eq!(v["allowedTools"][0], "edit_file");
+    }
+}

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -160,6 +160,33 @@ pub struct ChatResponse {
     /// magic `finish_reason` string. A complete-but-then-dropped stream (the
     /// model already sent `finish_reason`) is NOT truncated.
     pub truncated: bool,
+    /// Token counts, when the backend reports them. Always present on a
+    /// non-streaming reply (the OpenAI-compatible `usage` object is part of
+    /// the standard, non-opt-in response shape); for streaming, only present
+    /// because `MonocleProvider::build_body` opts in via
+    /// `stream_options.include_usage` — see that fn's doc comment.
+    pub usage: Option<TokenUsage>,
+}
+
+/// Token counts for one turn (OpenAI-compatible `usage` object:
+/// `prompt_tokens` + `completion_tokens` = `total_tokens`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Parse an OpenAI-compatible `usage` object off a response/chunk body, if
+/// present. Shared by the non-streaming parser and the streaming assembler's
+/// final-chunk handling.
+fn parse_usage(data: &Value) -> Option<TokenUsage> {
+    let usage = data.get("usage")?;
+    Some(TokenUsage {
+        prompt_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
+        completion_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
+        total_tokens: usage["total_tokens"].as_u64().unwrap_or(0) as u32,
+    })
 }
 
 /// Ensure every assembled tool call has a non-empty `id`, synthesizing a stable
@@ -192,12 +219,14 @@ fn parse_response_value(data: &Value) -> Result<ChatResponse> {
     let finish_reason = data["choices"][0]["finish_reason"]
         .as_str()
         .map(String::from);
+    let usage = parse_usage(data);
     Ok(ChatResponse {
         content,
         tool_calls,
         model,
         finish_reason,
         truncated: false,
+        usage,
     })
 }
 
@@ -243,6 +272,10 @@ fn assemble_sse_stream(
     let mut model: Option<String> = None;
     let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
     let mut truncated = false;
+    // Only present when the request opted in via `stream_options.include_usage`
+    // (see `MonocleProvider::build_body`) — OpenAI-compatible servers then send
+    // one extra terminal chunk carrying `usage` alongside an empty `choices`.
+    let mut usage: Option<TokenUsage> = None;
 
     loop {
         let raw = match next_line() {
@@ -277,6 +310,9 @@ fn assemble_sse_stream(
         };
         if model.is_none() {
             model = v["model"].as_str().map(String::from);
+        }
+        if usage.is_none() {
+            usage = parse_usage(&v);
         }
         let choice = &v["choices"][0];
         if let Some(fr) = choice["finish_reason"].as_str() {
@@ -344,6 +380,7 @@ fn assemble_sse_stream(
         model,
         finish_reason,
         truncated,
+        usage,
     })
 }
 
@@ -425,6 +462,12 @@ impl MonocleProvider {
             "messages": messages,
             "stream": stream,
         });
+        if stream {
+            // OpenAI-compatible streaming omits `usage` unless the request
+            // opts in — without this, a streamed turn's `/diag` would never
+            // have token counts (only the non-streaming path would).
+            body["stream_options"] = json!({"include_usage": true});
+        }
         if let Some(max_tokens) = req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
@@ -607,6 +650,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn non_streaming_response_with_usage_is_parsed() {
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15},
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: 12,
+                completion_tokens: 3,
+                total_tokens: 15,
+            })
+        );
+    }
+
+    #[test]
+    fn non_streaming_response_without_usage_is_none() {
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(resp.usage, None);
+    }
+
+    #[test]
+    fn streaming_final_usage_chunk_is_captured() {
+        // Mirrors the terminal chunk an OpenAI-compatible server sends when the
+        // request opts in via `stream_options.include_usage`: empty `choices`
+        // alongside a `usage` object, after the content-bearing deltas.
+        let usage_chunk =
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}";
+        let (resp, deltas) = run_stream(vec![
+            content_line("Hi"),
+            Ok(Some(usage_chunk.to_string())),
+            Ok(Some("data: [DONE]".to_string())),
+            Ok(None),
+        ]);
+        let resp = resp.expect("normal completion with a trailing usage chunk should succeed");
+        assert_eq!(resp.content, "Hi");
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 2,
+                total_tokens: 7,
+            })
+        );
+        assert_eq!(deltas, vec!["Hi".to_string()]);
+    }
+
     fn dummy_provider() -> MonocleProvider {
         MonocleProvider::new("token", "https://router.example")
     }
@@ -628,6 +725,27 @@ mod tests {
         assert_eq!(body["messages"][1]["content"], json!("hello"));
         assert!(body["messages"][1]["content"].is_string());
         assert_eq!(body["max_tokens"], json!(100));
+    }
+
+    #[test]
+    fn build_body_streaming_opts_into_usage() {
+        // Streaming requests must ask for the terminal `usage` chunk (OpenAI-
+        // compatible servers omit it otherwise) so `/diag` can show token
+        // counts on a streamed turn, same as a non-streaming one.
+        let provider = dummy_provider();
+        let req = ChatRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![Message::user("hello")],
+            ..Default::default()
+        };
+        let streaming_body = provider.build_body(&req, true);
+        assert_eq!(
+            streaming_body["stream_options"],
+            json!({"include_usage": true})
+        );
+
+        let non_streaming_body = provider.build_body(&req, false);
+        assert!(non_streaming_body.get("stream_options").is_none());
     }
 
     #[test]

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -389,6 +389,15 @@ impl MonocleProvider {
         Self::new(session.token, session.router_url)
     }
 
+    /// Update this provider's token/router_url from a freshly resolved auth
+    /// session, reusing the existing HTTP client (its connection pool and TLS
+    /// session) rather than rebuilding one — `Client::new()` is real setup cost
+    /// a token refresh doesn't need to pay for every turn.
+    pub fn refresh(&mut self, session: AuthSession) {
+        self.token = session.token;
+        self.router_url = session.router_url;
+    }
+
     fn build_body(&self, req: &ChatRequest, stream: bool) -> Value {
         let mut messages = json!(req.messages);
         // Vision requests (monocle-cli file-attach plan): rewrite the last

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -181,11 +181,18 @@ pub struct TokenUsage {
 /// present. Shared by the non-streaming parser and the streaming assembler's
 /// final-chunk handling.
 fn parse_usage(data: &Value) -> Option<TokenUsage> {
+    // `.unwrap_or(0)` handles a missing/non-numeric field; the `u32::try_from`
+    // below handles a present-but-oversized one (e.g. a malformed upstream
+    // payload) by saturating to `u32::MAX` instead of silently wrapping to a
+    // small, wrong number via an `as u32` truncation.
     let usage = data.get("usage")?;
+    let field = |name: &str| -> u32 {
+        u32::try_from(usage[name].as_u64().unwrap_or(0)).unwrap_or(u32::MAX)
+    };
     Some(TokenUsage {
-        prompt_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
-        completion_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
-        total_tokens: usage["total_tokens"].as_u64().unwrap_or(0) as u32,
+        prompt_tokens: field("prompt_tokens"),
+        completion_tokens: field("completion_tokens"),
+        total_tokens: field("total_tokens"),
     })
 }
 
@@ -676,6 +683,30 @@ mod tests {
         });
         let resp = parse_response_value(&data).unwrap();
         assert_eq!(resp.usage, None);
+    }
+
+    #[test]
+    fn oversized_usage_field_saturates_instead_of_wrapping() {
+        // A malformed/oversized upstream value must saturate to `u32::MAX`,
+        // not silently wrap to a small (wrong-looking) number via `as u32`.
+        let data = serde_json::json!({
+            "model": "gpt-4o",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": u64::MAX,
+                "completion_tokens": (u32::MAX as u64) + 1,
+                "total_tokens": 15,
+            },
+        });
+        let resp = parse_response_value(&data).unwrap();
+        assert_eq!(
+            resp.usage,
+            Some(TokenUsage {
+                prompt_tokens: u32::MAX,
+                completion_tokens: u32::MAX,
+                total_tokens: 15,
+            })
+        );
     }
 
     #[test]

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -200,7 +200,11 @@ fn parse_usage(data: &Value) -> Option<TokenUsage> {
 /// `call_{i}` from position when the wire delivered an empty one. Downstream (ACP)
 /// correlates `ToolCall` / permission / `ToolCallUpdate` by this id, so an empty id
 /// would silently break that correlation. Non-empty ids are left untouched.
-fn ensure_tool_call_ids(tool_calls: &mut [ToolCall]) {
+///
+/// `pub(crate)`: also called by `responses_api::parse_tool_calls` (monocle-cli#101),
+/// which parses `tool_calls` off jarvice's `/api/responses` reply against this same
+/// `ToolCall` type and must not silently diverge on id-normalization from this path.
+pub(crate) fn ensure_tool_call_ids(tool_calls: &mut [ToolCall]) {
     for (i, tc) in tool_calls.iter_mut().enumerate() {
         if tc.id.is_empty() {
             tc.id = format!("call_{i}");

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
-use crate::agent::providers::{ChatRequest, LlmProvider, Message};
+use crate::agent::providers::{ChatRequest, ChatResponse, LlmProvider, Message};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
 use crate::error::Result;
 
@@ -62,6 +62,12 @@ pub trait Observer {
     /// A meta/control notice (stopped, cancelled) — NOT model answer text, so the
     /// CLI keeps it off the stdout answer channel.
     fn on_notice(&mut self, _msg: &str) {}
+    /// Called once per LLM call this turn makes (a turn can be several steps
+    /// when tool calls happen) — carries whatever metadata this step's response
+    /// reported (served model, token usage), so a caller can accumulate turn-level
+    /// diagnostics. Default no-op; `Silent` and any observer that doesn't care
+    /// about diagnostics need no changes.
+    fn on_turn_step(&mut self, _resp: &ChatResponse) {}
 }
 
 pub struct Silent;
@@ -164,6 +170,7 @@ impl<'a, P: LlmProvider> Agent<'a, P> {
             let resp = self
                 .provider
                 .chat_stream(&req, &mut |delta| observer.on_text_delta(delta))?;
+            observer.on_turn_step(&resp);
 
             // A mid-stream drop was salvaged into a truncated response
             // (monocle-cli#59): tool_calls are already dropped, so this falls

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -45,10 +45,12 @@ pub fn red(s: &str) -> String {
 }
 
 /// Monocle brand orange (#f97316, DESIGN.md §2 Primary/Orange/500) via
-/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints
-/// (see agent.rs/chat.rs mode banners) — NOT a general-purpose accent color;
-/// the rest of this CLI intentionally stays muted/cyan (gh/brew convention)
-/// so it never fights the user's terminal theme.
+/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints —
+/// today, just `monocle agent`'s "▸ agent" mode banner (`monocle chat`'s "▸
+/// chat" banner deliberately stays cyan, see `commands::repl::mode_banner`) —
+/// NOT a general-purpose accent color; the rest of this CLI intentionally
+/// stays muted/cyan (gh/brew convention) so it never fights the user's
+/// terminal theme.
 pub fn orange(s: &str) -> String {
     wrap("38;2;249;115;22", "39", s)
 }
@@ -57,9 +59,17 @@ pub fn orange(s: &str) -> String {
 mod tests {
     use super::orange;
     use std::env;
+    use std::sync::Mutex;
+
+    // `FORCE_COLOR` is process-wide state and `cargo test` runs unit tests on
+    // parallel threads within one process — guard the mutation so a future
+    // test that reads/sets NO_COLOR/FORCE_COLOR (or asserts exact-equality on
+    // colored output) can't race with this one.
+    static COLOR_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn orange_wraps_with_truecolor_sgr_when_forced() {
+        let _guard = COLOR_ENV_LOCK.lock().unwrap();
         env::set_var("FORCE_COLOR", "1");
         let out = orange("agent");
         env::remove_var("FORCE_COLOR");

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -43,3 +43,26 @@ pub fn cyan(s: &str) -> String {
 pub fn red(s: &str) -> String {
     wrap("31", "39", s)
 }
+
+/// Monocle brand orange (#f97316, DESIGN.md §2 Primary/Orange/500) via
+/// truecolor ANSI. Reserved for the handful of deliberate brand touchpoints
+/// (see agent.rs/chat.rs mode banners) — NOT a general-purpose accent color;
+/// the rest of this CLI intentionally stays muted/cyan (gh/brew convention)
+/// so it never fights the user's terminal theme.
+pub fn orange(s: &str) -> String {
+    wrap("38;2;249;115;22", "39", s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::orange;
+    use std::env;
+
+    #[test]
+    fn orange_wraps_with_truecolor_sgr_when_forced() {
+        env::set_var("FORCE_COLOR", "1");
+        let out = orange("agent");
+        env::remove_var("FORCE_COLOR");
+        assert!(out.contains("38;2;249;115;22"));
+    }
+}

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
+use crate::agent::permission::PermissionStore;
 use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent, AllowAll, Approver, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
@@ -103,45 +104,83 @@ const SLASH_COMMANDS: &[&str] = &[
     "/help", "/config", "/status", "/model", "/diag", "/exit", "/quit",
 ];
 
-/// Interactive approver: prompts the user (stderr) before each side-effecting
-/// tool call and reads a y/N answer from stdin. Default (empty / non-y / EOF) is
-/// deny — the safe choice. Only ever constructed on an interactive TTY, where the
-/// terminal is in cooked mode during a turn so a plain `read_line` works.
-struct PromptApprover;
-impl Approver for PromptApprover {
+/// Interactive approver with a memory. Before each side-effecting tool call it
+/// consults the session's [`PermissionStore`]; if the call is already authorized
+/// (allowed earlier this session, or persisted in `.monocle/settings.json`) it
+/// runs with no prompt. Otherwise it prompts on stderr with four choices —
+/// **[y]** once, **[s]** this session, **[a]** always (persist), **[N]** deny —
+/// and records `s`/`a` in the store. Default (empty / unknown / EOF) is deny.
+/// Only ever constructed on an interactive TTY, where the terminal is in cooked
+/// mode during a turn so a plain `read_line` works.
+struct PromptApprover<'a> {
+    store: &'a mut PermissionStore,
+}
+impl Approver for PromptApprover<'_> {
     fn approve(&mut self, _id: &str, name: &str, args: &Value) -> bool {
-        // For `shell`, the interesting thing is the command; else show the JSON.
-        let summary = if name == "shell" {
-            args.get("command")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .unwrap_or_else(|| args.to_string())
-        } else {
-            args.to_string()
-        };
+        // A prior session/persisted decision skips the prompt entirely.
+        if self.store.is_allowed(name, args) {
+            return true;
+        }
+        // For the shell tool the interesting thing is the command; else the JSON.
+        let summary = args
+            .get("command")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| args.to_string());
         eprint!(
             "{} {} {}: {}  {} ",
             c::yellow("⚠"),
             c::dim("run"),
             c::bold(name),
             c::dim(&one_line(&summary, 120)),
-            c::yellow("[y/N]"),
+            c::yellow("[y]es once / [s]ession / [a]lways / [N]o"),
         );
         let _ = std::io::stderr().flush();
         let mut line = String::new();
-        match std::io::stdin().read_line(&mut line) {
-            Ok(0) => false, // EOF → deny
+        let answer = match std::io::stdin().read_line(&mut line) {
+            Ok(0) => ApprovalAnswer::Deny, // EOF → deny
             Ok(_) => approve_answer(&line),
-            Err(_) => false,
+            Err(_) => ApprovalAnswer::Deny,
+        };
+        match answer {
+            ApprovalAnswer::Once => true,
+            ApprovalAnswer::Session => {
+                self.store.allow_session(name, args);
+                true
+            }
+            ApprovalAnswer::Always => {
+                if let Err(e) = self.store.allow_always(name, args) {
+                    eprintln!("{} 권한을 저장하지 못했습니다: {e}", c::yellow("⚠"));
+                }
+                true
+            }
+            ApprovalAnswer::Deny => false,
         }
     }
 }
 
-/// Pure y/N decision for an approval prompt: an answer counts as "yes" only if,
-/// after leading whitespace, it starts with `y`/`Y`. Everything else (empty,
-/// `n`, a stray word) is "no" — the safe default.
-fn approve_answer(input: &str) -> bool {
-    matches!(input.trim_start().chars().next(), Some('y') | Some('Y'))
+/// A four-way approval decision. Anything but a leading `y`/`s`/`a` is `Deny` —
+/// the safe default (empty, `n`, EOF, a stray word).
+#[derive(Debug, PartialEq, Eq)]
+enum ApprovalAnswer {
+    /// `y` — allow this one call only.
+    Once,
+    /// `s` — allow for the rest of this session (in-memory).
+    Session,
+    /// `a` — allow always; persist to `.monocle/settings.json`.
+    Always,
+    /// `n` / empty / unknown / EOF — deny.
+    Deny,
+}
+
+/// Pure decision for an approval prompt, keyed on the first non-space character.
+fn approve_answer(input: &str) -> ApprovalAnswer {
+    match input.trim_start().chars().next() {
+        Some('y') | Some('Y') => ApprovalAnswer::Once,
+        Some('s') | Some('S') => ApprovalAnswer::Session,
+        Some('a') | Some('A') => ApprovalAnswer::Always,
+        _ => ApprovalAnswer::Deny,
+    }
 }
 
 /// Approver-selection policy: use the interactive [`PromptApprover`] only on an
@@ -169,6 +208,9 @@ struct Repl<'a> {
     auto_approve: bool,
     /// Whether this session runs on an interactive TTY (can prompt for approval).
     interactive: bool,
+    /// Remembered tool-permission decisions (session + `.monocle/settings.json`),
+    /// so an allowed tool isn't re-prompted for the life of the session.
+    permissions: PermissionStore,
     /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
     /// first successful turn, mirroring `monocle chat`'s REPL.
     diagnostics: Option<TurnDiagnostics>,
@@ -207,7 +249,9 @@ impl Repl<'_> {
         // Gate side-effecting tools behind the user in interactive mode; scripts
         // / one-shot / `--auto-approve` keep the unattended `AllowAll` behavior.
         let mut allow = AllowAll;
-        let mut prompt = PromptApprover;
+        let mut prompt = PromptApprover {
+            store: &mut self.permissions,
+        };
         let approver: &mut dyn Approver =
             if use_prompt_approver(self.auto_approve, self.interactive) {
                 &mut prompt
@@ -310,6 +354,15 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         move || c.cancel()
     });
 
+    // Layer any guide files (personal ~/.monocle, then the workdir) onto the
+    // system prompt so user/project instructions steer the agent. Only seeds a
+    // *new* conversation; a resumed session replays its own persisted system turn.
+    let guides = crate::agent::guide::load_guides(&home_dir(), &workdir);
+    for g in &guides {
+        eprintln!("{}", c::dim(&format!("loaded guide — {}", g.label)));
+    }
+    let system_prompt = crate::agent::guide::augment_system_prompt(SYSTEM_PROMPT, &guides);
+
     // Optional named session: resume by replaying the persisted conversation.
     let session: Option<SessionStore> = opts
         .session
@@ -319,7 +372,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         Some(store) => {
             let loaded = store.load()?;
             if loaded.is_empty() {
-                (vec![Message::system(SYSTEM_PROMPT)], 0)
+                (vec![Message::system(system_prompt)], 0)
             } else {
                 eprintln!(
                     "{}",
@@ -329,8 +382,12 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                 (loaded, n)
             }
         }
-        None => (vec![Message::system(SYSTEM_PROMPT)], 0),
+        None => (vec![Message::system(system_prompt)], 0),
     };
+
+    // Load any previously-persisted tool permissions for this working directory
+    // so allowed tools run without re-prompting.
+    let permissions = PermissionStore::load(&workdir);
 
     let mut repl = Repl {
         client,
@@ -345,6 +402,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         persisted,
         auto_approve: opts.auto_approve,
         interactive,
+        permissions,
         diagnostics: None,
     };
 
@@ -529,16 +587,26 @@ mod tests {
     }
 
     #[test]
-    fn approve_answer_treats_y_prefix_as_yes() {
+    fn approve_answer_treats_y_prefix_as_once() {
         for yes in ["y", "yes", "Y", "YES", "yeah", "  y", "y\n"] {
-            assert!(approve_answer(yes), "expected yes for {yes:?}");
+            assert_eq!(approve_answer(yes), ApprovalAnswer::Once, "for {yes:?}");
         }
     }
 
     #[test]
-    fn approve_answer_defaults_to_no() {
-        for no in ["", "n", "no", "N", "find", "\n", "  ", "1", "sure"] {
-            assert!(!approve_answer(no), "expected no for {no:?}");
+    fn approve_answer_maps_session_and_always() {
+        for s in ["s", "session", "S", "  s"] {
+            assert_eq!(approve_answer(s), ApprovalAnswer::Session, "for {s:?}");
+        }
+        for a in ["a", "always", "A", "a\n"] {
+            assert_eq!(approve_answer(a), ApprovalAnswer::Always, "for {a:?}");
+        }
+    }
+
+    #[test]
+    fn approve_answer_defaults_to_deny() {
+        for no in ["", "n", "no", "N", "find", "\n", "  ", "1"] {
+            assert_eq!(approve_answer(no), ApprovalAnswer::Deny, "for {no:?}");
         }
     }
 

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -18,7 +18,7 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -232,7 +232,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
 
     eprintln!(
         "{} {}",
-        c::orange("\u{25B8} agent"),
+        mode_banner("agent", c::orange),
         c::dim(&workdir.display().to_string())
     );
     // Interactive sessions gate side-effecting tools behind a y/N prompt (unless

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -188,8 +188,9 @@ impl Repl<'_> {
         // Fresh token each turn (get_access_token refreshes if near expiry).
         let auth = get_access_token(self.client, self.creds);
         // Captured before `MonocleProvider::from_session` consumes `auth` —
-        // `/diag`'s endpoint must reflect the request this turn actually sent.
-        let turn_endpoint = auth.router_url.clone();
+        // `/diag`'s endpoint must reflect the request this turn actually sent
+        // (the full URL `MonocleProvider` posts to, not just the router base).
+        let turn_endpoint = format!("{}{}", auth.router_url, crate::endpoints::CHAT_COMPLETIONS);
         let provider = MonocleProvider::from_session(auth);
         let agent = Agent::with_max_steps(
             &provider,
@@ -231,14 +232,14 @@ impl Repl<'_> {
         out.write_all(b"\n")?;
         out.flush()?;
 
-        self.diagnostics = Some(TurnDiagnostics {
-            requested_model: self.model.clone(),
-            served_model: observer.served_model.clone(),
-            endpoint: turn_endpoint,
-            latency_ms: started.elapsed().as_millis(),
-            usage: observer.usage.clone(),
-            steps: Some(observer.steps),
-        });
+        self.diagnostics = Some(TurnDiagnostics::for_agent(
+            self.model.clone(),
+            observer.served_model.clone(),
+            turn_endpoint,
+            started.elapsed().as_millis(),
+            observer.usage.clone(),
+            observer.steps,
+        ));
 
         // Persist this turn's new messages (append-only).
         if let Some(store) = &self.session {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -18,7 +18,7 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -232,7 +232,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
 
     eprintln!(
         "{} {}",
-        c::dim("agent · workdir"),
+        c::orange("\u{25B8} agent"),
         c::dim(&workdir.display().to_string())
     );
     // Interactive sessions gate side-effecting tools behind a y/N prompt (unless
@@ -355,7 +355,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
     };
     let history_path = home_dir().join(".monocle").join("agent_history");
 
-    run_repl(helper, history_path, "» ", |msg| {
+    run_repl(helper, history_path, PROMPT, |msg| {
         // `/model` switches the model for subsequent turns (handled before
         // the general dispatch since it carries an argument).
         if handle_model_command(msg, &mut repl.model) {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::agent::commands::{config_text, help_text, login_view, status_text};
-use crate::agent::providers::{Message, MonocleProvider};
+use crate::agent::providers::{ChatResponse, Message, MonocleProvider, TokenUsage};
 use crate::agent::runner::{Agent, AllowAll, Approver, Cancel, Observer};
 use crate::agent::session::{session_path, SessionStore};
 use crate::agent::tools::{ToolContext, ToolOutcome, ToolRegistry};
@@ -18,7 +18,9 @@ use crate::agent::SYSTEM_PROMPT;
 use crate::auth::get_access_token;
 use crate::colors as c;
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{
+    diag_output, mode_banner, run_repl, LoopControl, ModelReplHelper, TurnDiagnostics, PROMPT,
+};
 use crate::credentials::Credentials;
 use crate::error::Result;
 use crate::net::Client;
@@ -35,7 +37,15 @@ pub struct AgentOptions {
     pub auto_approve: bool,
 }
 
-struct CliObserver;
+/// Turn-scoped accumulator for `/diag`: `Agent::run`'s tool-use loop can call
+/// the LLM several times per turn (each a "step"), and this collects the
+/// last-known served model plus a running token total across all of them.
+#[derive(Default)]
+struct CliObserver {
+    served_model: Option<String>,
+    usage: Option<TokenUsage>,
+    steps: u32,
+}
 impl Observer for CliObserver {
     fn on_text_delta(&mut self, delta: &str) {
         // Stream assistant text to stdout as it arrives (tool progress goes to stderr).
@@ -63,12 +73,35 @@ impl Observer for CliObserver {
         // Control notices go to stderr — stdout stays the clean answer channel.
         eprintln!("\n{}", c::dim(msg));
     }
+    fn on_turn_step(&mut self, resp: &ChatResponse) {
+        self.steps += 1;
+        if let Some(model) = &resp.model {
+            self.served_model = Some(model.clone());
+        }
+        if let Some(u) = &resp.usage {
+            // Each step's `usage.prompt_tokens` reflects that step's *entire*
+            // re-sent conversation, so summing across steps overcounts
+            // "distinct prompt content" — but it's still the right number for
+            // "total tokens this turn billed across all its LLM calls", the
+            // practically useful DX/cost question, so it's summed anyway.
+            let acc = self.usage.get_or_insert(TokenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            });
+            acc.prompt_tokens = acc.prompt_tokens.saturating_add(u.prompt_tokens);
+            acc.completion_tokens = acc.completion_tokens.saturating_add(u.completion_tokens);
+            acc.total_tokens = acc.total_tokens.saturating_add(u.total_tokens);
+        }
+    }
 }
 
 /// The slash commands the REPL understands, offered by the completer and shown
 /// by `/help`. Kept here (next to the dispatcher) so completion never drifts from
 /// what `dispatch_command` / `parse_model_command` actually handle.
-const SLASH_COMMANDS: &[&str] = &["/help", "/config", "/status", "/model", "/exit", "/quit"];
+const SLASH_COMMANDS: &[&str] = &[
+    "/help", "/config", "/status", "/model", "/diag", "/exit", "/quit",
+];
 
 /// Interactive approver: prompts the user (stderr) before each side-effecting
 /// tool call and reads a y/N answer from stdin. Default (empty / non-y / EOF) is
@@ -136,6 +169,9 @@ struct Repl<'a> {
     auto_approve: bool,
     /// Whether this session runs on an interactive TTY (can prompt for approval).
     interactive: bool,
+    /// Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    /// first successful turn, mirroring `monocle chat`'s REPL.
+    diagnostics: Option<TurnDiagnostics>,
 }
 
 impl Repl<'_> {
@@ -151,6 +187,9 @@ impl Repl<'_> {
     fn run_turn(&mut self, user: String) -> Result<()> {
         // Fresh token each turn (get_access_token refreshes if near expiry).
         let auth = get_access_token(self.client, self.creds);
+        // Captured before `MonocleProvider::from_session` consumes `auth` —
+        // `/diag`'s endpoint must reflect the request this turn actually sent.
+        let turn_endpoint = auth.router_url.clone();
         let provider = MonocleProvider::from_session(auth);
         let agent = Agent::with_max_steps(
             &provider,
@@ -174,9 +213,16 @@ impl Repl<'_> {
             } else {
                 &mut allow
             };
-        if let Err(e) = agent.run(&mut self.convo, approver, &mut CliObserver, &self.cancel) {
+        // Wrapped tightly around the agent-core loop itself — this is what
+        // `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
+        let mut observer = CliObserver::default();
+        if let Err(e) = agent.run(&mut self.convo, approver, &mut observer, &self.cancel) {
             // Roll back this failed turn's (partial) messages so a retry — and the
-            // persisted session — stay well-formed.
+            // persisted session — stay well-formed. A failed turn must not leave
+            // stale diagnostics from an earlier successful turn silently
+            // displayable via `/diag`, mirroring `monocle chat`'s REPL.
+            self.diagnostics = None;
             self.convo.truncate(mark);
             return Err(e);
         }
@@ -184,6 +230,15 @@ impl Repl<'_> {
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
         out.flush()?;
+
+        self.diagnostics = Some(TurnDiagnostics {
+            requested_model: self.model.clone(),
+            served_model: observer.served_model.clone(),
+            endpoint: turn_endpoint,
+            latency_ms: started.elapsed().as_millis(),
+            usage: observer.usage.clone(),
+            steps: Some(observer.steps),
+        });
 
         // Persist this turn's new messages (append-only).
         if let Some(store) = &self.session {
@@ -201,6 +256,7 @@ enum Command {
     Help,
     Config,
     Status,
+    Diag,
     Quit,
     Unknown(String),
     /// Not a slash command — send it to the agent as a normal turn.
@@ -217,6 +273,7 @@ fn dispatch_command(input: &str) -> Command {
         "/help" => Command::Help,
         "/config" => Command::Config,
         "/status" => Command::Status,
+        "/diag" => Command::Diag,
         "/exit" | "/quit" => Command::Quit,
         other => Command::Unknown(other.to_string()),
     }
@@ -287,6 +344,7 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
         persisted,
         auto_approve: opts.auto_approve,
         interactive,
+        diagnostics: None,
     };
 
     // Seed the first turn from the prompt arg, or (non-interactive) piped stdin.
@@ -398,6 +456,10 @@ pub fn agent_command(client: &Client, creds: &Credentials, opts: AgentOptions) -
                 );
                 Ok(LoopControl::Continue)
             }
+            Command::Diag => {
+                eprintln!("{}", diag_output(&repl.diagnostics));
+                Ok(LoopControl::Continue)
+            }
             Command::Unknown(cmd) => {
                 eprintln!("unknown command: {cmd} (try /help)");
                 Ok(LoopControl::Continue)
@@ -446,6 +508,7 @@ mod tests {
         assert_eq!(dispatch_command("/help"), Command::Help);
         assert_eq!(dispatch_command("/config"), Command::Config);
         assert_eq!(dispatch_command("/status"), Command::Status);
+        assert_eq!(dispatch_command("/diag"), Command::Diag);
         assert_eq!(dispatch_command("/quit"), Command::Quit);
         assert_eq!(dispatch_command("/exit"), Command::Quit);
     }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,13 +5,16 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, TokenUsage,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{
+    handle_diag_command, mode_banner, run_repl, LoopControl, ModelReplHelper, TurnDiagnostics,
+    PROMPT,
+};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -159,61 +162,34 @@ fn resolve_repl_attachments(
 
 /// The slash commands the REPL understands. `/model` mirrors `monocle
 /// agent`'s REPL (switches the model for subsequent turns); `/diag` shows
-/// diagnostics for the last turn; chat still has no `/help`/`/config`/`/status`.
-const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/diag", "/exit", "/quit"];
+/// diagnostics for the last turn; `/help` (re-)prints the onboarding block
+/// shown at REPL startup — chat still has no `/config`/`/status` (those are
+/// agent-specific session state with no chat equivalent).
+const CHAT_SLASH_COMMANDS: &[&str] = &["/help", "/model", "/diag", "/exit", "/quit"];
 
-/// Diagnostics for the most recently completed turn, shown on demand by
-/// `/diag` — REPL-only, overwritten each turn (no history is kept). Built
-/// fresh after every successful turn in both `run_completions_chat` and
-/// `run_responses_chat`; `served_model`/`usage` stay `None` wherever the
-/// backend doesn't report them (the `--responses` path reports neither today
-/// — see module docs on `responses_api::ResponsesReply`).
-struct TurnDiagnostics {
-    requested_model: String,
-    served_model: Option<String>,
-    endpoint: String,
-    latency_ms: u128,
-    usage: Option<TokenUsage>,
+/// The onboarding block printed once at REPL startup (both `run_completions_chat`
+/// and `run_responses_chat`) and re-printed on demand by `/help` — one string,
+/// two call sites, so the two never drift.
+fn chat_help_text() -> String {
+    [
+        "Type your message. Press Ctrl+D to exit.".to_string(),
+        "↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input."
+            .to_string(),
+        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+            .to_string(),
+        "/help shows this message again.".to_string(),
+    ]
+    .join("\n")
 }
 
-/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
-/// `--responses` REPL's prior-history replay). Lines for data the backend
-/// didn't report are omitted entirely — never printed as `None`/`null`.
-fn format_diag(d: &TurnDiagnostics) -> String {
-    let mut lines = vec![
-        "--- diag ---".to_string(),
-        format!("Endpoint: {}", d.endpoint),
-        format!("Requested model: {}", d.requested_model),
-    ];
-    if let Some(served) = &d.served_model {
-        lines.push(format!("Served model: {served}"));
-    }
-    lines.push(format!("Latency: {}ms", d.latency_ms));
-    if let Some(u) = &d.usage {
-        lines.push(format!(
-            "Tokens: {} prompt + {} completion = {} total",
-            u.prompt_tokens, u.completion_tokens, u.total_tokens
-        ));
-    }
-    lines.push("--- end diag ---".to_string());
-    lines.join("\n")
-}
-
-/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
-/// diagnostics (or a "nothing yet" hint before the first turn). Returns
-/// `true` if this input was consumed as `/diag`, mirroring
-/// `model_list::handle_model_command`'s contract.
-fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
-    if trimmed != "/diag" {
+/// Handle a `/help` line if `trimmed` is one: (re-)prints the onboarding
+/// block. Returns `true` if this input was consumed as `/help`, mirroring
+/// `handle_diag_command`'s contract.
+fn handle_help_command(trimmed: &str) -> bool {
+    if trimmed != "/help" {
         return false;
     }
-    match diagnostics {
-        None => eprintln!(
-            "{}",
-            crate::colors::dim("No response yet — send a message first.")
-        ),
-        Some(d) => eprintln!("{}", format_diag(d)),
-    }
+    eprintln!("{}", chat_help_text());
     true
 }
 
@@ -237,6 +213,9 @@ fn dispatch_chat_command(
         return Some(LoopControl::Continue);
     }
     if handle_diag_command(trimmed, diagnostics) {
+        return Some(LoopControl::Continue);
+    }
+    if handle_help_command(trimmed) {
         return Some(LoopControl::Continue);
     }
     None
@@ -370,11 +349,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     if let Some(sp) = &system_prompt {
         eprintln!("System prompt loaded ({} chars)", sp.chars().count());
     }
-    eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
-    eprintln!(
-        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
-    );
+    eprintln!("{}", chat_help_text());
     eprintln!("---");
     eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
@@ -463,6 +438,8 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                     endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
                     latency_ms: started.elapsed().as_millis(),
                     usage: resp.usage.clone(),
+                    // A chat turn is always exactly one LLM call.
+                    steps: None,
                 });
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
@@ -561,9 +538,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     // Interactive REPL.
     eprintln!("Monocle Chat — Responses API (model: {model})");
     eprintln!("jarvice: {jarvice_url}");
-    eprintln!("Type your message. Press Ctrl+D to exit.");
-    eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
-    eprintln!("/diag shows diagnostics (endpoint, latency) for the last turn.");
+    eprintln!("{}", chat_help_text());
     eprintln!("The server owns this conversation's thread — no local history is resent.");
     eprintln!("---");
 
@@ -658,6 +633,8 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     endpoint: format!("{jarvice_url}/api/responses"),
                     latency_ms: started.elapsed().as_millis(),
                     usage: None,
+                    // A chat turn is always exactly one LLM call.
+                    steps: None,
                 });
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
@@ -744,10 +721,9 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 #[cfg(test)]
 mod tests {
     use super::{
-        dispatch_chat_command, format_diag, resolve_max_tokens, resolve_repl_attachments,
-        TurnDiagnostics,
+        chat_help_text, dispatch_chat_command, handle_help_command, resolve_max_tokens,
+        resolve_repl_attachments, TurnDiagnostics,
     };
-    use crate::agent::providers::TokenUsage;
     use crate::commands::repl::LoopControl;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
@@ -778,6 +754,30 @@ mod tests {
         let mut model = "monocle-auto".to_string();
         let diagnostics: Option<TurnDiagnostics> = None;
         assert!(dispatch_chat_command("hello there", &mut model, &diagnostics).is_none());
+    }
+
+    #[test]
+    fn dispatch_chat_command_recognizes_help() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(matches!(
+            dispatch_chat_command("/help", &mut model, &diagnostics),
+            Some(LoopControl::Continue)
+        ));
+    }
+
+    #[test]
+    fn handle_help_command_only_consumes_exact_slash_help() {
+        assert!(!handle_help_command("not help"));
+        assert!(handle_help_command("/help"));
+    }
+
+    #[test]
+    fn chat_help_text_mentions_the_documented_commands() {
+        let text = chat_help_text();
+        for cmd in ["/model", "/diag", "/help", "/quit", "/exit"] {
+            assert!(text.contains(cmd), "help text missing {cmd}: {text}");
+        }
     }
 
     #[test]
@@ -842,57 +842,6 @@ mod tests {
     fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
         let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
         assert!(err.contains("not found"), "unexpected message: {err}");
-    }
-
-    #[test]
-    fn format_diag_omits_served_model_and_usage_when_unavailable() {
-        // The `--responses` path: only endpoint/requested-model/latency are
-        // ever known — served model and usage must never render as a literal
-        // "None"/"null", they're just absent lines.
-        let d = TurnDiagnostics {
-            requested_model: "monocle-auto".to_string(),
-            served_model: None,
-            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
-            latency_ms: 842,
-            usage: None,
-        };
-        let block = format_diag(&d);
-        assert_eq!(
-            block,
-            "--- diag ---\n\
-             Endpoint: https://acme.monocle-ai.com/api/responses\n\
-             Requested model: monocle-auto\n\
-             Latency: 842ms\n\
-             --- end diag ---"
-        );
-        assert!(!block.contains("None"));
-        assert!(!block.contains("null"));
-    }
-
-    #[test]
-    fn format_diag_shows_served_model_and_usage_when_present() {
-        let d = TurnDiagnostics {
-            requested_model: "monocle-auto".to_string(),
-            served_model: Some("claude-sonnet-4-6".to_string()),
-            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
-            latency_ms: 1234,
-            usage: Some(TokenUsage {
-                prompt_tokens: 120,
-                completion_tokens: 45,
-                total_tokens: 165,
-            }),
-        };
-        let block = format_diag(&d);
-        assert_eq!(
-            block,
-            "--- diag ---\n\
-             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
-             Requested model: monocle-auto\n\
-             Served model: claude-sonnet-4-6\n\
-             Latency: 1234ms\n\
-             Tokens: 120 prompt + 45 completion = 165 total\n\
-             --- end diag ---"
-        );
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -494,6 +494,29 @@ pub fn chat_list_command(client: &Client, creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
+/// Surface (never silently drop) any `tool_calls` a `--responses` turn came
+/// back with (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only
+/// runs its MCP tool-execution loop on the streaming branch, and this client
+/// always sends `"stream": false`, so a tool-calling model's request goes
+/// unexecuted here. Actually executing tools in this mode is out of scope
+/// (tracked separately, monocle#274) — this just makes the drop visible
+/// instead of silent, on stderr like every other warning in this path, and
+/// degrades gracefully rather than erroring the turn.
+fn warn_dropped_tool_calls(reply: &crate::responses_api::ResponsesReply) {
+    if reply.tool_calls.is_empty() {
+        return;
+    }
+    let names = reply
+        .tool_calls
+        .iter()
+        .map(|tc| tc.function.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    eprintln!(
+        "⚠ model requested tool call(s) ({names}) but --responses mode does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101"
+    );
+}
+
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
 /// docs). The server owns the conversation thread — this REPL only tracks
 /// the `thread_id` to pass on the next turn, never a local message history.
@@ -534,6 +557,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!("jarvice: {jarvice_url}");
         let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
+        warn_dropped_tool_calls(&reply);
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
@@ -640,6 +664,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     started.elapsed().as_millis(),
                     None,
                 ));
+                warn_dropped_tool_calls(&reply);
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -11,7 +11,7 @@ use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
+use crate::commands::repl::{mode_banner, run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -376,7 +376,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
     );
     eprintln!("---");
-    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+    eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
     // stay independent. The Editor build, bracketed-paste config, history
@@ -614,7 +614,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         }
     }
 
-    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+    eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
     run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -217,6 +217,31 @@ fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> 
     true
 }
 
+/// Dispatch a slash-command line to whichever handler recognizes it (shared
+/// by both REPL loops, so the two don't drift out of sync). Returns
+/// `Some(control)` when `trimmed` was consumed as a recognized command — the
+/// caller should return it immediately. `None` means it wasn't a recognized
+/// command and should be treated as ordinary chat input.
+fn dispatch_chat_command(
+    trimmed: &str,
+    model: &mut String,
+    diagnostics: &Option<TurnDiagnostics>,
+) -> Option<LoopControl> {
+    if trimmed == "/quit" || trimmed == "/exit" {
+        eprintln!("Bye.");
+        return Some(LoopControl::Quit);
+    }
+    // `/model` switches the model for subsequent turns — handled before
+    // `/diag` since it carries an argument, same as `monocle agent`'s REPL.
+    if handle_model_command(trimmed, model) {
+        return Some(LoopControl::Continue);
+    }
+    if handle_diag_command(trimmed, diagnostics) {
+        return Some(LoopControl::Continue);
+    }
+    None
+}
+
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     if options.responses {
         run_responses_chat(client, creds, options)
@@ -375,18 +400,8 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     let mut diagnostics: Option<TurnDiagnostics> = None;
 
     run_repl(helper, history_path, "> ", |trimmed| {
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("Bye.");
-            return Ok(LoopControl::Quit);
-        }
-        // `/model` switches the model for subsequent turns — handled before
-        // the general dispatch since it carries an argument, same as
-        // `monocle agent`'s REPL.
-        if handle_model_command(trimmed, &mut model) {
-            return Ok(LoopControl::Continue);
-        }
-        if handle_diag_command(trimmed, &diagnostics) {
-            return Ok(LoopControl::Continue);
+        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+            return Ok(control);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -416,6 +431,12 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             Some(s) => s,
             None => return Ok(LoopControl::Continue),
         };
+        // Captured before `provider.refresh` consumes `session` — the actual
+        // per-turn request goes to whatever router URL THIS session carries,
+        // which can differ from the outer `router_url` after a mid-session
+        // refresh re-discovers a different router. `/diag`'s endpoint must
+        // reflect the request that was actually sent, not the startup value.
+        let turn_router_url = session.router_url.clone();
         provider.refresh(session);
 
         eprintln!();
@@ -438,7 +459,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                 diagnostics = Some(TurnDiagnostics {
                     requested_model: model.clone(),
                     served_model: resp.model.clone(),
-                    endpoint: format!("{router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
                     latency_ms: started.elapsed().as_millis(),
                     usage: resp.usage.clone(),
                 });
@@ -449,6 +470,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             }
             Err(e) => {
                 convo.truncate(mark);
+                // A failed turn must not leave stale diagnostics from an
+                // earlier successful turn silently displayable via `/diag`.
+                diagnostics = None;
                 eprintln!("Error: {e}");
                 if crate::diag::was_logged() {
                     eprintln!("  (details logged to {})", crate::diag::display_path());
@@ -590,18 +614,8 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     }
 
     run_repl(helper, history_path, "> ", |trimmed| {
-        if trimmed == "/quit" || trimmed == "/exit" {
-            eprintln!("Bye.");
-            return Ok(LoopControl::Quit);
-        }
-        // `/model` switches the model for subsequent turns — handled before
-        // the general dispatch since it carries an argument, same as
-        // `monocle agent`'s REPL.
-        if handle_model_command(trimmed, &mut model) {
-            return Ok(LoopControl::Continue);
-        }
-        if handle_diag_command(trimmed, &diagnostics) {
-            return Ok(LoopControl::Continue);
+        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+            return Ok(control);
         }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
@@ -655,6 +669,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                 println!();
             }
             Err(e) => {
+                // A failed turn must not leave stale diagnostics from an
+                // earlier successful turn silently displayable via `/diag`.
+                diagnostics = None;
                 eprintln!("Error: {e}");
                 if crate::diag::was_logged() {
                     eprintln!("  (details logged to {})", crate::diag::display_path());
@@ -723,12 +740,42 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_diag, resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics};
+    use super::{
+        dispatch_chat_command, format_diag, resolve_max_tokens, resolve_repl_attachments,
+        TurnDiagnostics,
+    };
     use crate::agent::providers::TokenUsage;
+    use crate::commands::repl::LoopControl;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is
     // covered there, since that's where its Completer/Hinter impls live.
+
+    // `/model`/`/diag` dispatch through `dispatch_chat_command` isn't
+    // re-tested in detail here — `handle_model_command` and
+    // `handle_diag_command` already have their own coverage; this just
+    // confirms the shared entry point recognizes `/quit`/`/exit` and passes
+    // through anything else as ordinary chat input.
+    #[test]
+    fn dispatch_chat_command_quit_and_exit_stop_the_repl() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(matches!(
+            dispatch_chat_command("/quit", &mut model, &diagnostics),
+            Some(LoopControl::Quit)
+        ));
+        assert!(matches!(
+            dispatch_chat_command("/exit", &mut model, &diagnostics),
+            Some(LoopControl::Quit)
+        ));
+    }
+
+    #[test]
+    fn dispatch_chat_command_unrecognized_line_is_chat_input() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(dispatch_chat_command("hello there", &mut model, &diagnostics).is_none());
+    }
 
     #[test]
     fn absent_flag_omits() {

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -11,7 +11,7 @@ use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
-use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
+use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper, PROMPT};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -376,6 +376,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
     );
     eprintln!("---");
+    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
     // stay independent. The Editor build, bracketed-paste config, history
@@ -399,7 +400,7 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     // first successful turn.
     let mut diagnostics: Option<TurnDiagnostics> = None;
 
-    run_repl(helper, history_path, "> ", |trimmed| {
+    run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
             return Ok(control);
         }
@@ -613,7 +614,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         }
     }
 
-    run_repl(helper, history_path, "> ", |trimmed| {
+    eprintln!("{}", crate::colors::cyan("\u{25B8} chat"));
+
+    run_repl(helper, history_path, PROMPT, |trimmed| {
         if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
             return Ok(control);
         }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -9,7 +9,7 @@ use crate::agent::providers::{
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
-use crate::auth::{get_access_token, jarvice_url_for, AuthSession};
+use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
 use crate::commands::repl::{run_repl, LoopControl, ModelReplHelper};
 use crate::credentials::Credentials;
@@ -245,12 +245,11 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         }
     }
 
-    let provider = MonocleProvider::new(token, router_url.clone());
-
     // Non-interactive: stdin was piped (input + attachments already resolved above).
     if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("Router: {router_url}");
+        let provider = MonocleProvider::new(token, router_url.clone());
         let mut messages = Vec::new();
         if let Some(sp) = &system_prompt {
             messages.push(Message::system(sp));
@@ -321,6 +320,23 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // over from an earlier one (this REPL loops for the life of the
         // process, same as `monocle agent`'s).
         crate::diag::reset();
+
+        // Fresh token each turn (`try_access_token` refreshes if near expiry)
+        // and a freshly built provider — mirrors `monocle agent`'s
+        // `Repl::run_turn` so a long-lived interactive session never sends a
+        // stale bearer. Resolved before touching `convo` (same order as
+        // `agent.rs`), so a refresh failure (e.g. a dead refresh token) never
+        // leaves a dangling user message — it's a per-turn error, not fatal,
+        // same recovery shape as a failed `call_chat` below.
+        let provider = match try_access_token(client, creds) {
+            Ok(session) => MonocleProvider::from_session(session),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                eprintln!();
+                return Ok(LoopControl::Continue);
+            }
+        };
+
         // Roll back this turn's user message on failure (mirrors `monocle
         // agent`'s `Repl::run_turn` mark/truncate) so a failed turn doesn't
         // leave a dangling, reply-less user message in the history sent next time.
@@ -407,11 +423,10 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
 
     let one_shot_input = read_one_shot_input(stdin_is_tty, &options.files)?;
 
-    let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
-
     if let Some((text, images)) = one_shot_input {
         eprintln!("Using model: {model}");
         eprintln!("jarvice: {jarvice_url}");
+        let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
@@ -494,6 +509,20 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
 
         eprintln!();
         crate::diag::reset();
+
+        // Fresh token each turn, same rationale and ordering as the
+        // completions path / `monocle agent`'s `Repl::run_turn` — rebuilds
+        // the client so a long-lived REPL never sends a stale bearer. A
+        // refresh failure is a per-turn error, not fatal.
+        let rc = match try_access_token(client, creds) {
+            Ok(session) => ResponsesClient::new(client, session.token, jarvice_url.clone()),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                eprintln!();
+                return Ok(LoopControl::Continue);
+            }
+        };
+
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
                 println!("{}", reply.content);

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -169,13 +169,21 @@ const CHAT_SLASH_COMMANDS: &[&str] = &["/help", "/model", "/diag", "/exit", "/qu
 
 /// The onboarding block printed once at REPL startup (both `run_completions_chat`
 /// and `run_responses_chat`) and re-printed on demand by `/help` — one string,
-/// two call sites, so the two never drift.
+/// two call sites, so the two never drift. The Tab-completion line is built
+/// from `CHAT_SLASH_COMMANDS` itself (not hand-typed) so it can't silently
+/// under-report a command again the way it previously did. The `/diag` line
+/// deliberately doesn't itemize which fields it shows — `run_responses_chat`
+/// never learns a served model or token usage (see `TurnDiagnostics` docs),
+/// so a shared, itemized promise would overclaim for that path; `format_diag`
+/// already self-describes by omitting whatever the backend didn't report.
 fn chat_help_text() -> String {
     [
         "Type your message. Press Ctrl+D to exit.".to_string(),
-        "↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input."
-            .to_string(),
-        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+        format!(
+            "↑/↓ history, Tab completes {} — a multi-line paste is one input.",
+            CHAT_SLASH_COMMANDS.join(", ")
+        ),
+        "/diag shows diagnostics for the last turn (only what the backend reports is shown)."
             .to_string(),
         "/help shows this message again.".to_string(),
     ]
@@ -432,15 +440,13 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         let started = std::time::Instant::now();
         match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
             Ok(resp) => {
-                diagnostics = Some(TurnDiagnostics {
-                    requested_model: model.clone(),
-                    served_model: resp.model.clone(),
-                    endpoint: format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
-                    latency_ms: started.elapsed().as_millis(),
-                    usage: resp.usage.clone(),
-                    // A chat turn is always exactly one LLM call.
-                    steps: None,
-                });
+                diagnostics = Some(TurnDiagnostics::for_chat(
+                    model.clone(),
+                    resp.model.clone(),
+                    format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    started.elapsed().as_millis(),
+                    resp.usage.clone(),
+                ));
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -627,15 +633,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         let started = std::time::Instant::now();
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
-                diagnostics = Some(TurnDiagnostics {
-                    requested_model: model.clone(),
-                    served_model: None,
-                    endpoint: format!("{jarvice_url}/api/responses"),
-                    latency_ms: started.elapsed().as_millis(),
-                    usage: None,
-                    // A chat turn is always exactly one LLM call.
-                    steps: None,
-                });
+                diagnostics = Some(TurnDiagnostics::for_chat(
+                    model.clone(),
+                    None,
+                    format!("{jarvice_url}/api/responses"),
+                    started.elapsed().as_millis(),
+                    None,
+                ));
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, ToolCall,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
@@ -337,7 +337,10 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             messages.push(Message::system(sp));
         }
         messages.push(Message::user(&text));
-        call_chat(&provider, &model, messages, max_tokens, &images)?;
+        let resp = call_chat(&provider, &model, messages, max_tokens, &images)?;
+        if let Some(msg) = dropped_tool_calls_message(&resp.tool_calls, 0, "monocle chat") {
+            eprintln!("{msg}");
+        }
         let mut out = std::io::stdout();
         out.write_all(b"\n")?;
         out.flush()?;
@@ -447,6 +450,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                     started.elapsed().as_millis(),
                     resp.usage.clone(),
                 ));
+                if let Some(msg) = dropped_tool_calls_message(&resp.tool_calls, 0, "monocle chat") {
+                    eprintln!("{msg}");
+                }
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -494,27 +500,42 @@ pub fn chat_list_command(client: &Client, creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
-/// Surface (never silently drop) any `tool_calls` a `--responses` turn came
-/// back with (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only
-/// runs its MCP tool-execution loop on the streaming branch, and this client
-/// always sends `"stream": false`, so a tool-calling model's request goes
-/// unexecuted here. Actually executing tools in this mode is out of scope
-/// (tracked separately, monocle#274) — this just makes the drop visible
-/// instead of silent, on stderr like every other warning in this path, and
-/// degrades gracefully rather than erroring the turn.
-fn warn_dropped_tool_calls(reply: &crate::responses_api::ResponsesReply) {
-    if reply.tool_calls.is_empty() {
-        return;
+/// Build a warning about tool call(s) a turn couldn't act on, or `None` if
+/// there's nothing to report (monocle-cli#101 / monocle#275 — see
+/// `responses_api::ResponsesReply::tool_calls` for the canonical explanation
+/// of why `--responses` mode can't execute them). Pure — no I/O — so it's
+/// directly unit-testable; the call site does the actual `eprintln!`, same as
+/// this path's other warnings degrading gracefully rather than erroring the
+/// turn. `unparsed` additionally reports tool_calls whose shape didn't even
+/// deserialize (see `responses_api::parse_tool_calls`) — those must be
+/// mentioned too, or a shape mismatch is just as silent as never reading the
+/// field at all. Shared by both `run_responses_chat` and `run_completions_chat`
+/// so plain `monocle chat` gets the same non-silent behavior, not just
+/// `--responses` mode (monocle-cli#101 code review).
+fn dropped_tool_calls_message(
+    tool_calls: &[ToolCall],
+    unparsed: usize,
+    mode: &str,
+) -> Option<String> {
+    if tool_calls.is_empty() && unparsed == 0 {
+        return None;
     }
-    let names = reply
-        .tool_calls
-        .iter()
-        .map(|tc| tc.function.name.as_str())
-        .collect::<Vec<_>>()
-        .join(", ");
-    eprintln!(
-        "⚠ model requested tool call(s) ({names}) but --responses mode does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101"
-    );
+    let mut reasons = Vec::new();
+    if !tool_calls.is_empty() {
+        let names = tool_calls
+            .iter()
+            .map(|tc| tc.function.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        reasons.push(format!("tool call(s) ({names})"));
+    }
+    if unparsed > 0 {
+        reasons.push(format!("{unparsed} tool call(s) in an unrecognized shape"));
+    }
+    Some(format!(
+        "⚠ model requested {} but {mode} does not execute tools yet — see https://github.com/warmblood-kr/monocle-cli/issues/101 (try `monocle agent` for local tool execution today)",
+        reasons.join(" and ")
+    ))
 }
 
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
@@ -557,7 +578,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!("jarvice: {jarvice_url}");
         let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
-        warn_dropped_tool_calls(&reply);
+        if let Some(msg) = dropped_tool_calls_message(
+            &reply.tool_calls,
+            reply.unparsed_tool_calls,
+            "--responses mode",
+        ) {
+            eprintln!("{msg}");
+        }
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
@@ -664,7 +691,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     started.elapsed().as_millis(),
                     None,
                 ));
-                warn_dropped_tool_calls(&reply);
+                if let Some(msg) = dropped_tool_calls_message(
+                    &reply.tool_calls,
+                    reply.unparsed_tool_calls,
+                    "--responses mode",
+                ) {
+                    eprintln!("{msg}");
+                }
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's
@@ -750,10 +783,56 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 #[cfg(test)]
 mod tests {
     use super::{
-        chat_help_text, dispatch_chat_command, handle_help_command, resolve_max_tokens,
-        resolve_repl_attachments, TurnDiagnostics,
+        chat_help_text, dispatch_chat_command, dropped_tool_calls_message, handle_help_command,
+        resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics,
     };
+    use crate::agent::providers::{FunctionCall, ToolCall};
     use crate::commands::repl::LoopControl;
+
+    fn tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            kind: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_none_when_nothing_to_report() {
+        assert_eq!(dropped_tool_calls_message(&[], 0, "--responses mode"), None);
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_names_the_call_and_the_mode() {
+        // monocle-cli#101 code review: the pairing between obtaining a reply
+        // and warning about it was previously enforced by convention only,
+        // with no test ever exercising the warning text itself. This locks
+        // it down directly, against the pure (non-eprintln!) builder.
+        let msg = dropped_tool_calls_message(&[tool_call("generate_image")], 0, "--responses mode")
+            .expect("should produce a message");
+        assert!(msg.contains("generate_image"), "{msg}");
+        assert!(msg.contains("--responses mode"), "{msg}");
+        assert!(msg.contains("monocle agent"), "{msg}");
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_reports_unparsed_count_even_with_no_named_calls() {
+        let msg = dropped_tool_calls_message(&[], 3, "--responses mode").expect("should report");
+        assert!(msg.contains('3'), "{msg}");
+        assert!(msg.contains("unrecognized shape"), "{msg}");
+    }
+
+    #[test]
+    fn dropped_tool_calls_message_reports_both_named_and_unparsed() {
+        let msg = dropped_tool_calls_message(&[tool_call("read_file")], 1, "monocle chat")
+            .expect("should report");
+        assert!(msg.contains("read_file"), "{msg}");
+        assert!(msg.contains('1'), "{msg}");
+        assert!(msg.contains("monocle chat"), "{msg}");
+    }
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use chrono::TimeZone;
 
 use crate::agent::providers::{
-    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider,
+    ChatRequest, ChatResponse, ImageAttachment, LlmProvider, Message, MonocleProvider, TokenUsage,
 };
 use crate::agent::DEFAULT_MODEL;
 use crate::attachment;
@@ -158,9 +158,64 @@ fn resolve_repl_attachments(
 }
 
 /// The slash commands the REPL understands. `/model` mirrors `monocle
-/// agent`'s REPL (switches the model for subsequent turns); chat still has no
-/// `/help`/`/config`/`/status`.
-const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/exit", "/quit"];
+/// agent`'s REPL (switches the model for subsequent turns); `/diag` shows
+/// diagnostics for the last turn; chat still has no `/help`/`/config`/`/status`.
+const CHAT_SLASH_COMMANDS: &[&str] = &["/model", "/diag", "/exit", "/quit"];
+
+/// Diagnostics for the most recently completed turn, shown on demand by
+/// `/diag` — REPL-only, overwritten each turn (no history is kept). Built
+/// fresh after every successful turn in both `run_completions_chat` and
+/// `run_responses_chat`; `served_model`/`usage` stay `None` wherever the
+/// backend doesn't report them (the `--responses` path reports neither today
+/// — see module docs on `responses_api::ResponsesReply`).
+struct TurnDiagnostics {
+    requested_model: String,
+    served_model: Option<String>,
+    endpoint: String,
+    latency_ms: u128,
+    usage: Option<TokenUsage>,
+}
+
+/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
+/// `--responses` REPL's prior-history replay). Lines for data the backend
+/// didn't report are omitted entirely — never printed as `None`/`null`.
+fn format_diag(d: &TurnDiagnostics) -> String {
+    let mut lines = vec![
+        "--- diag ---".to_string(),
+        format!("Endpoint: {}", d.endpoint),
+        format!("Requested model: {}", d.requested_model),
+    ];
+    if let Some(served) = &d.served_model {
+        lines.push(format!("Served model: {served}"));
+    }
+    lines.push(format!("Latency: {}ms", d.latency_ms));
+    if let Some(u) = &d.usage {
+        lines.push(format!(
+            "Tokens: {} prompt + {} completion = {} total",
+            u.prompt_tokens, u.completion_tokens, u.total_tokens
+        ));
+    }
+    lines.push("--- end diag ---".to_string());
+    lines.join("\n")
+}
+
+/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
+/// diagnostics (or a "nothing yet" hint before the first turn). Returns
+/// `true` if this input was consumed as `/diag`, mirroring
+/// `model_list::handle_model_command`'s contract.
+fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
+    if trimmed != "/diag" {
+        return false;
+    }
+    match diagnostics {
+        None => eprintln!(
+            "{}",
+            crate::colors::dim("No response yet — send a message first.")
+        ),
+        Some(d) => eprintln!("{}", format_diag(d)),
+    }
+    true
+}
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
     if options.responses {
@@ -292,6 +347,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     }
     eprintln!("Type your message. Press Ctrl+D to exit.");
     eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
+    eprintln!(
+        "/diag shows diagnostics (served model, endpoint, latency, tokens) for the last turn."
+    );
     eprintln!("---");
 
     // Separate history file from `monocle agent`'s — the two REPLs' histories
@@ -312,6 +370,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     if let Some(sp) = &system_prompt {
         convo.push(Message::system(sp));
     }
+    // Last turn's diagnostics, shown on demand by `/diag` — `None` until the
+    // first successful turn.
+    let mut diagnostics: Option<TurnDiagnostics> = None;
 
     run_repl(helper, history_path, "> ", |trimmed| {
         if trimmed == "/quit" || trimmed == "/exit" {
@@ -322,6 +383,9 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // the general dispatch since it carries an argument, same as
         // `monocle agent`'s REPL.
         if handle_model_command(trimmed, &mut model) {
+            return Ok(LoopControl::Continue);
+        }
+        if handle_diag_command(trimmed, &diagnostics) {
             return Ok(LoopControl::Continue);
         }
 
@@ -366,8 +430,18 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         // leave a dangling, reply-less user message in the history sent next time.
         let mark = convo.len();
         convo.push(Message::user(text));
+        // Wrapped tightly around the network call itself (not REPL input-wait
+        // time) — this is what `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
         match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
             Ok(resp) => {
+                diagnostics = Some(TurnDiagnostics {
+                    requested_model: model.clone(),
+                    served_model: resp.model.clone(),
+                    endpoint: format!("{router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    latency_ms: started.elapsed().as_millis(),
+                    usage: resp.usage.clone(),
+                });
                 convo.push(Message::assistant(resp.content));
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
@@ -464,6 +538,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     eprintln!("jarvice: {jarvice_url}");
     eprintln!("Type your message. Press Ctrl+D to exit.");
     eprintln!("↑/↓ history, Tab completes /model, /quit, /exit — a multi-line paste is one input.");
+    eprintln!("/diag shows diagnostics (endpoint, latency) for the last turn.");
     eprintln!("The server owns this conversation's thread — no local history is resent.");
     eprintln!("---");
 
@@ -479,6 +554,10 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         commands: CHAT_SLASH_COMMANDS,
         models: model_ids,
     };
+    // Last turn's diagnostics, shown on demand by `/diag`. This path never
+    // learns a served model or token usage (see `TurnDiagnostics` docs), so
+    // those fields stay `None` for the life of the session.
+    let mut diagnostics: Option<TurnDiagnostics> = None;
 
     // Replay prior history for an existing thread, REPL-only (never in the
     // one-shot path above, never on stdout — this repo treats stdout as
@@ -521,6 +600,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         if handle_model_command(trimmed, &mut model) {
             return Ok(LoopControl::Continue);
         }
+        if handle_diag_command(trimmed, &diagnostics) {
+            return Ok(LoopControl::Continue);
+        }
 
         let (text, images) = match resolve_repl_attachments(trimmed) {
             Ok(v) => v,
@@ -548,8 +630,18 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!();
         crate::diag::reset();
 
+        // Wrapped tightly around the network call itself, same as the
+        // completions path — this is what `/diag`'s `Latency:` line reports.
+        let started = std::time::Instant::now();
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
+                diagnostics = Some(TurnDiagnostics {
+                    requested_model: model.clone(),
+                    served_model: None,
+                    endpoint: format!("{jarvice_url}/api/responses"),
+                    latency_ms: started.elapsed().as_millis(),
+                    usage: None,
+                });
                 println!("{}", reply.content);
                 // Announce the thread id only when it's newly learned (the
                 // first turn) or changed — not on every turn, since it's
@@ -631,7 +723,8 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_max_tokens, resolve_repl_attachments};
+    use super::{format_diag, resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics};
+    use crate::agent::providers::TokenUsage;
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +
     // `/model` fuzzy completion) now lives in `commands::repl` and is
@@ -699,6 +792,57 @@ mod tests {
     fn repl_line_with_nonexistent_file_ref_errors_without_panicking() {
         let err = resolve_repl_attachments("file:/no/such/path.png").unwrap_err();
         assert!(err.contains("not found"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn format_diag_omits_served_model_and_usage_when_unavailable() {
+        // The `--responses` path: only endpoint/requested-model/latency are
+        // ever known — served model and usage must never render as a literal
+        // "None"/"null", they're just absent lines.
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
+            latency_ms: 842,
+            usage: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://acme.monocle-ai.com/api/responses\n\
+             Requested model: monocle-auto\n\
+             Latency: 842ms\n\
+             --- end diag ---"
+        );
+        assert!(!block.contains("None"));
+        assert!(!block.contains("null"));
+    }
+
+    #[test]
+    fn format_diag_shows_served_model_and_usage_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            latency_ms: 1234,
+            usage: Some(TokenUsage {
+                prompt_tokens: 120,
+                completion_tokens: 45,
+                total_tokens: 165,
+            }),
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 1234ms\n\
+             Tokens: 120 prompt + 45 completion = 165 total\n\
+             --- end diag ---"
+        );
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -121,6 +121,21 @@ fn read_one_shot_input(
     Ok(Some((cleaned_text, images)))
 }
 
+/// Resolve a fresh (auto-refreshing) session for this turn, or print the
+/// error and return `None` so the caller can bail out of the turn with
+/// `LoopControl::Continue` — a dead refresh token is a per-turn error here,
+/// never fatal to the whole REPL session.
+fn resolve_turn_session(client: &Client, creds: &Credentials) -> Option<AuthSession> {
+    match try_access_token(client, creds) {
+        Ok(session) => Some(session),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            eprintln!();
+            None
+        }
+    }
+}
+
 /// Resolve inband `file:<path>` refs in a REPL line into images, mirroring the
 /// one-shot path's resolution (`attachment::extract_inband_refs` +
 /// `attachment::resolve`) but returning a failure as `Err(String)` instead of
@@ -262,6 +277,13 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         return Ok(());
     }
 
+    // Built once for the REPL's lifetime (mutable) and refreshed in place
+    // each turn via `MonocleProvider::refresh` — reuses the underlying HTTP
+    // client/connection pool instead of rebuilding one every turn, unlike a
+    // fresh `MonocleProvider::from_session` call which pays `Client::new()`'s
+    // real setup cost each time.
+    let mut provider = MonocleProvider::new(token, router_url.clone());
+
     // Interactive REPL.
     eprintln!("Monocle Chat (model: {model})");
     eprintln!("Router: {router_url}");
@@ -314,28 +336,30 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             }
         };
 
+        // Fresh token each turn (`try_access_token` refreshes if near expiry),
+        // refreshed in place on the shared `provider` (see
+        // `MonocleProvider::refresh`) rather than rebuilding it — mirrors
+        // `monocle agent`'s `Repl::run_turn` so a long-lived interactive
+        // session never sends a stale bearer. Resolved before touching
+        // `convo` (same order as `agent.rs`), so a refresh failure (e.g. a
+        // dead refresh token) never leaves a dangling user message — it's a
+        // per-turn error, not fatal, same recovery shape as a failed
+        // `call_chat` below. Placed here (before `eprintln!();
+        // crate::diag::reset();` below, not after) so this insertion point
+        // doesn't land on the same anchor as the sibling `/diag` PR's
+        // `Instant::now()` insertion right after `crate::diag::reset()`.
+        let session = match resolve_turn_session(client, creds) {
+            Some(s) => s,
+            None => return Ok(LoopControl::Continue),
+        };
+        provider.refresh(session);
+
         eprintln!();
         // Reset before this turn's work runs, so the hint below reflects only
         // whether *this* turn logged a network error — not a stale flag left
         // over from an earlier one (this REPL loops for the life of the
         // process, same as `monocle agent`'s).
         crate::diag::reset();
-
-        // Fresh token each turn (`try_access_token` refreshes if near expiry)
-        // and a freshly built provider — mirrors `monocle agent`'s
-        // `Repl::run_turn` so a long-lived interactive session never sends a
-        // stale bearer. Resolved before touching `convo` (same order as
-        // `agent.rs`), so a refresh failure (e.g. a dead refresh token) never
-        // leaves a dangling user message — it's a per-turn error, not fatal,
-        // same recovery shape as a failed `call_chat` below.
-        let provider = match try_access_token(client, creds) {
-            Ok(session) => MonocleProvider::from_session(session),
-            Err(e) => {
-                eprintln!("Error: {e}");
-                eprintln!();
-                return Ok(LoopControl::Continue);
-            }
-        };
 
         // Roll back this turn's user message on failure (mirrors `monocle
         // agent`'s `Repl::run_turn` mark/truncate) so a failed turn doesn't
@@ -507,21 +531,22 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
             }
         };
 
-        eprintln!();
-        crate::diag::reset();
-
         // Fresh token each turn, same rationale and ordering as the
         // completions path / `monocle agent`'s `Repl::run_turn` — rebuilds
         // the client so a long-lived REPL never sends a stale bearer. A
-        // refresh failure is a per-turn error, not fatal.
-        let rc = match try_access_token(client, creds) {
-            Ok(session) => ResponsesClient::new(client, session.token, jarvice_url.clone()),
-            Err(e) => {
-                eprintln!("Error: {e}");
-                eprintln!();
-                return Ok(LoopControl::Continue);
-            }
+        // refresh failure is a per-turn error, not fatal. Placed here
+        // (before `eprintln!(); crate::diag::reset();` below, not after) so
+        // this insertion point doesn't land on the same anchor as the
+        // sibling `/diag` PR's `Instant::now()` insertion right after
+        // `crate::diag::reset()`.
+        let session = match resolve_turn_session(client, creds) {
+            Some(s) => s,
+            None => return Ok(LoopControl::Continue),
         };
+        let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
+
+        eprintln!();
+        crate::diag::reset();
 
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -15,6 +15,7 @@ use rustyline::{CompletionType, Config, Context, Editor, Helper, Validator};
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+use crate::agent::providers::TokenUsage;
 use crate::colors as c;
 use crate::commands::model_list::fuzzy_model_candidates;
 use crate::error::Result;
@@ -44,6 +45,76 @@ pub fn mode_banner(label: &str, colorize: impl Fn(&str) -> String) -> String {
 pub enum LoopControl {
     Continue,
     Quit,
+}
+
+/// Diagnostics for the most recently completed turn, shown on demand by
+/// `/diag` — REPL-only, overwritten each turn (no history is kept). Shared by
+/// `monocle chat` (built fresh after every successful turn in both
+/// `run_completions_chat` and `run_responses_chat`, `steps` always `None`
+/// since a chat turn is exactly one LLM call) and `monocle agent` (`steps`
+/// accumulated across the agent-core loop's tool-use steps, since one turn
+/// can make several LLM calls). `served_model`/`usage` stay `None` wherever
+/// the backend doesn't report them (the `--responses` path reports neither
+/// today — see module docs on `responses_api::ResponsesReply`).
+pub struct TurnDiagnostics {
+    pub requested_model: String,
+    pub served_model: Option<String>,
+    pub endpoint: String,
+    pub latency_ms: u128,
+    pub usage: Option<TokenUsage>,
+    /// How many LLM calls this turn made. `None` for chat (always exactly
+    /// one); `Some(n)` for agent, whose tool-use loop can call the LLM
+    /// multiple times per turn.
+    pub steps: Option<u32>,
+}
+
+/// Render `/diag`'s bordered block (same `--- ... ---` framing as the
+/// `--responses` REPL's prior-history replay). Lines for data the backend
+/// didn't report are omitted entirely — never printed as `None`/`null`.
+pub fn format_diag(d: &TurnDiagnostics) -> String {
+    let mut lines = vec![
+        "--- diag ---".to_string(),
+        format!("Endpoint: {}", d.endpoint),
+        format!("Requested model: {}", d.requested_model),
+    ];
+    if let Some(served) = &d.served_model {
+        lines.push(format!("Served model: {served}"));
+    }
+    lines.push(format!("Latency: {}ms", d.latency_ms));
+    if let Some(steps) = d.steps {
+        lines.push(format!("Steps: {steps}"));
+    }
+    if let Some(u) = &d.usage {
+        lines.push(format!(
+            "Tokens: {} prompt + {} completion = {} total",
+            u.prompt_tokens, u.completion_tokens, u.total_tokens
+        ));
+    }
+    lines.push("--- end diag ---".to_string());
+    lines.join("\n")
+}
+
+/// Renders `/diag` output for either REPL: the last turn's diagnostics, or
+/// a dim "nothing yet" hint before the first turn.
+pub fn diag_output(diagnostics: &Option<TurnDiagnostics>) -> String {
+    match diagnostics {
+        None => crate::colors::dim("No response yet — send a message first."),
+        Some(d) => format_diag(d),
+    }
+}
+
+/// Handle a `/diag` line if `trimmed` is one: prints the last turn's
+/// diagnostics (or a "nothing yet" hint before the first turn). Returns
+/// `true` if this input was consumed as `/diag`, mirroring
+/// `model_list::handle_model_command`'s contract. `monocle chat`'s dispatch
+/// is a plain boolean chain, so this keeps that contract; `monocle agent`'s
+/// `Command`-enum dispatch calls `diag_output` directly instead.
+pub fn handle_diag_command(trimmed: &str, diagnostics: &Option<TurnDiagnostics>) -> bool {
+    if trimmed != "/diag" {
+        return false;
+    }
+    eprintln!("{}", diag_output(diagnostics));
+    true
 }
 
 /// Ghost-text hint shared by both REPL helpers' `Hinter` impls: given the
@@ -432,5 +503,115 @@ mod tests {
 
         let line = "/model sonnet";
         assert_eq!(h.hint(line, line.len(), &ctx), None);
+    }
+
+    #[test]
+    fn format_diag_omits_served_model_and_usage_when_unavailable() {
+        // The `--responses` path: only endpoint/requested-model/latency are
+        // ever known — served model and usage must never render as a literal
+        // "None"/"null", they're just absent lines.
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
+            latency_ms: 842,
+            usage: None,
+            steps: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://acme.monocle-ai.com/api/responses\n\
+             Requested model: monocle-auto\n\
+             Latency: 842ms\n\
+             --- end diag ---"
+        );
+        assert!(!block.contains("None"));
+        assert!(!block.contains("null"));
+    }
+
+    #[test]
+    fn format_diag_shows_served_model_and_usage_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            latency_ms: 1234,
+            usage: Some(TokenUsage {
+                prompt_tokens: 120,
+                completion_tokens: 45,
+                total_tokens: 165,
+            }),
+            steps: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 1234ms\n\
+             Tokens: 120 prompt + 45 completion = 165 total\n\
+             --- end diag ---"
+        );
+    }
+
+    /// `steps` is agent-only — when present it renders between "Latency" and
+    /// "Tokens", since an agent turn's step count is a fact about the turn as
+    /// a whole (like latency), not part of the token accounting.
+    #[test]
+    fn format_diag_shows_steps_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            latency_ms: 2500,
+            usage: Some(TokenUsage {
+                prompt_tokens: 300,
+                completion_tokens: 80,
+                total_tokens: 380,
+            }),
+            steps: Some(3),
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/agent\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Latency: 2500ms\n\
+             Steps: 3\n\
+             Tokens: 300 prompt + 80 completion = 380 total\n\
+             --- end diag ---"
+        );
+    }
+
+    #[test]
+    fn diag_output_shows_nothing_yet_hint_before_first_turn() {
+        let out = diag_output(&None);
+        assert!(out.contains("No response yet"));
+    }
+
+    #[test]
+    fn diag_output_renders_format_diag_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: None,
+            endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            latency_ms: 10,
+            usage: None,
+            steps: Some(1),
+        };
+        assert!(diag_output(&Some(d)).contains("Steps: 1"));
+    }
+
+    #[test]
+    fn handle_diag_command_only_consumes_exact_slash_diag() {
+        let diagnostics: Option<TurnDiagnostics> = None;
+        assert!(!handle_diag_command("not diag", &diagnostics));
+        assert!(handle_diag_command("/diag", &diagnostics));
     }
 }

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -29,6 +29,17 @@ use crate::error::Result;
 /// this prompt.
 pub const PROMPT: &str = "\u{276F} "; // ❯ — the modern CLI prompt glyph (Starship/Spaceship convention), replacing the old "$"/">" default.
 
+/// Renders this REPL's mode-identity marker ("▸ <label>") in the given color
+/// — shared so `monocle chat`'s and `monocle agent`'s banners (and any future
+/// REPL mode's) can't drift on the glyph or format the way the prompt caret
+/// itself briefly did before `PROMPT` was unified. Callers still choose their
+/// own color (agent: orange, "the active/acting mode" per DESIGN.md; chat:
+/// cyan, informational) and print it themselves, since some banners (agent's)
+/// append extra context (the workdir) that isn't part of this shared shape.
+pub fn mode_banner(label: &str, colorize: impl Fn(&str) -> String) -> String {
+    colorize(&format!("\u{25B8} {label}"))
+}
+
 /// What the per-line callback wants the loop to do next.
 pub enum LoopControl {
     Continue,

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -68,6 +68,48 @@ pub struct TurnDiagnostics {
     pub steps: Option<u32>,
 }
 
+impl TurnDiagnostics {
+    /// A chat turn is always exactly one LLM call — `steps` is never
+    /// meaningful here, so callers don't set it themselves (and can't get it
+    /// wrong the way a bare struct literal would let them).
+    pub fn for_chat(
+        requested_model: String,
+        served_model: Option<String>,
+        endpoint: String,
+        latency_ms: u128,
+        usage: Option<TokenUsage>,
+    ) -> Self {
+        Self {
+            requested_model,
+            served_model,
+            endpoint,
+            latency_ms,
+            usage,
+            steps: None,
+        }
+    }
+
+    /// An agent turn's tool-use loop can call the LLM several times —
+    /// `steps` records how many this turn actually took.
+    pub fn for_agent(
+        requested_model: String,
+        served_model: Option<String>,
+        endpoint: String,
+        latency_ms: u128,
+        usage: Option<TokenUsage>,
+        steps: u32,
+    ) -> Self {
+        Self {
+            requested_model,
+            served_model,
+            endpoint,
+            latency_ms,
+            usage,
+            steps: Some(steps),
+        }
+    }
+}
+
 /// Render `/diag`'s bordered block (same `--- ... ---` framing as the
 /// `--responses` REPL's prior-history replay). Lines for data the backend
 /// didn't report are omitted entirely — never printed as `None`/`null`.

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -19,6 +19,16 @@ use crate::colors as c;
 use crate::commands::model_list::fuzzy_model_candidates;
 use crate::error::Result;
 
+/// Shared REPL prompt for both `monocle chat` and `monocle agent` — unifies
+/// what were previously two different carets ("> " and "» "). Plain ASCII-
+/// safe text only: rustyline computes prompt width by skipping recognized
+/// ANSI escapes, but on Windows consoles without VT processing enabled those
+/// escapes print as literal bytes instead, desyncing the cursor column from
+/// what rustyline thinks it is. Mode identity is signaled by a colored line
+/// printed BEFORE the REPL starts (see chat.rs/agent.rs), not by coloring
+/// this prompt.
+pub const PROMPT: &str = "\u{276F} "; // ❯ — the modern CLI prompt glyph (Starship/Spaceship convention), replacing the old "$"/">" default.
+
 /// What the per-line callback wants the loop to do next.
 pub enum LoopControl {
     Continue,

--- a/src/net.rs
+++ b/src/net.rs
@@ -86,6 +86,15 @@ impl Client {
             // TCP keepalive lets the OS surface a dead peer on the streaming path
             // (which has no total timeout) without capping a healthy long stream.
             .tcp_keepalive(std::time::Duration::from_secs(60))
+            // Kept below AWS ALB's default 60s idle timeout (our chat-proxy/
+            // jarvice endpoints sit behind one) so THIS client evicts an idle
+            // pooled connection before the peer does. Without this, reqwest's
+            // own default (90s) leaves a ~30s window where we trust a
+            // connection the peer already closed — the next request's send
+            // then fails with a connection reset (surfaced as "error sending
+            // request for url", not a timeout). `send_with_retry` below is
+            // the backstop for whatever this doesn't catch.
+            .pool_idle_timeout(std::time::Duration::from_secs(50))
             .build()
             .expect("failed to build HTTP client");
         Self { inner }
@@ -114,8 +123,9 @@ impl Client {
             req = req.header(*k, *v);
         }
         // Inline send (not the shared `send()`) so the 600s timeout above is the
-        // only cap that applies to the download.
-        let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+        // only cap that applies to the download — but still goes through
+        // `send_with_retry` for the same stale-connection backstop.
+        let resp = send_with_retry("GET", url, req).map_err(|e| AppError(e.to_string()))?;
         let status = resp.status().as_u16();
         let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
         let headers = collect_headers(resp.headers());
@@ -205,7 +215,7 @@ impl Client {
         for (k, v) in headers {
             req = req.header(*k, *v);
         }
-        let resp = req.send().map_err(|e| AppError(e.to_string()))?;
+        let resp = send_with_retry("POST", url, req).map_err(|e| AppError(e.to_string()))?;
         let status = resp.status().as_u16();
         let content_type = resp
             .headers()
@@ -222,12 +232,56 @@ impl Client {
     }
 }
 
+/// Send a request, retrying exactly once with a fresh connection if the
+/// first attempt fails before we get a response back at all.
+///
+/// No backoff: the overwhelmingly likely cause is a stale pooled connection
+/// (a peer — e.g. an AWS ALB — idle-closed it after we last used it; see
+/// `Client::new`'s `pool_idle_timeout` comment), and a brand-new connection
+/// clears that instantly. Waiting wouldn't help a dead socket, and a genuine
+/// outage fails the retry just as fast as the original attempt — so this is
+/// not the "retry a flaky API with growing backoff" policy (that's a
+/// different problem — real transient 5xx/429 responses from a server that
+/// *did* answer — and would need its own, separately-scoped retry policy).
+///
+/// Safe to retry unconditionally here (not just for idempotent methods):
+/// every call site through this module is an LLM/media API call (chat
+/// completion, token exchange, audio upload/synthesis) where, at worst, a
+/// retry re-dispatches a request the first attempt never got a response for
+/// — wasteful if the server did somehow start work, never corrupting.
+///
+/// `try_clone()` only fails for a non-replayable body (a raw stream); every
+/// body sent through this module (JSON, form, in-memory multipart) is
+/// buffered and clones fine, so this silently skips the retry only in a case
+/// that doesn't occur here.
+fn send_with_retry(
+    method: &str,
+    url: &str,
+    req: reqwest::blocking::RequestBuilder,
+) -> reqwest::Result<reqwest::blocking::Response> {
+    let retry = req.try_clone();
+    match req.send() {
+        Ok(resp) => Ok(resp),
+        Err(first_err) => {
+            crate::diag::log_network_error(
+                method,
+                url,
+                &format!("retrying once after: {first_err}"),
+            );
+            match retry {
+                Some(retry_req) => retry_req.send(),
+                None => Err(first_err),
+            }
+        }
+    }
+}
+
 fn send(method: &str, url: &str, req: reqwest::blocking::RequestBuilder) -> Result<Resp> {
     // Total request timeout — non-streaming only (see `Client::new`). Streaming
     // (`post_json_stream`) builds and sends its own request without this, so a
     // long generation is never cut short.
     let req = req.timeout(std::time::Duration::from_secs(120));
-    let resp = req.send().map_err(|e| {
+    let resp = send_with_retry(method, url, req).map_err(|e| {
         let msg = e.to_string();
         crate::diag::log_network_error(method, url, &msg);
         AppError(msg)
@@ -304,5 +358,75 @@ impl EventStream {
         let mut s = String::new();
         let _ = self.reader.read_to_string(&mut s);
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::send_with_retry;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// Simulates the actual bug: a first attempt that fails, then a
+    /// perfectly normal one. Both connections run a full, ordinary
+    /// accept/read/write/close cycle — the only difference is that the
+    /// first writes content hyper's h1 parser will reject.
+    ///
+    /// (An earlier version of this test instead had the first connection
+    /// die with no response at all, mimicking a stale pooled connection
+    /// exactly — but that made the test itself flaky, independent of
+    /// `send_with_retry`: hyper's client occasionally read the *second*
+    /// connection's perfectly valid response as `UnexpectedMessage` (seen
+    /// even with the first connection's request fully drained before close,
+    /// and even with the retry using a wholly separate `Client`, ruling out
+    /// connection-pool reuse as the cause — some hyper/loopback timing
+    /// artifact specific to two rapid-fire real connections to the same
+    /// address, not a defect in this module. This version sidesteps it
+    /// entirely, at zero cost to what's actually under test: `send_with_retry`
+    /// only cares that the first `send()` returned `Err`, not why.)
+    #[test]
+    fn send_with_retry_recovers_from_a_failed_first_attempt() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(b"not an http response at all\r\n\r\n");
+            }
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok",
+                );
+            }
+        });
+
+        let client = reqwest::blocking::Client::new();
+        let url = format!("http://{addr}/");
+        let resp = send_with_retry("GET", &url, client.get(&url)).expect("retry should recover");
+        assert_eq!(resp.status(), 200);
+    }
+
+    /// When even the retry fails (the peer never comes back at all), the
+    /// original error surfaces rather than hanging or panicking.
+    #[test]
+    fn send_with_retry_gives_up_after_one_retry() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            // Drop both the first attempt and the retry.
+            if let Ok((stream, _)) = listener.accept() {
+                drop(stream);
+            }
+            if let Ok((stream, _)) = listener.accept() {
+                drop(stream);
+            }
+        });
+
+        let client = reqwest::blocking::Client::new();
+        let url = format!("http://{addr}/");
+        assert!(send_with_retry("GET", &url, client.get(&url)).is_err());
     }
 }

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -24,7 +24,7 @@
 
 use serde_json::{json, Value};
 
-use crate::agent::providers::ImageAttachment;
+use crate::agent::providers::{ImageAttachment, ToolCall};
 use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::auth_headers;
@@ -37,6 +37,14 @@ use crate::origin::auth_headers;
 pub struct ResponsesReply {
     pub content: String,
     pub thread_id: Option<String>,
+    /// Tool calls the model requested, surfaced but NOT executed
+    /// (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only runs
+    /// its MCP tool-execution loop on the streaming branch, and this client
+    /// always sends `"stream": false` (see the module docs), so a non-empty
+    /// `tool_calls` here means the model's request went unexecuted. Callers
+    /// must warn rather than silently drop it — actually executing tools in
+    /// this mode is out of scope (tracked separately, monocle#274).
+    pub tool_calls: Vec<ToolCall>,
 }
 
 /// Build the `input` field: a plain string when there's no attachment (the
@@ -118,18 +126,30 @@ impl<'a> ResponsesClient<'a> {
             )));
         }
         let data: Value = resp.json()?;
-        if data.get("choices").and_then(|c| c.get(0)).is_none() {
-            return Err(AppError::new(format!(
-                "unexpected /api/responses reply (no choices): {data}"
-            )));
-        }
-        let content = data["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
         let thread_id = resp.header("x-thread-id").map(str::to_string);
-        Ok(ResponsesReply { content, thread_id })
+        parse_reply(&data, thread_id)
     }
+}
+
+/// Parse a `/api/responses` JSON body into a `ResponsesReply`. Split out from
+/// `respond` so the parsing — including the `tool_calls` extraction
+/// (monocle-cli#101) — can be exercised directly against fixture JSON in
+/// tests, without an HTTP round-trip.
+fn parse_reply(data: &Value, thread_id: Option<String>) -> Result<ResponsesReply> {
+    if data.get("choices").and_then(|c| c.get(0)).is_none() {
+        return Err(AppError::new(format!(
+            "unexpected /api/responses reply (no choices): {data}"
+        )));
+    }
+    let message = &data["choices"][0]["message"];
+    let content = message["content"].as_str().unwrap_or_default().to_string();
+    let tool_calls: Vec<ToolCall> =
+        serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    Ok(ResponsesReply {
+        content,
+        thread_id,
+        tool_calls,
+    })
 }
 
 #[cfg(test)]
@@ -165,6 +185,51 @@ mod tests {
         assert_eq!(
             build_input("", &images),
             json!([{"type": "input_image", "image_url": "https://example.com/a.png"}])
+        );
+    }
+
+    /// Build a minimal `/api/responses`-shaped body, optionally with a
+    /// `tool_calls` array on `choices[0].message`.
+    fn responses_body(content: &str, tool_calls: Option<Value>) -> Value {
+        let mut message = json!({"content": content});
+        if let Some(tc) = tool_calls {
+            message["tool_calls"] = tc;
+        }
+        json!({"choices": [{"message": message}]})
+    }
+
+    #[test]
+    fn tool_calls_empty_when_absent() {
+        // The common, no-tool-calls case: `tool_calls` must come back empty,
+        // not error, when the field is simply missing from the message.
+        let data = responses_body("hello", None);
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.content, "hello");
+        assert!(reply.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn tool_calls_populated_when_present() {
+        // monocle-cli#101: a non-streaming /api/responses reply can legitimately
+        // carry an unexecuted tool_calls array — it must round-trip intact into
+        // `ResponsesReply.tool_calls` so the caller can warn instead of
+        // silently dropping it.
+        let data = responses_body(
+            "",
+            Some(json!([{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"a.txt\"}"},
+            }])),
+        );
+        let reply = parse_reply(&data, Some("thread_1".to_string())).unwrap();
+        assert_eq!(reply.thread_id.as_deref(), Some("thread_1"));
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].id, "call_1");
+        assert_eq!(reply.tool_calls[0].function.name, "read_file");
+        assert_eq!(
+            reply.tool_calls[0].function.arguments,
+            "{\"path\":\"a.txt\"}"
         );
     }
 

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -24,7 +24,7 @@
 
 use serde_json::{json, Value};
 
-use crate::agent::providers::{ImageAttachment, ToolCall};
+use crate::agent::providers::{ensure_tool_call_ids, ImageAttachment, ToolCall};
 use crate::error::{AppError, Result};
 use crate::net::Client;
 use crate::origin::auth_headers;
@@ -38,13 +38,23 @@ pub struct ResponsesReply {
     pub content: String,
     pub thread_id: Option<String>,
     /// Tool calls the model requested, surfaced but NOT executed
-    /// (monocle-cli#101 / monocle#275): jarvice's `/api/responses` only runs
-    /// its MCP tool-execution loop on the streaming branch, and this client
-    /// always sends `"stream": false` (see the module docs), so a non-empty
-    /// `tool_calls` here means the model's request went unexecuted. Callers
-    /// must warn rather than silently drop it — actually executing tools in
-    /// this mode is out of scope (tracked separately, monocle#274).
+    /// (monocle-cli#101 / monocle#275) — **this is the canonical explanation,
+    /// referenced rather than repeated elsewhere**: jarvice's `/api/responses`
+    /// only runs its MCP tool-execution loop on the streaming branch, and this
+    /// client always sends `"stream": false` (see the module docs), so a
+    /// non-empty `tool_calls` here means the model's request went unexecuted.
+    /// Callers must warn rather than silently drop it — actually executing
+    /// tools in this mode is out of scope (tracked separately, monocle#274).
     pub tool_calls: Vec<ToolCall>,
+    /// Count of `tool_calls` entries jarvice sent whose JSON shape didn't
+    /// deserialize into `ToolCall` (e.g. a missing `id`, or `function.arguments`
+    /// sent as a parsed object rather than a JSON-encoded string). Parsed
+    /// per-entry (see `parse_tool_calls`) specifically so ONE malformed entry
+    /// can't silently discard every OTHER, well-formed entry alongside it —
+    /// the all-or-nothing failure mode a single `Vec<ToolCall>` deserialize
+    /// would have. Callers should mention this count too, not just `tool_calls`,
+    /// so a shape mismatch is never silent either (monocle-cli#101).
+    pub unparsed_tool_calls: usize,
 }
 
 /// Build the `input` field: a plain string when there's no attachment (the
@@ -143,13 +153,37 @@ fn parse_reply(data: &Value, thread_id: Option<String>) -> Result<ResponsesReply
     }
     let message = &data["choices"][0]["message"];
     let content = message["content"].as_str().unwrap_or_default().to_string();
-    let tool_calls: Vec<ToolCall> =
-        serde_json::from_value(message["tool_calls"].clone()).unwrap_or_default();
+    let (tool_calls, unparsed_tool_calls) = parse_tool_calls(&message["tool_calls"]);
     Ok(ResponsesReply {
         content,
         thread_id,
         tool_calls,
+        unparsed_tool_calls,
     })
+}
+
+/// Deserialize a `message.tool_calls` JSON value entry-by-entry rather than as
+/// one `Vec<ToolCall>` (monocle-cli#101): `serde`'s derived `Vec<T>` decode
+/// fails the WHOLE sequence if a single element doesn't match `ToolCall`'s
+/// shape, which would silently discard every other, well-formed tool call
+/// alongside it — reproducing the exact silent-drop bug this fix exists for,
+/// just one layer deeper. Returns the entries that parsed (ids normalized via
+/// `ensure_tool_call_ids`, same as the chat-proxy path) plus a count of the
+/// ones that didn't, so a caller can report both instead of neither.
+fn parse_tool_calls(value: &Value) -> (Vec<ToolCall>, usize) {
+    let Some(entries) = value.as_array() else {
+        return (Vec::new(), 0);
+    };
+    let mut tool_calls = Vec::new();
+    let mut unparsed = 0usize;
+    for entry in entries {
+        match serde_json::from_value::<ToolCall>(entry.clone()) {
+            Ok(tc) => tool_calls.push(tc),
+            Err(_) => unparsed += 1,
+        }
+    }
+    ensure_tool_call_ids(&mut tool_calls);
+    (tool_calls, unparsed)
 }
 
 #[cfg(test)]
@@ -206,6 +240,7 @@ mod tests {
         let reply = parse_reply(&data, None).unwrap();
         assert_eq!(reply.content, "hello");
         assert!(reply.tool_calls.is_empty());
+        assert_eq!(reply.unparsed_tool_calls, 0);
     }
 
     #[test]
@@ -231,6 +266,55 @@ mod tests {
             reply.tool_calls[0].function.arguments,
             "{\"path\":\"a.txt\"}"
         );
+        assert_eq!(reply.unparsed_tool_calls, 0);
+    }
+
+    #[test]
+    fn one_malformed_tool_call_no_longer_discards_its_well_formed_sibling() {
+        // The regression this fix closes (monocle-cli#101 code review): a
+        // naive `Vec<ToolCall>` deserialize fails the WHOLE array on one bad
+        // element. `parse_tool_calls` must parse per-entry instead, so the
+        // well-formed `read_file` call survives even though the second entry
+        // is missing `function` entirely.
+        let data = responses_body(
+            "",
+            Some(json!([
+                {"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "call_2", "type": "function"},
+            ])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].function.name, "read_file");
+        // The malformed entry is counted, not silently dropped with zero trace.
+        assert_eq!(reply.unparsed_tool_calls, 1);
+    }
+
+    #[test]
+    fn all_malformed_tool_calls_are_counted_not_silently_dropped() {
+        let data = responses_body("", Some(json!([{"id": "call_1"}, {"id": "call_2"}])));
+        let reply = parse_reply(&data, None).unwrap();
+        assert!(reply.tool_calls.is_empty());
+        assert_eq!(reply.unparsed_tool_calls, 2);
+    }
+
+    #[test]
+    fn tool_call_missing_id_gets_normalized_like_the_chat_proxy_path() {
+        // monocle-cli#101 code review: `parse_reply` must normalize an
+        // empty/missing `id` the same way `agent::providers::parse_response_value`
+        // already does for the chat-proxy path (`ensure_tool_call_ids`), so the
+        // two `ToolCall`-producing parsers don't quietly diverge on the same type.
+        let data = responses_body(
+            "",
+            Some(json!([{
+                "id": "",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tool_calls.len(), 1);
+        assert_eq!(reply.tool_calls[0].id, "call_0");
     }
 
     #[test]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -77,6 +77,42 @@ fn loop_executes_tool_then_returns_final_answer() {
 }
 
 #[test]
+fn on_turn_step_fires_once_per_llm_call_in_a_multi_step_turn() {
+    // Same tool-call-then-final-answer script as
+    // `loop_executes_tool_then_returns_final_answer`: the fake provider is
+    // called twice (once for the tool-call step, once for the final-answer
+    // step) — `on_turn_step` must fire exactly once per LLM call, i.e. twice.
+    let provider = FakeProvider::new(|req| {
+        if has_tool_result(req) {
+            text_response("done")
+        } else {
+            tool_call_response(
+                "call_1",
+                "write_file",
+                json!({"path":"out.txt","content":"hi"}),
+            )
+        }
+    });
+    let tools = ToolRegistry::with_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let agent = agent(&provider, &tools, dir.path(), 20);
+
+    let mut rec = RecordingObserver::new();
+    let stop = agent
+        .run(
+            &mut vec![Message::user("write out.txt")],
+            &mut AllowAll,
+            &mut rec,
+            &Cancel::new(),
+        )
+        .unwrap();
+
+    assert!(matches!(stop, RunStop::EndTurn));
+    let steps: Vec<String> = rec.events().into_iter().filter(|e| e == "step").collect();
+    assert_eq!(steps.len(), 2, "expected one on_turn_step per LLM call");
+}
+
+#[test]
 fn denied_side_effecting_tool_is_not_executed() {
     let provider = FakeProvider::new(|req| {
         if has_tool_result(req) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -54,6 +54,7 @@ pub fn text_response(content: &str) -> ChatResponse {
         model: None,
         finish_reason: Some("stop".to_string()),
         truncated: false,
+        usage: None,
     }
 }
 
@@ -78,6 +79,7 @@ pub fn tool_call_response_raw(id: &str, name: &str, arguments: &str) -> ChatResp
         model: None,
         finish_reason: Some("tool_calls".to_string()),
         truncated: false,
+        usage: None,
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -289,7 +289,8 @@ impl FsBackend for InMemoryFs {
 /// can assert exactly which tool calls the agent made and in what order:
 /// - `call:<name>:<args-compact-json>`
 /// - `result:<name>:<is_error>`
-/// - `text:<delta>` · `notice:<msg>`
+/// - `text:<delta>` · `notice:<msg>` · `step` (one per `on_turn_step` call — once
+///   per LLM call the turn makes)
 #[derive(Default)]
 pub struct RecordingObserver {
     events: Vec<String>,
@@ -319,5 +320,8 @@ impl Observer for RecordingObserver {
     }
     fn on_notice(&mut self, msg: &str) {
         self.events.push(format!("notice:{msg}"));
+    }
+    fn on_turn_step(&mut self, _resp: &ChatResponse) {
+        self.events.push("step".to_string());
     }
 }


### PR DESCRIPTION
devel → main 승격. 포함 내용: PR #104(net.rs stale-connection 재시도 — ALB 유휴
타임아웃 대응 pool_idle_timeout + 전송 실패 1회 재시도), PR #106(버전 bump
1.4.1 → 1.4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)