### PR TITLE
feat: --responses에 --verify-tool-firing 검증 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>] [--verify-tool-firing]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead; `--verify-tool-firing` (with `--responses`, one-shot) exits non-zero if a tool request came back unresolved |
 | `monocle chat list` | List existing jarvice chat threads (id/title/last-updated) — including threads created in jarvice's own web UI |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
@@ -269,13 +269,27 @@ Notes:
   it's fully generated, unlike the plain chat path's live token stream.
 - **`--system-prompt`/`--system-prompt-file`/`--max-tokens` are ignored** — the
   endpoint has no equivalent fields (a warning is printed if you pass them).
-- **Tool calls aren't executed** — this mode doesn't run a tool loop yet; if a
-  tool-calling model requests one, a warning is printed to stderr — naming it
-  when its shape parses, or noting the count when it doesn't — instead of
-  silently dropping it (see
+- **Tool calls aren't executed client-side** — this mode doesn't run a tool
+  loop itself; if the model requests a tool this CLI can't run locally, a
+  warning is printed to stderr — naming it when its shape parses, or noting
+  the count when it doesn't — instead of silently dropping it (see
   [monocle-cli#101](https://github.com/warmblood-kr/monocle-cli/issues/101)).
   `monocle agent` executes tools client-side today, if that's what you need
-  right now.
+  right now. This is separate from jarvice's own **server-executed** tools
+  (e.g. `web_search`) — those run on jarvice and come back already resolved;
+  see `--verify-tool-firing` below to check that they actually did.
+- **`--verify-tool-firing`** — one-shot only; turns the warning above from
+  stderr-text into a scriptable check. If the reply comes back with an
+  unresolved tool_calls report, this exits non-zero (and prints
+  `✗ tool-firing verification FAILED: ...`) instead of just warning; if
+  nothing was dropped, it prints `✓ tool-firing verification: passed` and
+  exits `0`. Useful to confirm a server-executed tool actually fired end to
+  end (e.g. after a jarvice/chat-proxy deploy) without eyeballing stderr:
+
+  ```bash
+  echo "search the web for today's date" | monocle chat --responses --verify-tool-firing
+  echo "exit: $?"
+  ```
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -35,6 +35,10 @@ pub struct ChatOptions {
     pub responses: bool,
     /// `--resume <ID>`: continue an existing `--responses` thread.
     pub resume: Option<String>,
+    /// `--verify-tool-firing`: with `--responses`, treat an unresolved
+    /// tool_calls report as a scriptable failure (nonzero exit) instead of
+    /// just a stderr warning. One-shot only.
+    pub verify_tool_firing: bool,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -230,6 +234,10 @@ fn dispatch_chat_command(
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
+    if options.verify_tool_firing && !options.responses {
+        eprintln!("--verify-tool-firing requires --responses (server-executed tools are only observable there)");
+        std::process::exit(1);
+    }
     if options.responses {
         run_responses_chat(client, creds, options)
     } else {
@@ -538,6 +546,23 @@ fn dropped_tool_calls_message(
     ))
 }
 
+/// `--verify-tool-firing`: turn the existing dropped-tool-calls warning into
+/// a scriptable pass/fail. Today that warning is stderr-text-only and never
+/// affects the exit code, so a verification script (e.g. confirming a
+/// server-executed tool like `web_search` actually ran) has to grep stderr
+/// rather than check `$?` — see the manual ritual in jarvice#1217's
+/// prod-verified comment. Pure — no I/O/`process::exit` — so it's directly
+/// unit-testable; the call site does the actual `eprintln!`/exit, same
+/// convention as `dropped_tool_calls_message`.
+fn tool_firing_verification_result(
+    dropped_message: Option<&str>,
+) -> std::result::Result<String, String> {
+    match dropped_message {
+        Some(msg) => Err(format!("✗ tool-firing verification FAILED: {msg}")),
+        None => Ok("✓ tool-firing verification: passed (no unresolved tool_calls)".to_string()),
+    }
+}
+
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
 /// docs). The server owns the conversation thread — this REPL only tracks
 /// the `thread_id` to pass on the next turn, never a local message history.
@@ -566,6 +591,12 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         );
         std::process::exit(1);
     }
+    if options.verify_tool_firing && stdin_is_tty {
+        eprintln!(
+            "--verify-tool-firing requires piped input. Pipe a tool-triggering prompt, e.g.:\n  echo \"search the web for today's date\" | monocle chat --responses --verify-tool-firing"
+        );
+        std::process::exit(1);
+    }
 
     // Auth FIRST, same rationale as the completions path — an expired/missing
     // login must surface before any local-input error masks it.
@@ -578,11 +609,20 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         eprintln!("jarvice: {jarvice_url}");
         let rc = ResponsesClient::new(client, session.token, jarvice_url.clone());
         let reply = rc.respond(&model, &text, &images, options.resume.as_deref())?;
-        if let Some(msg) = dropped_tool_calls_message(
+        let dropped_msg = dropped_tool_calls_message(
             &reply.tool_calls,
             reply.unparsed_tool_calls,
             "--responses mode",
-        ) {
+        );
+        if options.verify_tool_firing {
+            match tool_firing_verification_result(dropped_msg.as_deref()) {
+                Ok(pass_msg) => eprintln!("{pass_msg}"),
+                Err(fail_msg) => {
+                    eprintln!("{fail_msg}");
+                    std::process::exit(1);
+                }
+            }
+        } else if let Some(msg) = dropped_msg {
             eprintln!("{msg}");
         }
         println!("{}", reply.content);
@@ -784,7 +824,8 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 mod tests {
     use super::{
         chat_help_text, dispatch_chat_command, dropped_tool_calls_message, handle_help_command,
-        resolve_max_tokens, resolve_repl_attachments, TurnDiagnostics,
+        resolve_max_tokens, resolve_repl_attachments, tool_firing_verification_result,
+        TurnDiagnostics,
     };
     use crate::agent::providers::{FunctionCall, ToolCall};
     use crate::commands::repl::LoopControl;
@@ -832,6 +873,23 @@ mod tests {
         assert!(msg.contains("read_file"), "{msg}");
         assert!(msg.contains('1'), "{msg}");
         assert!(msg.contains("monocle chat"), "{msg}");
+    }
+
+    #[test]
+    fn tool_firing_verification_passes_when_nothing_dropped() {
+        let outcome = tool_firing_verification_result(None);
+        let msg = outcome.expect("no dropped tool_calls should be a pass");
+        assert!(msg.contains('✓'), "{msg}");
+    }
+
+    #[test]
+    fn tool_firing_verification_fails_when_something_dropped() {
+        let dropped = dropped_tool_calls_message(&[tool_call("web_search")], 0, "--responses mode")
+            .expect("should report");
+        let outcome = tool_firing_verification_result(Some(&dropped));
+        let msg = outcome.expect_err("a dropped tool_calls message should be a failure");
+        assert!(msg.contains('✗'), "{msg}");
+        assert!(msg.contains("web_search"), "{msg}");
     }
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,13 @@ struct ChatArgs {
     /// `monocle chat list` to discover thread ids.)
     #[arg(long)]
     resume: Option<String>,
+    /// With `--responses`, treat an unresolved (unexecuted) tool_calls report
+    /// as a scriptable failure — nonzero exit — instead of just a stderr
+    /// warning. One-shot (piped input) only. Useful to verify a
+    /// server-executed tool (e.g. `web_search`) actually fired and resolved,
+    /// e.g. in a deploy-verification script.
+    #[arg(long = "verify-tool-firing")]
+    verify_tool_firing: bool,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -195,6 +202,7 @@ impl From<ChatArgs> for ChatOptions {
             files: a.file,
             responses: a.responses,
             resume: a.resume,
+            verify_tool_firing: a.verify_tool_firing,
         }
     }
 }


### PR DESCRIPTION
## 배경

jarvice#1217("stream:false 경로가 서버 실행 툴 루프를 우회") 조사 과정에서 알게
된 것: 그 이슈의 2026-07-28 prod-verified 코멘트에서 `monocle chat --responses`가
실사용 경로 검증 도구로 쓰였는데, "`dropped_tool_calls_message` 경고가 stderr에
안 뜨는 것"을 성공 신호로 삼았다. 문제는 그 경고가 **exit code에 반영되지
않는다**는 점 — 사람이 stderr 텍스트를 읽고 판단해야 했고, 스크립트로 재현/검증에
쓰기엔 약한 신호였다.

(참고: jarvice#1217 자체는 이 PR과 무관 — 이미 jarvice#1218/#1221 +
chat-proxy#305로 고쳐져 prod 반영·검증까지 끝났고 이슈는 CLOSED다. git log +
이슈 코멘트로 직접 확인했다. jarvice 코드는 건드리지 않았다.)

## 변경

`monocle chat --responses`에 `--verify-tool-firing` 플래그 추가 (one-shot 전용):

- 미해결 tool_calls(서버가 실행 못 하고 그대로 돌려준 것)가 있으면 →
  `✗ tool-firing verification FAILED: ...`를 stderr에 찍고 **exit 1**.
- 없으면 → `✓ tool-firing verification: passed`를 stderr에 찍고 exit 0.
- `--responses` 없이 쓰면(서버 실행 툴은 `--responses` 경로에서만 관측 가능하므로)
  즉시 에러 + exit 1.
- 인터랙티브(TTY) 입력에서 쓰면(스크립트 용도이므로) `--file`과 동일한 패턴으로
  즉시 에러 + exit 1.

## 설계

판정 로직(`tool_firing_verification_result`)을 순수 함수로 분리해 단위 테스트로
고정 — 기존 `dropped_tool_calls_message`와 같은 컨벤션(순수 함수 + 호출부에서
I/O). TDD red→green으로 진행: 함수 없이 테스트부터 추가해 컴파일 실패 확인 후 구현.

기존 `dropped_tool_calls_message` 경고 자체는 그대로 유지 — `--verify-tool-firing`
없이 쓰면 오늘과 동일하게 경고만 찍고 exit 0.

## 테스트

```bash
cargo test    # 160+ 기존 테스트 + 신규 2건, 전체 통과
cargo clippy --all-targets -- -D warnings   # clean
cargo fmt --check   # clean
```

가드 경로 수동 스모크 테스트(자격증명 불필요):
```
$ monocle chat --verify-tool-firing
--verify-tool-firing requires --responses (server-executed tools are only observable there)
$ echo $?
1
```

실사용 네트워크 호출을 통한 라이브 검증은 하지 않았다 — 저장된 세션 토큰을 건드릴
위험(이 저장소 CLAUDE.md의 자격증명 단일 슬롯 경고)을 피하려 보수적으로 스킵.
서버 쪽 동작(web_search가 실제로 resolve되는지)은 jarvice#1217 스레드에서 이미
별도로 라이브 검증됐다.

## README

`--responses` 섹션에 새 플래그 사용법·예시 추가, 커맨드 표 갱신 (README 반영
규칙 — 사용자에게 보이는 변화).
