### PR TITLE
docs: warn about the single credential slot, and correct the verification path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,41 @@ cargo fmt               # 포매팅
 > 즉 **프로덕션 세션이 살아있는 상태에서 `monocle login --env stg`를 실행하면 그
 > 세션은 경고 없이 사라진다.** 되돌리려면 재인증해야 한다.
 >
+> **잃는 것이 액세스 토큰만이 아니다.** 프로덕션 리프레시 토큰은 수명이 길어 —
+> 관측 시점 기준 **2026-08-22까지 유효** — 그동안 무인(unattended) 프로덕션
+> 호출을 가능하게 한다. 덮어쓰면 그 능력이 통째로 사라지고, 재인증에는 사람이
+> 붙어야 한다. (날짜는 해당 시점의 실제 세션에서 관측한 값이며 계약이 아니다.)
+>
 > **환경을 바꾸기 전에 백업할 것:**
 > ```bash
 > cp ~/.monocle/credentials.json ~/.monocle/credentials.json.prod   # 전환 전
 > cp ~/.monocle/credentials.json.prod ~/.monocle/credentials.json   # 복구
 > ```
 > (백업본도 토큰이므로 `chmod 600`을 유지하고 레포에 넣지 말 것.)
+>
+> **스테이징은 로그인에 성공해도 동작하지 않을 수 있다.** 스테이징 액세스
+> 토큰에는 `email` 클레임이 없어서(stark#1061) jarvice REST가 401을 낼 수 있다.
+> 즉 "로그인 성공"을 "스테이징이 정상"으로 읽으면 안 된다 — 프로덕션 세션을
+> 날린 대가로 얻은 것이 401뿐일 수 있다.
+
+### 검증 경로 — CLI로 확인한 것은 모바일로 확인한 것이 아니다
+
+`monocle` CLI는 **`X-Session-Id` 헤더를 보내지 않지만 모바일 클라이언트는 보낸다.**
+jarvice는 이 헤더로 처리 분기를 가르므로(jarvice `middleware.py:2440-2451`),
+**CLI에서 통과한 것이 모바일 경로에서도 통과한다는 보장이 없다.** CLI 결과를
+모바일 동작의 근거로 삼는 것은 잘못된 검증이다.
+
+모바일 계열 동작을 검증할 때는 CLI 대신 **헤더 3개를 갖춘 `curl`**을 쓸 것:
+
+```bash
+curl -sS https://stg-agent.monocle-ai.com/<endpoint> \
+  -H 'content-type: application/json' \
+  -H "X-Session-Id: $SESSION_ID" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+호스트를 헷갈리지 말 것 — 스테이징 **jarvice** 테넌트는 `stg-agent.monocle-ai.com`
+이고, `stg.monocle-ai.com`은 **Stark**(인증 서버)다.
 
 ## 설계 원칙 — 조합성·상호운용성 (유닉스 철학)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,25 @@ cargo fmt               # 포매팅
 - 자격증명 파일(`~/.monocle/credentials.json`)은 drop-in 호환 계약 — JSON 스키마/키
   순서/0600 권한을 바꾸지 말 것 (기존 로그인 사용자가 재인증하지 않도록)
 
+## 인증 · 자격증명
+
+> ⚠️ **자격증명 슬롯은 하나뿐이다 — 환경 전환은 현재 세션을 조용히 파괴한다.**
+>
+> `monocle login`은 `--env <prod|stg|local>`(기본 `prod`)을 받지만, 저장 경로는
+> **환경과 무관하게 `~/.monocle/credentials.json` 하나**다. 환경별 파일이 없다.
+> 로그인은 기존 세션 확인도, 확인 절차도 없이 그대로 덮어쓴다
+> (`src/commands/login.rs`의 `store.write(&creds)`).
+>
+> 즉 **프로덕션 세션이 살아있는 상태에서 `monocle login --env stg`를 실행하면 그
+> 세션은 경고 없이 사라진다.** 되돌리려면 재인증해야 한다.
+>
+> **환경을 바꾸기 전에 백업할 것:**
+> ```bash
+> cp ~/.monocle/credentials.json ~/.monocle/credentials.json.prod   # 전환 전
+> cp ~/.monocle/credentials.json.prod ~/.monocle/credentials.json   # 복구
+> ```
+> (백업본도 토큰이므로 `chmod 600`을 유지하고 레포에 넣지 말 것.)
+
 ## 설계 원칙 — 조합성·상호운용성 (유닉스 철학)
 
 `monocle`은 **"하나를 잘하고 조합 가능한 도구"** 를 지향한다. 최근 코딩 에이전트가


### PR DESCRIPTION
## Why

`monocle-mobile-voice` hit a real footgun: **monocle-cli has exactly one credential slot**, so switching environments silently destroys the current session. This PR routes that hazard to its durable home so future agents working in this repo don't rediscover it the hard way.

## Verified in this repo

- `monocle login` accepts `--env <prod|stg|local>` (default `prod`) — `src/main.rs:84-86`
- but the storage path is **environment-independent**: `Credentials::path()` is always `~/.monocle/credentials.json` (`src/credentials.rs`). There are no per-env files.
- login writes unconditionally — no existing-session check, no confirmation: `store.write(&creds)` at `src/commands/login.rs:325` and `:398`

So `monocle login --env stg` with a live **production** session wipes it silently, and recovery means re-authenticating.

## What the doc now records

A dedicated **인증 · 자격증명** section in `CLAUDE.md` (there was none — only a Conventions bullet about the drop-in compat contract):

- one credential slot, no per-env files
- `login --env <x>` overwrites the live session with no warning
- **what you actually lose**: the prod *refresh* token is long-lived (observed valid to 2026-08-22) and is what enables **unattended** production calls — overwriting it costs that capability, and re-auth needs a human
- back up `~/.monocle/credentials.json` before switching (copy/restore commands, keep `chmod 600`, never commit it)
- **staging can fail even after a successful login**: staging access tokens carry no `email` claim (stark#1061), so jarvice REST may 401 — "login succeeded" must not be read as "staging works"

Plus a new sub-section, **검증 경로 — CLI로 확인한 것은 모바일로 확인한 것이 아니다**:

- the CLI does **not** send `X-Session-Id`; mobile does, and jarvice branches on it (jarvice `middleware.py:2440-2451`) — so a CLI result is not evidence about the mobile path
- verify mobile-class behavior with `curl` carrying three headers (`content-type`, `X-Session-Id`, `Authorization`), not with the CLI
- host gotcha: staging **jarvice** is `stg-agent.monocle-ai.com`; `stg.monocle-ai.com` is **Stark**

Written in Korean to match the surrounding file. **Docs only — no behavior change.**

## Provenance

The three code references I could reach from this repo (`main.rs`, `credentials.rs`, `login.rs`) are verified first-hand. The refresh-token expiry, stark#1061, and the jarvice `middleware.py` line range come from the reporting session — they live in other repos/systems I can't read from here, so they're recorded on that authority rather than independently confirmed. The expiry date is written as an observed value, not a contract, so it doesn't read as an invariant once it lapses.

## Notes for the reviewer

This documents the hazard rather than fixing it, as asked. Removing the footgun would be a separate PR — per-env credential files (`credentials.<env>.json`), or a confirmation prompt when `--env` differs from the stored session's environment. Happy to open an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)