### PR TITLE
fix(diag): /diag에 TTFB와 total latency를 분리해서 표시

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,19 @@ see which concrete model actually served the response:
 Endpoint: https://api.monocle-ai.com/v1/chat/completions
 Requested model: monocle-auto
 Served model: claude-sonnet-4-6
-Latency: 842ms
+Time to first byte: 312ms
+Latency (total): 842ms
 Tokens: 120 prompt + 45 completion = 165 total
 --- end diag ---
 ```
 
-`Served model` and `Tokens` are only shown when the backend reports them (always true for
-`monocle chat`'s default path; `--responses`, below, reports neither today, so those lines
-are simply omitted rather than printed as empty). Before the first turn, `/diag` just
-prints a hint to send a message first.
+`Time to first byte` is how long the response took to *start* streaming; `Latency (total)`
+is how long the full reply took to finish. `Served model` and `Tokens` are only shown when
+the backend reports them (always true for `monocle chat`'s default path; `--responses`,
+below, reports neither today, so those lines are simply omitted rather than printed as
+empty); `--responses` also makes a single blocking call with no incremental deltas, so
+`Time to first byte` has nothing to measure there and is omitted too. Before the first
+turn, `/diag` just prints a hint to send a message first.
 
 `/help` re-prints the REPL's onboarding message (the same lines shown when the
 session starts) — handy if you've scrolled past it.
@@ -245,8 +249,9 @@ echo "and in Python?" | monocle chat --responses --resume 3fa3b2c1-...
 ```
 
 `/diag` also works in this REPL, but the Responses API doesn't echo back a served
-model or token usage, so those lines are omitted — only `Endpoint`/`Requested
-model`/`Latency` are shown.
+model or token usage, and (being a single blocking call, not streamed) has no
+time-to-first-byte to report either — so those lines are omitted, and only
+`Endpoint`/`Requested model`/`Latency (total)` are shown.
 
 List your existing threads (including ones started in jarvice's own web UI —
 both share the same storage) with the `list` subcommand:
@@ -394,8 +399,8 @@ persists across sessions in `~/.monocle/agent_history`.
 In the interactive REPL, lines starting with `/` are local management commands (handled
 without calling the model, printed to stderr): `/help` lists them, `/config` shows the
 session config (model, max-steps, workdir, session), `/status` adds your login status,
-`/diag` shows diagnostics (served model, endpoint, latency, tokens, and step count) for
-the last turn, `/model` shows the current model (or `/model <id>` switches it for later
+`/diag` shows diagnostics (served model, endpoint, time to first byte, total latency,
+tokens, and step count) for the last turn, `/model` shows the current model (or `/model <id>` switches it for later
 turns), and `/exit` (or `/quit`, Ctrl-D) quits. `/model <TAB>` fuzzy-completes against the
 model ids available to your account (fetched once at startup) — e.g. `/model cla<TAB>`
 narrows to matching ids, and a bare `/model <TAB>` lists them all; if you're not logged in

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -318,6 +318,7 @@ impl Agent for MonocleAgent {
                 served_model: None,
                 usage: None,
                 steps: 0,
+                first_delta_at: None,
             };
             let mut approver = AcpApprover {
                 calls: updates,
@@ -356,7 +357,8 @@ impl Agent for MonocleAgent {
                 }));
             }
             // Wrapped tightly around the agent-core loop itself — this is what
-            // `/diag`'s `Latency:` line reports.
+            // `/diag`'s `Latency (total):` line reports (and, via the
+            // observer's first `on_text_delta`, its `Time to first byte:` line).
             let started = std::time::Instant::now();
             let requested_model = model.clone();
             let agent = CoreAgent::with_max_steps(&provider, &tools, ctx, model, DEFAULT_MAX_STEPS);
