### PR TITLE
fix: readline 에러가 EOF/Interrupted가 아니면 세션 전체를 죽이던 버그 수정

### DIFF
--- a/src/commands/repl.rs
+++ b/src/commands/repl.rs
@@ -303,10 +303,16 @@ impl Highlighter for ModelReplHelper {
 /// `on_line` receives each non-empty trimmed line (already added to history)
 /// and returns whether the loop should continue or quit. Ctrl-C at the idle
 /// prompt just starts a fresh line (rustyline surfaces it as `Interrupted`
-/// without raising SIGINT); Ctrl-D (EOF) quits with a "Bye." message. `prompt`
-/// must be plain text with no raw ANSI escapes — see `agent.rs`'s prompt
-/// comment for why (rustyline's cursor-column math assumes 0-width escapes,
-/// which breaks when a terminal doesn't actually interpret them as color).
+/// without raising SIGINT); Ctrl-D (EOF) quits with a "Bye." message. Any
+/// other `readline()` error (e.g. rustyline's UTF-8 decoder losing sync —
+/// observed after a bracketed-paste marker race with a fast terminal) is
+/// treated as a discarded line, not a fatal one: a single bad read shouldn't
+/// end an otherwise-healthy interactive session. Only
+/// `MAX_CONSECUTIVE_READLINE_ERRORS` in a row gives up, so a truly broken
+/// terminal/stream still can't spin forever. `prompt` must be plain text with
+/// no raw ANSI escapes — see `agent.rs`'s prompt comment for why (rustyline's
+/// cursor-column math assumes 0-width escapes, which breaks when a terminal
+/// doesn't actually interpret them as color).
 pub fn run_repl<H: Helper>(
     helper: H,
     history_path: PathBuf,
@@ -329,9 +335,11 @@ pub fn run_repl<H: Helper>(
     }
     let _ = rl.load_history(&history_path);
 
+    let mut consecutive_errors = 0u32;
     loop {
         match rl.readline(prompt) {
             Ok(line) => {
+                consecutive_errors = 0;
                 let trimmed = line.trim();
                 if trimmed.is_empty() {
                     continue;
@@ -348,14 +356,36 @@ pub fn run_repl<H: Helper>(
                 break;
             }
             Err(e) => {
-                eprintln!("{} {e}", c::red("Error:"));
-                break;
+                consecutive_errors += 1;
+                eprintln!(
+                    "{} {e} (line discarded — often a transient terminal read hiccup; try again)",
+                    c::yellow("Warning:")
+                );
+                if readline_errors_exhausted(consecutive_errors) {
+                    eprintln!(
+                        "{} too many consecutive read errors — exiting",
+                        c::red("Error:")
+                    );
+                    break;
+                }
             }
         }
     }
 
     let _ = rl.save_history(&history_path);
     Ok(())
+}
+
+/// After this many consecutive non-EOF/non-Interrupted `readline()` errors in
+/// a row, `run_repl` gives up rather than looping forever — a guard against a
+/// truly broken terminal/stream, while still tolerating the occasional
+/// single-line hiccup (see `run_repl`'s `Err(e)` arm).
+const MAX_CONSECUTIVE_READLINE_ERRORS: u32 = 5;
+
+/// Pure so the give-up threshold is unit-testable without a real rustyline
+/// `Editor` (which `run_repl` can't easily inject a fake reader into).
+fn readline_errors_exhausted(consecutive: u32) -> bool {
+    consecutive >= MAX_CONSECUTIVE_READLINE_ERRORS
 }
 
 #[cfg(test)]
@@ -377,6 +407,22 @@ mod tests {
             commands: TEST_COMMANDS,
             models: model_ids(models),
         }
+    }
+
+    #[test]
+    fn readline_errors_exhausted_tolerates_occasional_hiccups() {
+        assert!(!readline_errors_exhausted(1));
+        assert!(!readline_errors_exhausted(
+            MAX_CONSECUTIVE_READLINE_ERRORS - 1
+        ));
+    }
+
+    #[test]
+    fn readline_errors_exhausted_gives_up_at_the_threshold() {
+        assert!(readline_errors_exhausted(MAX_CONSECUTIVE_READLINE_ERRORS));
+        assert!(readline_errors_exhausted(
+            MAX_CONSECUTIVE_READLINE_ERRORS + 1
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes monocle-cli#115 (부모: monocle#366)

## 배경

`monocle chat --responses` 인터랙티브 REPL을 쓰다가, 터미널에 긴 텍스트를
붙여넣은 직후 다음 프롬프트에서 세션이 그대로 죽는 증상을 리포트받았다:

```
❯
Error: invalid data
➜  ~
```

## 진단

`src/commands/repl.rs`의 `run_repl` — `monocle chat`(completions/`--responses`
둘 다)와 `monocle agent`가 공유하는 REPL 루프 — 가 EOF(Ctrl-D)/Interrupted
(Ctrl-C) 외의 모든 `readline()` 에러를 **무조건 세션 종료**로 처리하고 있었다:

```rust
Err(e) => {
    eprintln!("{} {e}", c::red("Error:"));
    break;
}
```

`"invalid data"`는 이 레포 코드가 만드는 문자열이 아니라 std
`io::ErrorKind::InvalidData`의 `Display`가 그대로 찍힌 것 — rustyline의
바이트 단위 UTF-8 디코더가 깨진 바이트를 만나면 이 에러를 낸다. 붙여넣기의
bracketed-paste 마커(`ESC[200~`/`ESC[201~`) 파싱이 터미널 타이밍에 따라
desync되는 게 유력한 트리거로 보이지만(업스트림 rustyline 동작이라 이 레포에서
깔끔히 고칠 지점을 못 찾음 — monocle-cli#115에 기록), **진짜 문제는 그 뒤**:
단발성 읽기 에러 하나가 멀쩡한 세션 전체를 죽이는 게 과도한 반응이었다.

## 변경

EOF/Interrupted가 아닌 에러를 "한 줄 버리고 계속"으로 바꿨다. 단, 진짜 끊긴
스트림에서 무한루프가 되지 않도록 연속 5회(`MAX_CONSECUTIVE_READLINE_ERRORS`)
까지만 봐주고 그 이상이면 그대로 종료한다. 성공적인 줄 읽기가 카운터를
리셋한다.

임계값 판정을 순수 함수 `readline_errors_exhausted`로 분리해 실제 rustyline
`Editor` 없이 단위 테스트로 고정했다(`run_repl` 자체는 이 레포의 기존 컨벤션
대로 — 예: `stdin_is_tty` 가드 — 터미널 I/O라 직접 단위테스트하지 않음).

## 범위 밖

붙여넣기 마커 desync 자체(rustyline 내부 ESC-vs-CSI 타이밍 휴리스틱)는 고치지
않았다 — 재현이 라이브 터미널 조건에 의존해 이 환경에서 확정할 수 없었고,
업스트림 이슈에 가깝다. 재발해도 이제 그 한 줄만 버려지고 세션은 계속된다.

## 테스트

```bash
cargo test    # 160+ 기존 + 신규 2건, 전체 통과
cargo clippy --all-targets -- -D warnings   # clean
cargo fmt --check   # clean
```