@@ -372,6 +374,9 @@ impl Agent for MonocleAgent {
                     requested_model,
                     observer.served_model.clone(),
                     turn_endpoint,
+                    observer
+                        .first_delta_at
+                        .map(|t| t.duration_since(started).as_millis()),
                     started.elapsed().as_millis(),
                     observer.usage.clone(),
                     observer.steps,
@@ -438,6 +443,10 @@ struct AcpObserver {
     served_model: Option<String>,
     usage: Option<TokenUsage>,
     steps: u32,
+    /// Set on the first `on_text_delta` call this turn — used to compute
+    /// `/diag`'s "time to first byte" line, mirroring
+    /// `commands::agent::CliObserver`.
+    first_delta_at: Option<std::time::Instant>,
 }
 
 impl AcpObserver {
@@ -453,6 +462,9 @@ impl AcpObserver {
 
 impl Observer for AcpObserver {
     fn on_text_delta(&mut self, delta: &str) {
+        if self.first_delta_at.is_none() {
+            self.first_delta_at = Some(std::time::Instant::now());
+        }
         self.send(acp::SessionUpdate::AgentMessageChunk(
             acp::ContentChunk::new(acp::ContentBlock::from(delta.to_string())),
         ));
@@ -1167,6 +1179,7 @@ mod tests {
             served_model: None,
             usage: None,
             steps: 0,
+            first_delta_at: None,
         };
         (observer, rx)
     }
@@ -1625,6 +1638,7 @@ mod tests {
                 DEFAULT_MODEL.to_string(),
                 Some("claude-sonnet-4-6".to_string()),
                 "https://api.example.com/v1/chat/completions".to_string(),
+                Some(7),
                 42,
                 None,
                 2,
@@ -1634,7 +1648,8 @@ mod tests {
         let out = agent.management_response(&key, Management::Diag);
         assert!(out.contains("Steps: 2"), "{out}");
         assert!(out.contains("claude-sonnet-4-6"), "{out}");
-        assert!(out.contains("42ms"), "{out}");
+        assert!(out.contains("Time to first byte: 7ms"), "{out}");
+        assert!(out.contains("Latency (total): 42ms"), "{out}");
     }
 
     #[test]

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -46,9 +46,15 @@ struct CliObserver {
     served_model: Option<String>,
     usage: Option<TokenUsage>,
     steps: u32,
+    /// Set on the first `on_text_delta` call this turn — used to compute
+    /// `/diag`'s "time to first byte" line (relative to `run_turn`'s `started`).
+    first_delta_at: Option<std::time::Instant>,
 }
 impl Observer for CliObserver {
     fn on_text_delta(&mut self, delta: &str) {
+        if self.first_delta_at.is_none() {
+            self.first_delta_at = Some(std::time::Instant::now());
+        }
         // Stream assistant text to stdout as it arrives (tool progress goes to stderr).
         let mut out = std::io::stdout();
         let _ = out.write_all(delta.as_bytes());
@@ -259,7 +265,8 @@ impl Repl<'_> {
                 &mut allow
             };
         // Wrapped tightly around the agent-core loop itself — this is what
-        // `/diag`'s `Latency:` line reports.
+        // `/diag`'s `Latency (total):` line reports (and, via the observer's
+        // first `on_text_delta`, its `Time to first byte:` line).
         let started = std::time::Instant::now();
         let mut observer = CliObserver::default();
         if let Err(e) = agent.run(&mut self.convo, approver, &mut observer, &self.cancel) {
@@ -280,6 +287,9 @@ impl Repl<'_> {
             self.model.clone(),
             observer.served_model.clone(),
             turn_endpoint,
+            observer
+                .first_delta_at
+                .map(|t| t.duration_since(started).as_millis()),
             started.elapsed().as_millis(),
             observer.usage.clone(),
             observer.steps,

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,4 +1,5 @@
 use std::io::{IsTerminal, Write};
+use std::time::Duration;
 
 use serde_json::Value;
 
@@ -53,13 +54,19 @@ fn resolve_max_tokens(flag: Option<&str>) -> Option<i64> {
 /// the full request the caller has already assembled (system prompt + any prior
 /// turns + this turn) — this fn only executes the network call and returns the
 /// assembled response so the caller can append it to its own running history.
+///
+/// Also returns the time-to-first-byte (`/diag`'s "Time to first byte" line):
+/// the elapsed time from just before the network call to the FIRST streamed
+/// delta, captured once via the `on_delta` closure this fn already hands to
+/// `chat_stream` — no new streaming plumbing needed. `None` only if the stream
+/// produced zero deltas (e.g. an empty response).
 fn call_chat(
     provider: &MonocleProvider,
     model: &str,
     messages: Vec<Message>,
     max_tokens: Option<i64>,
     images: &[ImageAttachment],
-) -> Result<ChatResponse> {
+) -> Result<(ChatResponse, Option<Duration>)> {
     let req = ChatRequest {
         model: model.to_string(),
         messages,
@@ -71,7 +78,12 @@ fn call_chat(
     // the closure writes+flushes to this single handle (per-delta flush keeps the
     // output live).
     let mut out = std::io::stdout().lock();
+    let started = std::time::Instant::now();
+    let mut ttfb: Option<Duration> = None;
     let resp = provider.chat_stream(&req, &mut |delta| {
+        if ttfb.is_none() {
+            ttfb = Some(started.elapsed());
+        }
         let _ = out.write_all(delta.as_bytes());
         let _ = out.flush();
     })?;
@@ -80,7 +92,7 @@ fn call_chat(
     if resp.truncated {
         eprintln!("\n⚠ the response was cut short (partial output shown).");
     }
-    Ok(resp)
+    Ok((resp, ttfb))
 }
 
 /// Read piped stdin (if not a TTY) and resolve `--file` + inband `file:<path>`
@@ -337,7 +349,8 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
             messages.push(Message::system(sp));
         }
         messages.push(Message::user(&text));
-        let resp = call_chat(&provider, &model, messages, max_tokens, &images)?;
+        // One-shot mode has no `/diag` to show — TTFB is discarded here.
+        let (resp, _ttfb) = call_chat(&provider, &model, messages, max_tokens, &images)?;
         if let Some(msg) = dropped_tool_calls_message(&resp.tool_calls, 0, "monocle chat") {
             eprintln!("{msg}");
         }
@@ -439,14 +452,17 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
         let mark = convo.len();
         convo.push(Message::user(text));
         // Wrapped tightly around the network call itself (not REPL input-wait
-        // time) — this is what `/diag`'s `Latency:` line reports.
+        // time) — this is what `/diag`'s `Latency (total):` line reports.
+        // `call_chat`'s own `Duration` return is `/diag`'s `Time to first byte:`
+        // line — captured inside `call_chat` at its first streamed delta.
         let started = std::time::Instant::now();
         match call_chat(&provider, &model, convo.clone(), max_tokens, &images) {
-            Ok(resp) => {
+            Ok((resp, ttfb)) => {
                 diagnostics = Some(TurnDiagnostics::for_chat(
                     model.clone(),
                     resp.model.clone(),
                     format!("{turn_router_url}{}", endpoints::CHAT_COMPLETIONS),
+                    ttfb.map(|d| d.as_millis()),
                     started.elapsed().as_millis(),
                     resp.usage.clone(),
                 ));
@@ -680,7 +696,10 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         crate::diag::reset();
 
         // Wrapped tightly around the network call itself, same as the
-        // completions path — this is what `/diag`'s `Latency:` line reports.
+        // completions path — this is what `/diag`'s `Latency (total):` line
+        // reports. This path makes one blocking call (no streamed deltas), so
+        // there's no `Time to first byte:` to capture — see the `for_chat`
+        // call below.
         let started = std::time::Instant::now();
         match rc.respond(&model, &text, &images, thread_id.as_deref()) {
             Ok(reply) => {
@@ -688,6 +707,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     model.clone(),
                     None,
                     format!("{jarvice_url}/api/responses"),
+                    // `--responses` makes one blocking call with no
+                    // incremental deltas — structurally no TTFB to report.
+                    None,
                     started.elapsed().as_millis(),
                     None,
                 ));

--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -60,6 +60,11 @@ pub struct TurnDiagnostics {
     pub requested_model: String,
     pub served_model: Option<String>,
     pub endpoint: String,
+    /// Time to first byte — elapsed time until the first streamed chunk of
+    /// the turn's answer arrived. `None` wherever the backend doesn't stream
+    /// (the `--responses` path makes one blocking call with no incremental
+    /// deltas, so it structurally has no TTFB to report).
+    pub ttfb_ms: Option<u128>,
     pub latency_ms: u128,
     pub usage: Option<TokenUsage>,
     /// How many LLM calls this turn made. `None` for chat (always exactly
@@ -76,6 +81,7 @@ impl TurnDiagnostics {
         requested_model: String,
         served_model: Option<String>,
         endpoint: String,
+        ttfb_ms: Option<u128>,
         latency_ms: u128,
         usage: Option<TokenUsage>,
     ) -> Self {
@@ -83,6 +89,7 @@ impl TurnDiagnostics {
             requested_model,
             served_model,
             endpoint,
+            ttfb_ms,
             latency_ms,
             usage,
             steps: None,
@@ -95,6 +102,7 @@ impl TurnDiagnostics {
         requested_model: String,
         served_model: Option<String>,
         endpoint: String,
+        ttfb_ms: Option<u128>,
         latency_ms: u128,
         usage: Option<TokenUsage>,
         steps: u32,
@@ -103,6 +111,7 @@ impl TurnDiagnostics {
             requested_model,
             served_model,
             endpoint,
+            ttfb_ms,
             latency_ms,
             usage,
             steps: Some(steps),
@@ -122,7 +131,10 @@ pub fn format_diag(d: &TurnDiagnostics) -> String {
     if let Some(served) = &d.served_model {
         lines.push(format!("Served model: {served}"));
     }
-    lines.push(format!("Latency: {}ms", d.latency_ms));
+    if let Some(ttfb) = d.ttfb_ms {
+        lines.push(format!("Time to first byte: {ttfb}ms"));
+    }
+    lines.push(format!("Latency (total): {}ms", d.latency_ms));
     if let Some(steps) = d.steps {
         lines.push(format!("Steps: {steps}"));
     }
@@ -551,11 +563,14 @@ mod tests {
     fn format_diag_omits_served_model_and_usage_when_unavailable() {
         // The `--responses` path: only endpoint/requested-model/latency are
         // ever known — served model and usage must never render as a literal
-        // "None"/"null", they're just absent lines.
+        // "None"/"null", they're just absent lines. `ttfb_ms` is also `None`
+        // here (the `--responses` path doesn't stream), so its line is
+        // omitted too.
         let d = TurnDiagnostics {
             requested_model: "monocle-auto".to_string(),
             served_model: None,
             endpoint: "https://acme.monocle-ai.com/api/responses".to_string(),
+            ttfb_ms: None,
             latency_ms: 842,
             usage: None,
             steps: None,
@@ -566,7 +581,7 @@ mod tests {
             "--- diag ---\n\
              Endpoint: https://acme.monocle-ai.com/api/responses\n\
              Requested model: monocle-auto\n\
-             Latency: 842ms\n\
+             Latency (total): 842ms\n\
              --- end diag ---"
         );
         assert!(!block.contains("None"));
@@ -579,6 +594,7 @@ mod tests {
             requested_model: "monocle-auto".to_string(),
             served_model: Some("claude-sonnet-4-6".to_string()),
             endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            ttfb_ms: None,
             latency_ms: 1234,
             usage: Some(TokenUsage {
                 prompt_tokens: 120,
@@ -594,7 +610,7 @@ mod tests {
              Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
              Requested model: monocle-auto\n\
              Served model: claude-sonnet-4-6\n\
-             Latency: 1234ms\n\
+             Latency (total): 1234ms\n\
              Tokens: 120 prompt + 45 completion = 165 total\n\
              --- end diag ---"
         );
@@ -609,6 +625,7 @@ mod tests {
             requested_model: "monocle-auto".to_string(),
             served_model: Some("claude-sonnet-4-6".to_string()),
             endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            ttfb_ms: None,
             latency_ms: 2500,
             usage: Some(TokenUsage {
                 prompt_tokens: 300,
@@ -624,9 +641,41 @@ mod tests {
              Endpoint: https://api.monocle-ai.com/agent\n\
              Requested model: monocle-auto\n\
              Served model: claude-sonnet-4-6\n\
-             Latency: 2500ms\n\
+             Latency (total): 2500ms\n\
              Steps: 3\n\
              Tokens: 300 prompt + 80 completion = 380 total\n\
+             --- end diag ---"
+        );
+    }
+
+    /// When `ttfb_ms` IS known (the streaming chat/agent paths), it renders as
+    /// its own line ahead of the total-latency line — this is the whole point
+    /// of the two numbers: "how fast did it start" vs "how long to finish".
+    #[test]
+    fn format_diag_shows_ttfb_ahead_of_total_latency_when_present() {
+        let d = TurnDiagnostics {
+            requested_model: "monocle-auto".to_string(),
+            served_model: Some("claude-sonnet-4-6".to_string()),
+            endpoint: "https://api.monocle-ai.com/v1/chat/completions".to_string(),
+            ttfb_ms: Some(312),
+            latency_ms: 4219,
+            usage: Some(TokenUsage {
+                prompt_tokens: 120,
+                completion_tokens: 45,
+                total_tokens: 165,
+            }),
+            steps: None,
+        };
+        let block = format_diag(&d);
+        assert_eq!(
+            block,
+            "--- diag ---\n\
+             Endpoint: https://api.monocle-ai.com/v1/chat/completions\n\
+             Requested model: monocle-auto\n\
+             Served model: claude-sonnet-4-6\n\
+             Time to first byte: 312ms\n\
+             Latency (total): 4219ms\n\
+             Tokens: 120 prompt + 45 completion = 165 total\n\
              --- end diag ---"
         );
     }
@@ -643,6 +692,7 @@ mod tests {
             requested_model: "monocle-auto".to_string(),
             served_model: None,
             endpoint: "https://api.monocle-ai.com/agent".to_string(),
+            ttfb_ms: None,
             latency_ms: 10,
             usage: None,
             steps: Some(1),


### PR DESCRIPTION
## 요약

`monocle chat`/`monocle agent`의 `/diag`가 보여주던 `Latency:`는 스트리밍
응답이 **다 끝난 시점까지의 전체 시간**이었고, TTFB(첫 바이트까지 걸린
시간)는 별도로 보여주지 않았다. 체감상 응답 시작은 빨랐는데 `Latency`가
4000ms대로 찍히는 식으로, "시작이 느린지 / 끝까지 오래 걸리는지"를 구분할
수 없었던 문제를 고쳤다.

- `TurnDiagnostics`(`src/commands/repl.rs`)에 `ttfb_ms: Option<u128>` 필드를
  추가하고, `format_diag`가 `Time to first byte:` / `Latency (total):`
  두 줄로 나눠 보여주도록 변경 (TTFB가 `None`이면 `served_model`/`usage`와
  같은 "없으면 생략" 컨벤션을 따라 그 줄만 생략).
- `call_chat`(`src/commands/chat.rs`)이 `chat_stream`에 넘기는 `on_delta`
  클로저의 **첫 호출 시점**에서 경과 시간을 잡아 `(ChatResponse,
  Option<Duration>)`을 반환하도록 시그니처 변경. `run_completions_chat`의
  두 호출부(one-shot/REPL) 모두 갱신.
- `--responses` 경로(`run_responses_chat`)는 스트리밍하지 않는 단일 blocking
  호출이라 TTFB를 잴 수 없어 `None` 고정.
- `monocle agent`(`CliObserver`, `src/commands/agent.rs`)와 ACP 표면
  (`AcpObserver`, `src/acp.rs`)도 동일한 `Observer::on_text_delta` 스트리밍
  경로를 쓰므로, 둘 다 `first_delta_at: Option<Instant>`을 추가해 같은
  방식으로 TTFB를 채움.
- README.md의 `/diag` 예시 및 설명 갱신 (`monocle chat`/`--responses`/
  `monocle agent` 세 군데).

Closes monocle-cli#113
Parent: warmblood-kr/monocle#365

## Test plan

- [x] `cargo test` — 전체 그린 (159 lib + 65 integration tests, 회귀 없음;
      `format_diag` 신규 케이스 1개 추가)
- [x] `cargo clippy --all-targets -- -D warnings` — 경고 없음
- [x] `cargo fmt --check` — 클린
- [x] TDD: `src/commands/repl.rs`의 `format_diag` 테스트를 먼저
      `ttfb_ms`/새 출력 형식으로 갱신(레드 확인) → 구현 → 그린 확인