### PR TITLE
fix: --verify-tool-firing이 툴 미실행을 통과시키던 결함 — tools_used 기반 양성 검증 + 기대 툴 지정

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>] [--verify-tool-firing]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead; `--verify-tool-firing` (with `--responses`, one-shot) exits non-zero if a tool request came back unresolved |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>] [--verify-tool-firing]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead; `--verify-tool-firing` (with `--responses`, one-shot) asserts a server-executed tool actually ran, as an exit code (`0` ran / `1` did not / `2` cannot verify) |
 | `monocle chat list` | List existing jarvice chat threads (id/title/last-updated) — including threads created in jarvice's own web UI |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
@@ -283,18 +283,39 @@ Notes:
   right now. This is separate from jarvice's own **server-executed** tools
   (e.g. `web_search`) — those run on jarvice and come back already resolved;
   see `--verify-tool-firing` below to check that they actually did.
-- **`--verify-tool-firing`** — one-shot only; turns the warning above from
-  stderr-text into a scriptable check. If the reply comes back with an
-  unresolved tool_calls report, this exits non-zero (and prints
-  `✗ tool-firing verification FAILED: ...`) instead of just warning; if
-  nothing was dropped, it prints `✓ tool-firing verification: passed` and
-  exits `0`. Useful to confirm a server-executed tool actually fired end to
-  end (e.g. after a jarvice/chat-proxy deploy) without eyeballing stderr:
+- **`--verify-tool-firing`** — one-shot only; asserts that a server-executed
+  tool **actually ran**, as a scriptable exit code. Useful after a
+  jarvice/chat-proxy deploy, without eyeballing stderr:
 
   ```bash
   echo "search the web for today's date" | monocle chat --responses --verify-tool-firing
   echo "exit: $?"
   ```
+
+  | exit | meaning | printed to stderr |
+  |------|---------|-------------------|
+  | `0` | a tool ran | `✓ tool-firing verification: passed — web_search ran` |
+  | `1` | no tool ran, **or** an unresolved tool_calls report leaked back | `✗ tool-firing verification FAILED: ...` |
+  | `2` | **cannot verify** — this jarvice does not report `tools_used` (it predates the field) | `? tool-firing verification: CANNOT VERIFY — ...` |
+
+  The answer itself is always written to stdout first, whatever the verdict, so
+  a failing check never swallows the output you need in order to see why it
+  failed.
+
+  Exit `2` is deliberately not folded into `1`. jarvice reports the tools it
+  executed in a `tools_used` field
+  ([jarvice#1441](https://github.com/warmblood-kr/jarvice/issues/1441)); an
+  **empty** `tools_used` is the server stating that nothing ran (a real
+  failure), while an **absent** one only means the deployment is older than the
+  field — which is not evidence either way. Reporting the second as a pass
+  would make this check unable to fail in the direction it claims to check;
+  reporting it as a failure would cry wolf through every rollout. Deploy the
+  server side first, then re-run.
+
+  Before
+  [monocle-cli#118](https://github.com/warmblood-kr/monocle-cli/issues/118)
+  this flag only checked that no *unresolved* tool_calls came back, so a prompt
+  that fired no tool at all also passed.
 - **Known auth gap**: this endpoint currently rejects the CLI's access token
   with a 401 (`JWT missing required claim: email`) against real staging/prod
   tenants — the same open issue that blocks `monocle mcp` today. It's fine to

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle status` | Show login, token, and Claude Code configuration status |
 | `monocle token` | Print current access token (auto-refreshed when near expiry) |
 | `monocle models` | List available models (with modality) |
-| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>] [--verify-tool-firing]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead; `--verify-tool-firing` (with `--responses`, one-shot) asserts a server-executed tool actually ran, as an exit code (`0` ran / `1` did not / `2` cannot verify) |
+| `monocle chat [--model <id>] [--system-prompt <text>] [--system-prompt-file <path>] [--max-tokens <n>] [--file <path\|url>]... [--responses] [--resume <id>] [--verify-tool-firing[=<tool>]]` | Chat with a model (REPL or stdin); attach files/images with `--file` (one-shot only); `--responses` uses jarvice's server-managed-thread API instead; `--verify-tool-firing[=<tool>]` (with `--responses`, one-shot) asserts a server-executed tool actually ran — name a tool to require that one — as an exit code (`0` ran / `1` did not / `2` cannot determine) |
 | `monocle chat list` | List existing jarvice chat threads (id/title/last-updated) — including threads created in jarvice's own web UI |
 | `monocle audio transcribe [file] [--model <id>] [--language <code>] [--response-format <fmt>]` | OpenAI-compatible STT (file or stdin) |
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
@@ -283,20 +283,35 @@ Notes:
   right now. This is separate from jarvice's own **server-executed** tools
   (e.g. `web_search`) — those run on jarvice and come back already resolved;
   see `--verify-tool-firing` below to check that they actually did.
-- **`--verify-tool-firing`** — one-shot only; asserts that a server-executed
-  tool **actually ran**, as a scriptable exit code. Useful after a
-  jarvice/chat-proxy deploy, without eyeballing stderr:
+- **`--verify-tool-firing[=<tool>]`** — one-shot only; asserts that a
+  server-executed tool **actually ran**, as a scriptable exit code. Useful
+  after a jarvice/chat-proxy deploy, without eyeballing stderr:
 
   ```bash
-  echo "search the web for today's date" | monocle chat --responses --verify-tool-firing
+  # 이 툴이 돌았는지 (권장)
+  echo "search the web for today's date" \
+    | monocle chat --responses --verify-tool-firing=web_search
   echo "exit: $?"
+
+  # 아무 툴이나 하나라도 돌았는지 (약한 형태)
+  echo "search the web for today's date" | monocle chat --responses --verify-tool-firing
   ```
 
-  | exit | meaning | printed to stderr |
-  |------|---------|-------------------|
-  | `0` | a tool ran | `✓ tool-firing verification: passed — web_search ran` |
-  | `1` | no tool ran, **or** an unresolved tool_calls report leaked back | `✗ tool-firing verification FAILED: ...` |
-  | `2` | **cannot verify** — this jarvice does not report `tools_used` (it predates the field) | `? tool-firing verification: CANNOT VERIFY — ...` |
+  **Name the tool you expect.** Bare, this only asks "did *any* tool run", so a
+  turn that fired `query_chat_history` when you were checking `web_search`
+  still goes green — the check cannot fail in the direction you care about.
+  `pytest.raises` takes an exception type for the same reason.
+
+  | exit | `--verify-tool-firing` (bare) | `--verify-tool-firing=web_search` |
+  |------|-------------------------------|-----------------------------------|
+  | `0` | some tool ran | **`web_search`** ran |
+  | `1` | no tool ran, **or** an unresolved tool_calls report leaked back | a different tool ran, or none ran, or a leak |
+  | `2` | jarvice did not report `tools_used` (predates the field) | same, **plus**: entries came back unreadable, so whether `web_search` ran is unknown |
+
+  Exit `2` is "could not determine", not "failed". With a named tool, entries
+  whose names could not be read report `2` rather than `1` — claiming the tool
+  did *not* run would assert something we do not know. Unreadable entries are
+  always counted and surfaced in the message, never passed over silently.
 
   The answer itself is always written to stdout first, whatever the verdict, so
   a failing check never swallows the output you need in order to see why it

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -36,10 +36,10 @@ pub struct ChatOptions {
     pub responses: bool,
     /// `--resume <ID>`: continue an existing `--responses` thread.
     pub resume: Option<String>,
-    /// `--verify-tool-firing`: with `--responses`, treat an unresolved
-    /// tool_calls report as a scriptable failure (nonzero exit) instead of
-    /// just a stderr warning. One-shot only.
-    pub verify_tool_firing: bool,
+    /// `--verify-tool-firing[=<tool>]`: with `--responses`, assert from the
+    /// server's `tools_used` that a tool actually ran, as an exit code.
+    /// `None` = flag absent. One-shot only.
+    pub verify_tool_firing: Option<ToolFiringExpectation>,
 }
 
 /// Resolve the `--max-tokens` flag to an output-token limit. Returns `Some(n)`
@@ -246,7 +246,7 @@ fn dispatch_chat_command(
 }
 
 pub fn chat_command(client: &Client, creds: &Credentials, options: ChatOptions) -> Result<()> {
-    if options.verify_tool_firing && !options.responses {
+    if options.verify_tool_firing.is_some() && !options.responses {
         eprintln!("--verify-tool-firing requires --responses (server-executed tools are only observable there)");
         std::process::exit(1);
     }
@@ -611,7 +611,34 @@ impl ToolFiringVerdict {
 /// The old negative check is kept as its own failure mode, not replaced: an
 /// unresolved `tool_calls` leak is a real defect whether or not other tools
 /// ran, so it is checked first and still fails.
+/// What `--verify-tool-firing` was asked to assert.
+///
+/// `Any` is the bare flag: "at least one server-side tool ran". That is the
+/// weaker question, and deliberately so — it answers "do server-side tools
+/// work at all", which is what you want right after a deploy.
+///
+/// `Named` is the stronger one, and the reason the value exists: with `Any`, a
+/// run that fired `query_chat_history` when you were checking `web_search`
+/// still goes green. That is the same shape as the defect this flag was
+/// rewritten to remove, one size smaller — the check cannot fail in the
+/// direction you actually care about. `pytest.raises` takes an exception type
+/// for the same reason.
+#[derive(Debug, Clone)]
+pub enum ToolFiringExpectation {
+    Any,
+    Named(String),
+}
+
+fn unparsed_note(unparsed_tools_used: usize) -> String {
+    // Passing QUIETLY on entries we could not read would be a miniature of the
+    // defect this change removes.
+    format!(
+        " (⚠ {unparsed_tools_used} `tools_used` entry/entries in an unrecognized shape — their names are unknown)"
+    )
+}
+
 fn tool_firing_verification(
+    expected: &ToolFiringExpectation,
     tools_used: &[String],
     unparsed_tools_used: usize,
     tools_used_present: bool,
@@ -628,31 +655,61 @@ fn tool_firing_verification(
         );
     }
 
-    // An entry we could not read is still evidence that a tool ran — counting
-    // it is the whole reason `parse_tools_used` does not discard it.
-    if tools_used.len() + unparsed_tools_used == 0 {
-        return ToolFiringVerdict::Failed(
-            "✗ tool-firing verification FAILED: the server reports that no tool ran (`tools_used` is empty)"
-                .to_string(),
-        );
-    }
+    match expected {
+        ToolFiringExpectation::Any => {
+            // An entry we could not read is still evidence that SOME tool ran —
+            // counting it is the whole reason `parse_tools_used` keeps it.
+            if tools_used.len() + unparsed_tools_used == 0 {
+                return ToolFiringVerdict::Failed(
+                    "✗ tool-firing verification FAILED: the server reports that no tool ran (`tools_used` is empty)"
+                        .to_string(),
+                );
+            }
+            let mut message = if tools_used.is_empty() {
+                "✓ tool-firing verification: passed".to_string()
+            } else {
+                format!(
+                    "✓ tool-firing verification: passed — {} ran",
+                    tools_used.join(", ")
+                )
+            };
+            if unparsed_tools_used > 0 {
+                message.push_str(&unparsed_note(unparsed_tools_used));
+            }
+            ToolFiringVerdict::Passed(message)
+        }
 
-    let mut message = if tools_used.is_empty() {
-        "✓ tool-firing verification: passed".to_string()
-    } else {
-        format!(
-            "✓ tool-firing verification: passed — {} ran",
-            tools_used.join(", ")
-        )
-    };
-    if unparsed_tools_used > 0 {
-        // Passing QUIETLY on entries we could not read would be a miniature of
-        // the defect this change removes.
-        message.push_str(&format!(
-            " (⚠ {unparsed_tools_used} `tools_used` entry/entries in an unrecognized shape — counted as evidence, but their names are unknown)"
-        ));
+        ToolFiringExpectation::Named(want) => {
+            if tools_used.iter().any(|t| t == want) {
+                let mut message = format!("✓ tool-firing verification: passed — {want} ran");
+                if unparsed_tools_used > 0 {
+                    message.push_str(&unparsed_note(unparsed_tools_used));
+                }
+                return ToolFiringVerdict::Passed(message);
+            }
+
+            // Entries exist but we could not read their names, so whether
+            // `want` ran is genuinely UNKNOWN. Reporting Failed here would
+            // assert "it did not run", which is not something we know — the
+            // same kind of claim-without-evidence this flag exists to stop.
+            if unparsed_tools_used > 0 {
+                return ToolFiringVerdict::CannotVerify(format!(
+                    "? tool-firing verification: CANNOT VERIFY — expected `{want}`, but {unparsed_tools_used} `tools_used` entry/entries came back in an unrecognized shape, so their names are unknown"
+                ));
+            }
+
+            if tools_used.is_empty() {
+                return ToolFiringVerdict::Failed(format!(
+                    "✗ tool-firing verification FAILED: expected `{want}`, but the server reports that no tool ran (`tools_used` is empty)"
+                ));
+            }
+
+            ToolFiringVerdict::Failed(format!(
+                "✗ tool-firing verification FAILED: expected `{want}`, but these ran instead: {}",
+                tools_used.join(", ")
+            ))
+        }
     }
-    ToolFiringVerdict::Passed(message)
 }
 
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
@@ -683,7 +740,7 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         );
         std::process::exit(1);
     }
-    if options.verify_tool_firing && stdin_is_tty {
+    if options.verify_tool_firing.is_some() && stdin_is_tty {
         eprintln!(
             "--verify-tool-firing requires piped input. Pipe a tool-triggering prompt, e.g.:\n  echo \"search the web for today's date\" | monocle chat --responses --verify-tool-firing"
         );
@@ -714,8 +771,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
         }
-        if options.verify_tool_firing {
+        if let Some(expected) = &options.verify_tool_firing {
             let verdict = tool_firing_verification(
+                expected,
                 &reply.tools_used,
                 reply.unparsed_tools_used,
                 reply.tools_used_present,
@@ -930,8 +988,8 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 mod tests {
     use super::{
         chat_help_text, dispatch_chat_command, dropped_tool_calls_message, handle_help_command,
-        resolve_max_tokens, resolve_repl_attachments, tool_firing_verification, ToolFiringVerdict,
-        TurnDiagnostics,
+        resolve_max_tokens, resolve_repl_attachments, tool_firing_verification,
+        ToolFiringExpectation, ToolFiringVerdict, TurnDiagnostics,
     };
     use crate::agent::providers::{FunctionCall, ToolCall};
     use crate::commands::repl::LoopControl;
@@ -956,7 +1014,8 @@ mod tests {
 
     #[test]
     fn verification_passes_when_a_tool_ran_and_names_it() {
-        let v = tool_firing_verification(&["web_search".to_string()], 0, true, None);
+        let v =
+            tool_firing_verification(&NONE_EXPECTED, &["web_search".to_string()], 0, true, None);
         assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
         assert_eq!(v.exit_code(), 0);
         assert!(v.message().contains("web_search"), "got {}", v.message());
@@ -965,7 +1024,7 @@ mod tests {
     #[test]
     fn verification_fails_when_the_server_says_nothing_ran() {
         // `[]` is authoritative: the server knows, and says nothing ran.
-        let v = tool_firing_verification(&[], 0, true, None);
+        let v = tool_firing_verification(&NONE_EXPECTED, &[], 0, true, None);
         assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
         assert_eq!(v.exit_code(), 1);
     }
@@ -975,7 +1034,7 @@ mod tests {
         // Absent means the deployment predates tools_used, NOT that no tool
         // ran. Calling that a pass would reproduce the defect being fixed;
         // calling it a failure would cry wolf through every rollout.
-        let v = tool_firing_verification(&[], 0, false, None);
+        let v = tool_firing_verification(&NONE_EXPECTED, &[], 0, false, None);
         assert!(matches!(v, ToolFiringVerdict::CannotVerify(_)), "got {v:?}");
         assert_eq!(v.exit_code(), 2);
     }
@@ -984,7 +1043,7 @@ mod tests {
     fn verification_passes_on_unreadable_entries_but_says_so_out_loud() {
         // Entries we can't read still prove a tool ran, so this passes — but
         // passing QUIETLY would be a miniature of the same defect.
-        let v = tool_firing_verification(&[], 2, true, None);
+        let v = tool_firing_verification(&NONE_EXPECTED, &[], 2, true, None);
         assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
         assert!(
             v.message().contains('2'),
@@ -998,10 +1057,115 @@ mod tests {
         // The original negative check is KEPT as a distinct failure mode —
         // the positive check is added alongside it, not in place of it.
         let v = tool_firing_verification(
+            &NONE_EXPECTED,
             &["web_search".to_string()],
             0,
             true,
             Some("\u{26a0} model requested tool call(s)"),
+        );
+        assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 1);
+    }
+
+    // ---- monocle-cli#118 후속: 기대 툴 지정 (--verify-tool-firing=<tool>) ----
+    //
+    // 값 없는 형태는 "아무 툴이나 하나 돌았으면 통과"다. 그건 web_search 를
+    // 기대했는데 엉뚱한 툴이 돌아도 초록불이라는 뜻이고, 방금 고친 결함의
+    // 축소판이다. pytest.raises 가 예외 타입을 받는 것과 같은 이유로 기대
+    // 대상을 지정할 수 있어야 한다.
+
+    const NONE_EXPECTED: ToolFiringExpectation = ToolFiringExpectation::Any;
+
+    fn expect(name: &str) -> ToolFiringExpectation {
+        ToolFiringExpectation::Named(name.to_string())
+    }
+
+    #[test]
+    fn named_expectation_passes_when_that_tool_ran() {
+        let v = tool_firing_verification(
+            &expect("web_search"),
+            &["web_search".to_string()],
+            0,
+            true,
+            None,
+        );
+        assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 0);
+        assert!(v.message().contains("web_search"));
+    }
+
+    #[test]
+    fn named_expectation_fails_when_a_different_tool_ran() {
+        // 이것이 이 변경의 이유다. 값 없는 형태였다면 통과였을 상황.
+        let v = tool_firing_verification(
+            &expect("web_search"),
+            &["query_chat_history".to_string()],
+            0,
+            true,
+            None,
+        );
+        assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 1);
+        assert!(
+            v.message().contains("query_chat_history"),
+            "무엇이 대신 돌았는지 말해야 한다: {}",
+            v.message()
+        );
+    }
+
+    #[test]
+    fn bare_flag_still_passes_on_any_tool() {
+        // 값이 선택적이므로 기존 사용법이 그대로 살아야 한다 (무회귀 가드).
+        let v = tool_firing_verification(
+            &NONE_EXPECTED,
+            &["query_chat_history".to_string()],
+            0,
+            true,
+            None,
+        );
+        assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 0);
+    }
+
+    #[test]
+    fn named_expectation_with_absent_field_is_cannot_verify_not_mismatch() {
+        // 세 번째 종료 상태를 잃으면 안 된다. 서버가 필드를 안 주면
+        // "기대와 다름(1)"이 아니라 "판정 불가(2)"다 — 아니면 monocle-cli#118
+        // 에서 고친 것이 되살아난다.
+        let v = tool_firing_verification(&expect("web_search"), &[], 0, false, None);
+        assert!(matches!(v, ToolFiringVerdict::CannotVerify(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 2);
+    }
+
+    #[test]
+    fn named_expectation_fails_when_nothing_ran_at_all() {
+        let v = tool_firing_verification(&expect("web_search"), &[], 0, true, None);
+        assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 1);
+    }
+
+    #[test]
+    fn named_expectation_cannot_verify_when_names_were_unreadable() {
+        // 엔트리는 있으나 이름을 못 읽었다 = 그 툴이 돌았는지 **모른다**.
+        // Failed 로 내면 "안 돌았다"를 주장하는 것인데 그건 아는 바가 아니다.
+        let v = tool_firing_verification(&expect("web_search"), &[], 2, true, None);
+        assert!(matches!(v, ToolFiringVerdict::CannotVerify(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 2);
+        assert!(
+            v.message().contains('2'),
+            "개수를 드러내야 한다: {}",
+            v.message()
+        );
+    }
+
+    #[test]
+    fn unresolved_leak_still_fails_regardless_of_expectation() {
+        let v = tool_firing_verification(
+            &expect("web_search"),
+            &["web_search".to_string()],
+            0,
+            true,
+            Some("\u{26a0} leaked"),
         );
         assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
         assert_eq!(v.exit_code(), 1);

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -562,21 +562,97 @@ fn dropped_tool_calls_message(
     ))
 }
 
-/// `--verify-tool-firing`: turn the existing dropped-tool-calls warning into
-/// a scriptable pass/fail. Today that warning is stderr-text-only and never
-/// affects the exit code, so a verification script (e.g. confirming a
-/// server-executed tool like `web_search` actually ran) has to grep stderr
-/// rather than check `$?` — see the manual ritual in jarvice#1217's
-/// prod-verified comment. Pure — no I/O/`process::exit` — so it's directly
-/// unit-testable; the call site does the actual `eprintln!`/exit, same
+/// `--verify-tool-firing`: turn the dropped-tool-calls warning into a
+/// scriptable pass/fail, so a verification script can check `$?` instead of
+/// grepping stderr. Pure — no I/O, no `process::exit` — so it is directly
+/// unit-testable; the call site does the `eprintln!` and the exit, same
 /// convention as `dropped_tool_calls_message`.
-fn tool_firing_verification_result(
-    dropped_message: Option<&str>,
-) -> std::result::Result<String, String> {
-    match dropped_message {
-        Some(msg) => Err(format!("✗ tool-firing verification FAILED: {msg}")),
-        None => Ok("✓ tool-firing verification: passed (no unresolved tool_calls)".to_string()),
+///
+/// The three outcomes it must keep apart. It used to have two, and the wrong
+/// two: it passed whenever `message.tool_calls` came back empty, which is
+/// equally true of "the tool ran fine" and "no tool was ever attempted". A
+/// control that cannot fail in the direction it claims to check is not a
+/// control — it converts "I checked nothing" into a green tick.
+///
+/// `CannotVerify` is the third, and it is not a hedge: while jarvice omitted
+/// `tools_used` when empty, "nothing ran" and "this server is too old to say"
+/// were the same bytes on the wire. jarvice#1449 made live responses always
+/// state it, so absence now means exactly one thing — an old deployment —
+/// which is a different answer from failure and gets a different exit code.
+#[derive(Debug)]
+pub enum ToolFiringVerdict {
+    Passed(String),
+    Failed(String),
+    CannotVerify(String),
+}
+
+impl ToolFiringVerdict {
+    /// The stderr line for this verdict.
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Passed(m) | Self::Failed(m) | Self::CannotVerify(m) => m,
+        }
     }
+
+    /// 0 = a tool ran · 1 = it did not · 2 = the server could not say.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Passed(_) => 0,
+            Self::Failed(_) => 1,
+            Self::CannotVerify(_) => 2,
+        }
+    }
+}
+
+/// Assert from POSITIVE evidence that a server-side tool actually ran, rather
+/// than from the absence of a leak. Replaces `tool_firing_verification_result`
+/// (monocle-cli#118).
+///
+/// The old negative check is kept as its own failure mode, not replaced: an
+/// unresolved `tool_calls` leak is a real defect whether or not other tools
+/// ran, so it is checked first and still fails.
+fn tool_firing_verification(
+    tools_used: &[String],
+    unparsed_tools_used: usize,
+    tools_used_present: bool,
+    dropped_message: Option<&str>,
+) -> ToolFiringVerdict {
+    if let Some(msg) = dropped_message {
+        return ToolFiringVerdict::Failed(format!("✗ tool-firing verification FAILED: {msg}"));
+    }
+
+    if !tools_used_present {
+        return ToolFiringVerdict::CannotVerify(
+            "? tool-firing verification: CANNOT VERIFY — this jarvice did not report `tools_used`, so it predates the field (jarvice#1441). Absence is not evidence that no tool ran; deploy the server side first, then re-run."
+                .to_string(),
+        );
+    }
+
+    // An entry we could not read is still evidence that a tool ran — counting
+    // it is the whole reason `parse_tools_used` does not discard it.
+    if tools_used.len() + unparsed_tools_used == 0 {
+        return ToolFiringVerdict::Failed(
+            "✗ tool-firing verification FAILED: the server reports that no tool ran (`tools_used` is empty)"
+                .to_string(),
+        );
+    }
+
+    let mut message = if tools_used.is_empty() {
+        "✓ tool-firing verification: passed".to_string()
+    } else {
+        format!(
+            "✓ tool-firing verification: passed — {} ran",
+            tools_used.join(", ")
+        )
+    };
+    if unparsed_tools_used > 0 {
+        // Passing QUIETLY on entries we could not read would be a miniature of
+        // the defect this change removes.
+        message.push_str(&format!(
+            " (⚠ {unparsed_tools_used} `tools_used` entry/entries in an unrecognized shape — counted as evidence, but their names are unknown)"
+        ));
+    }
+    ToolFiringVerdict::Passed(message)
 }
 
 /// `--responses`: jarvice's `/api/responses` (see `responses_api` module
@@ -630,20 +706,28 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
             reply.unparsed_tool_calls,
             "--responses mode",
         );
-        if options.verify_tool_firing {
-            match tool_firing_verification_result(dropped_msg.as_deref()) {
-                Ok(pass_msg) => eprintln!("{pass_msg}"),
-                Err(fail_msg) => {
-                    eprintln!("{fail_msg}");
-                    std::process::exit(1);
-                }
-            }
-        } else if let Some(msg) = dropped_msg {
-            eprintln!("{msg}");
-        }
+        // The answer goes out FIRST, whatever the verdict (monocle-cli#118):
+        // the previous order exited before printing it, so a failing check
+        // swallowed the one thing you need in order to see why it failed.
+        // stdout stays the answer channel, stderr the verdict channel.
         println!("{}", reply.content);
         if let Some(id) = reply.thread_id {
             eprintln!("Thread: {id}");
+        }
+        if options.verify_tool_firing {
+            let verdict = tool_firing_verification(
+                &reply.tools_used,
+                reply.unparsed_tools_used,
+                reply.tools_used_present,
+                dropped_msg.as_deref(),
+            );
+            eprintln!("{}", verdict.message());
+            let code = verdict.exit_code();
+            if code != 0 {
+                std::process::exit(code);
+            }
+        } else if let Some(msg) = dropped_msg {
+            eprintln!("{msg}");
         }
         return Ok(());
     }
@@ -846,7 +930,7 @@ fn print_threads_table(threads: &[crate::jarvice_chats::ChatSummary]) {
 mod tests {
     use super::{
         chat_help_text, dispatch_chat_command, dropped_tool_calls_message, handle_help_command,
-        resolve_max_tokens, resolve_repl_attachments, tool_firing_verification_result,
+        resolve_max_tokens, resolve_repl_attachments, tool_firing_verification, ToolFiringVerdict,
         TurnDiagnostics,
     };
     use crate::agent::providers::{FunctionCall, ToolCall};
@@ -861,6 +945,66 @@ mod tests {
                 arguments: "{}".to_string(),
             },
         }
+    }
+
+    // ---- monocle-cli#118: POSITIVE tool-firing verification ----
+    //
+    // The old check passed whenever `message.tool_calls` came back empty, so
+    // "the tool ran fine" and "no tool was ever attempted" both went green.
+    // A control that cannot fail in the direction it claims to check is not a
+    // control. These pin the three outcomes it must now distinguish.
+
+    #[test]
+    fn verification_passes_when_a_tool_ran_and_names_it() {
+        let v = tool_firing_verification(&["web_search".to_string()], 0, true, None);
+        assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 0);
+        assert!(v.message().contains("web_search"), "got {}", v.message());
+    }
+
+    #[test]
+    fn verification_fails_when_the_server_says_nothing_ran() {
+        // `[]` is authoritative: the server knows, and says nothing ran.
+        let v = tool_firing_verification(&[], 0, true, None);
+        assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 1);
+    }
+
+    #[test]
+    fn verification_cannot_verify_when_the_field_is_absent() {
+        // Absent means the deployment predates tools_used, NOT that no tool
+        // ran. Calling that a pass would reproduce the defect being fixed;
+        // calling it a failure would cry wolf through every rollout.
+        let v = tool_firing_verification(&[], 0, false, None);
+        assert!(matches!(v, ToolFiringVerdict::CannotVerify(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 2);
+    }
+
+    #[test]
+    fn verification_passes_on_unreadable_entries_but_says_so_out_loud() {
+        // Entries we can't read still prove a tool ran, so this passes — but
+        // passing QUIETLY would be a miniature of the same defect.
+        let v = tool_firing_verification(&[], 2, true, None);
+        assert!(matches!(v, ToolFiringVerdict::Passed(_)), "got {v:?}");
+        assert!(
+            v.message().contains('2'),
+            "the unparsed count must surface, got: {}",
+            v.message()
+        );
+    }
+
+    #[test]
+    fn verification_still_fails_when_unresolved_tool_calls_leaked() {
+        // The original negative check is KEPT as a distinct failure mode —
+        // the positive check is added alongside it, not in place of it.
+        let v = tool_firing_verification(
+            &["web_search".to_string()],
+            0,
+            true,
+            Some("\u{26a0} model requested tool call(s)"),
+        );
+        assert!(matches!(v, ToolFiringVerdict::Failed(_)), "got {v:?}");
+        assert_eq!(v.exit_code(), 1);
     }
 
     #[test]
@@ -895,23 +1039,6 @@ mod tests {
         assert!(msg.contains("read_file"), "{msg}");
         assert!(msg.contains('1'), "{msg}");
         assert!(msg.contains("monocle chat"), "{msg}");
-    }
-
-    #[test]
-    fn tool_firing_verification_passes_when_nothing_dropped() {
-        let outcome = tool_firing_verification_result(None);
-        let msg = outcome.expect("no dropped tool_calls should be a pass");
-        assert!(msg.contains('✓'), "{msg}");
-    }
-
-    #[test]
-    fn tool_firing_verification_fails_when_something_dropped() {
-        let dropped = dropped_tool_calls_message(&[tool_call("web_search")], 0, "--responses mode")
-            .expect("should report");
-        let outcome = tool_firing_verification_result(Some(&dropped));
-        let msg = outcome.expect_err("a dropped tool_calls message should be a failure");
-        assert!(msg.contains('✗'), "{msg}");
-        assert!(msg.contains("web_search"), "{msg}");
     }
 
     // The shared `ModelReplHelper` (Completer/Hinter, slash-command +

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use monocle_cli::commands::audio_transcribe::{audio_transcribe_command, AudioTra
 use monocle_cli::commands::audio_transcribe_azure::{
     audio_transcribe_azure_command, AudioTranscribeAzureOptions,
 };
-use monocle_cli::commands::chat::{chat_command, chat_list_command, ChatOptions};
+use monocle_cli::commands::chat::{
+    chat_command, chat_list_command, ChatOptions, ToolFiringExpectation,
+};
 use monocle_cli::commands::claude::claude_command;
 use monocle_cli::commands::login::login_command;
 use monocle_cli::commands::model_list::model_list_command;
@@ -183,14 +185,17 @@ struct ChatArgs {
     /// `monocle chat list` to discover thread ids.)
     #[arg(long)]
     resume: Option<String>,
-    /// With `--responses`, assert that a server-executed tool (e.g.
-    /// `web_search`) actually RAN, as a scriptable exit code: 0 = a tool ran,
-    /// 1 = none ran (or an unresolved tool_calls report leaked back), 2 =
-    /// cannot verify, because this jarvice does not report `tools_used` and so
-    /// predates the field. One-shot (piped input) only. The answer is written
-    /// to stdout first regardless of the verdict.
-    #[arg(long = "verify-tool-firing")]
-    verify_tool_firing: bool,
+    /// With `--responses`, assert from the server's `tools_used` that a
+    /// server-executed tool actually RAN, as a scriptable exit code. Pass a
+    /// tool name to require THAT tool (`--verify-tool-firing=web_search`);
+    /// bare, it only requires that at least one tool ran. Exit codes: 0 = the
+    /// expected tool ran, 1 = it did not (a different tool ran, none ran, or an
+    /// unresolved tool_calls report leaked back), 2 = could not determine (this
+    /// jarvice does not report `tools_used`, or the entries were unreadable).
+    /// One-shot (piped input) only. The answer is written to stdout first
+    /// regardless of the verdict.
+    #[arg(long = "verify-tool-firing", num_args = 0..=1)]
+    verify_tool_firing: Option<Option<String>>,
 }
 
 impl From<ChatArgs> for ChatOptions {
@@ -203,7 +208,10 @@ impl From<ChatArgs> for ChatOptions {
             files: a.file,
             responses: a.responses,
             resume: a.resume,
-            verify_tool_firing: a.verify_tool_firing,
+            verify_tool_firing: a.verify_tool_firing.map(|v| match v {
+                Some(name) => ToolFiringExpectation::Named(name),
+                None => ToolFiringExpectation::Any,
+            }),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,11 +183,12 @@ struct ChatArgs {
     /// `monocle chat list` to discover thread ids.)
     #[arg(long)]
     resume: Option<String>,
-    /// With `--responses`, treat an unresolved (unexecuted) tool_calls report
-    /// as a scriptable failure — nonzero exit — instead of just a stderr
-    /// warning. One-shot (piped input) only. Useful to verify a
-    /// server-executed tool (e.g. `web_search`) actually fired and resolved,
-    /// e.g. in a deploy-verification script.
+    /// With `--responses`, assert that a server-executed tool (e.g.
+    /// `web_search`) actually RAN, as a scriptable exit code: 0 = a tool ran,
+    /// 1 = none ran (or an unresolved tool_calls report leaked back), 2 =
+    /// cannot verify, because this jarvice does not report `tools_used` and so
+    /// predates the field. One-shot (piped input) only. The answer is written
+    /// to stdout first regardless of the verdict.
     #[arg(long = "verify-tool-firing")]
     verify_tool_firing: bool,
 }

--- a/src/responses_api.rs
+++ b/src/responses_api.rs
@@ -55,6 +55,29 @@ pub struct ResponsesReply {
     /// would have. Callers should mention this count too, not just `tool_calls`,
     /// so a shape mismatch is never silent either (monocle-cli#101).
     pub unparsed_tool_calls: usize,
+    /// Names of the server-side tools jarvice actually EXECUTED on this turn,
+    /// from the top-level `tools_used` array (jarvice#1441).
+    ///
+    /// This is the POSITIVE counterpart of `tool_calls` above: that field says
+    /// "the model asked and nobody ran it", this one says "these ran". Without
+    /// it, `--verify-tool-firing` could only assert the absence of a leak,
+    /// which passes just as happily when no tool was ever attempted
+    /// (monocle-cli#118).
+    pub tools_used: Vec<String>,
+    /// Count of `tools_used` entries whose name couldn't be read. Counted
+    /// rather than dropped, for the same reason as `unparsed_tool_calls` —
+    /// and with an extra edge here: an unreadable entry is still EVIDENCE a
+    /// tool ran, so discarding it would let a shape mismatch masquerade as
+    /// "nothing ran" and pass a verification that should have failed.
+    pub unparsed_tools_used: usize,
+    /// Whether the server sent `tools_used` at all.
+    ///
+    /// Load-bearing, not cosmetic. `[]` means "nothing ran" (authoritative —
+    /// jarvice#1449 makes every live response state this). Absent means the
+    /// deployment predates the field, i.e. **we cannot know**. Collapsing the
+    /// two would either pass a real failure or fail every turn during a
+    /// rollout; both end with the check switched off.
+    pub tools_used_present: bool,
 }
 
 /// Build the `input` field: a plain string when there's no attachment (the
@@ -154,12 +177,45 @@ fn parse_reply(data: &Value, thread_id: Option<String>) -> Result<ResponsesReply
     let message = &data["choices"][0]["message"];
     let content = message["content"].as_str().unwrap_or_default().to_string();
     let (tool_calls, unparsed_tool_calls) = parse_tool_calls(&message["tool_calls"]);
+    // Top-level, a sibling of `choices` — not a field on the message.
+    let (tools_used, unparsed_tools_used, tools_used_present) =
+        parse_tools_used(data.get("tools_used"));
     Ok(ResponsesReply {
         content,
         thread_id,
         tool_calls,
         unparsed_tool_calls,
+        tools_used,
+        unparsed_tools_used,
+        tools_used_present,
     })
+}
+
+/// Read jarvice's top-level `tools_used` (jarvice#1441) into
+/// `(names, unparsed_count, present)`.
+///
+/// Per-entry, like `parse_tool_calls` — one entry we can't read must not
+/// discard its well-formed siblings. The difference that matters here is what
+/// an unreadable entry MEANS: it is still evidence that a tool ran, so it is
+/// counted rather than dropped. Silently dropping it would let a shape
+/// mismatch read as "nothing ran" and turn a failing verification green — the
+/// same silent-false-pass defect monocle-cli#118 exists to remove.
+///
+/// A missing or non-array value reports `present = false`: "this server never
+/// told us", which callers must keep distinct from `[]` ("nothing ran").
+fn parse_tools_used(value: Option<&Value>) -> (Vec<String>, usize, bool) {
+    let Some(entries) = value.and_then(|v| v.as_array()) else {
+        return (Vec::new(), 0, false);
+    };
+    let mut names = Vec::new();
+    let mut unparsed = 0usize;
+    for entry in entries {
+        match entry.get("name").and_then(|n| n.as_str()) {
+            Some(name) if !name.is_empty() => names.push(name.to_string()),
+            _ => unparsed += 1,
+        }
+    }
+    (names, unparsed, true)
 }
 
 /// Deserialize a `message.tool_calls` JSON value entry-by-entry rather than as
@@ -230,6 +286,76 @@ mod tests {
             message["tool_calls"] = tc;
         }
         json!({"choices": [{"message": message}]})
+    }
+
+    /// Same, plus jarvice's TOP-LEVEL `tools_used` (jarvice#1441 / #1449) —
+    /// a sibling of `choices`, not a field on the message.
+    fn body_with_tools_used(content: &str, tools_used: Option<Value>) -> Value {
+        let mut body = responses_body(content, None);
+        if let Some(tu) = tools_used {
+            body["tools_used"] = tu;
+        }
+        body
+    }
+
+    #[test]
+    fn tools_used_absent_is_reported_as_not_present() {
+        // A jarvice too old to know the field. Distinguishable from "[]"
+        // (nothing ran) only because we track presence separately — collapsing
+        // the two is what made positive verification impossible.
+        let reply = parse_reply(&body_with_tools_used("hello", None), None).unwrap();
+        assert!(!reply.tools_used_present);
+        assert!(reply.tools_used.is_empty());
+        assert_eq!(reply.unparsed_tools_used, 0);
+    }
+
+    #[test]
+    fn tools_used_empty_array_is_present_but_names_nothing() {
+        let reply = parse_reply(&body_with_tools_used("hello", Some(json!([]))), None).unwrap();
+        assert!(reply.tools_used_present);
+        assert!(reply.tools_used.is_empty());
+        assert_eq!(reply.unparsed_tools_used, 0);
+    }
+
+    #[test]
+    fn tools_used_names_are_extracted_in_order() {
+        let data = body_with_tools_used(
+            "hi",
+            Some(json!([
+                {"id": "call_1", "name": "web_search", "arguments": {"query": "x"}, "result": "r"},
+                {"id": "call_2", "name": "query_chat_history", "arguments": {}, "result": "r"},
+            ])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tools_used, vec!["web_search", "query_chat_history"]);
+        assert_eq!(reply.unparsed_tools_used, 0);
+        assert!(reply.tools_used_present);
+    }
+
+    #[test]
+    fn tools_used_entry_without_a_name_is_counted_not_dropped() {
+        // An entry we can't read is still EVIDENCE that a tool ran. Dropping
+        // it would let a shape mismatch read as "nothing ran" — exactly the
+        // silent false-pass monocle-cli#118 exists to remove. Same per-entry
+        // tolerance as `parse_tool_calls` above, for the same reason.
+        let data = body_with_tools_used(
+            "hi",
+            Some(json!([
+                {"id": "call_1", "result": "r"},
+                {"id": "call_2", "name": "web_search"},
+            ])),
+        );
+        let reply = parse_reply(&data, None).unwrap();
+        assert_eq!(reply.tools_used, vec!["web_search"]);
+        assert_eq!(reply.unparsed_tools_used, 1);
+        assert!(reply.tools_used_present);
+    }
+
+    #[test]
+    fn tools_used_of_the_wrong_type_is_treated_as_absent() {
+        let reply = parse_reply(&body_with_tools_used("hi", Some(json!("nope"))), None).unwrap();
+        assert!(!reply.tools_used_present);
+        assert!(reply.tools_used.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #118 (부모: warmblood-kr/monocle#379). 선행 조건: jarvice#1449 (PR jarvice#1450) **머지 완료**.

## 결함 — 개선이 아니라 결함이다

`--verify-tool-firing`(#112)은 **`message.tool_calls`가 비면 통과**시켰다. 그 조건은 두 상황에서 똑같이 참이다:

| | 상황 | `message.tool_calls` | 옛 검사 |
|---|---|---|---|
| (a) | 툴이 정상 실행됨 | 비어 있음 | ✓ passed |
| (b) | **툴을 아예 시도조차 안 함** | 비어 있음 | ✓ passed |

(b)는 이 플래그를 켜는 사람이 잡으려던 바로 그 실패다. 그런데 통과했다. **자기가 검사한다고 주장하는 방향으로 실패할 수 없는 검사는 검사가 아니라, "아무것도 확인 못 함"을 초록 체크로 바꾸는 장치다.**

## 실제 실행 관측 — 이 PR의 핵심 증거

> 유닛테스트가 Fail을 리턴하는 것은 *함수가* Fail을 리턴한다는 증명이지, *이 검사가* 빨간불이 된다는 증명이 아니다. 배선·가드·종료코드가 전부 그 사이에 있다. 그래서 실제 바이너리를 돌려 종료코드를 관측했다.

**동일 프롬프트, 동일 서버 응답**(툴이 하나도 안 돈 턴, `"tools_used": []`)에 대해:

```
########## 수정 전 바이너리 (devel a46e35d) ##########
$ echo "what is the capital of France?" | monocle chat --responses --verify-tool-firing --model gpt-5.5
Using model: gpt-5.5
jarvice: http://127.0.0.1:8791
✓ tool-firing verification: passed (no unresolved tool_calls)
The capital of France is Paris.
Thread: thread-stub-1
exit=0                                   ← 결함. 툴이 안 돌았는데 초록불

########## 수정 후 바이너리 (이 PR) ##########
$ echo "what is the capital of France?" | monocle chat --responses --verify-tool-firing --model gpt-5.5
Using model: gpt-5.5
jarvice: http://127.0.0.1:8791
The capital of France is Paris.
Thread: thread-stub-1
✗ tool-firing verification FAILED: the server reports that no tool ran (`tools_used` is empty)
exit=1                                   ← 통제가 자기 방향으로 실패한다
```

**이 두 줄(exit=0 → exit=1)이 이 PR이 실제로 무엇을 바꿨는지를 말해준다.** 수정 후만 봤다면 1이 나온 이유가 검사 때문인지 다른 것 때문인지 가릴 수 없었다.

나머지 두 케이스도 관측했다:

```
[구버전 서버 흉내 — tools_used 필드 자체가 없음]
? tool-firing verification: CANNOT VERIFY — this jarvice did not report `tools_used`,
  so it predates the field (jarvice#1441). Absence is not evidence that no tool ran;
  deploy the server side first, then re-run.
exit=2

[web_search 가 실제로 실행됨]
✓ tool-firing verification: passed — web_search ran
exit=0
```

수정 후 출력에서 **답변이 판정보다 먼저** 나오는 것도 확인된다 — 옛 동작은 실패 시 답변을 찍기 전에 exit 해서, 왜 실패했는지 보려면 필요한 바로 그 출력을 삼키고 죽었다.

### 실행 환경 — 자격증명을 건드리지 않았다

`~/.monocle/credentials.json`은 슬롯이 하나뿐이라 덮어쓰면 프로덕션 세션이 사라진다(CLAUDE.md 경고). 그래서 `src/util.rs:100`의 `home_dir()`가 `$HOME`을 읽는 점을 이용해 **`HOME=<임시디렉터리>`로 완전히 격리**했고, 스텁 jarvice는 `scheme_for_host()`가 `127.0.0.1`에 http를 쓰는 점(`src/auth.rs:20`)을 이용해 붙였다.

격리를 **믿지 않고 먼저 관측**했다 — 임시 HOME에 자격증명이 없는 상태로 실행해 `Not logged in`이 뜨는 것을 확인한 뒤에야 더미 자격증명을 넣었다. 실제 자격증명 파일은 mtime 기준 변경 없음.

## 변경

- **`parse_tools_used`** (`src/responses_api.rs`) — `parse_tool_calls` 옆, 같은 per-entry 방식. 읽지 못한 엔트리는 **버리지 않고 센다.** 여기서는 그 차이가 더 중요하다: 읽지 못한 엔트리도 **툴이 돌았다는 증거**이므로, 조용히 버리면 형태 불일치가 "아무것도 안 돌았다"로 읽혀 실패해야 할 검증이 초록불이 된다.
- **`ToolFiringVerdict`** (`src/commands/chat.rs`) — 세 결과를 구분. 종료코드 **0**(툴이 돌았다) / **1**(안 돌았다) / **2**(서버가 말해주지 못했다).
- **읽지 못한 엔트리가 있으면 통과시키되 개수를 출력에 반드시 표시.** 조용한 통과는 이 변경이 없애려는 결함의 축소판이다.
- **기존 음성 검사(미해결 tool_calls 누출)는 유지.** 별개 실패 모드이며 대체가 아니라 추가다.
- 답변을 stdout에 먼저 출력한 뒤 판정·종료.

### `2`를 `1`로 접지 않은 이유

`tools_used`가 **비어 있음**은 서버가 "아무것도 안 돌았다"고 **말한 것**(확정적 실패)이고, **부재**는 서버가 그 필드를 모르는 구버전이라는 뜻(판단 불가)이다. 다른 사실이다. 부재를 통과로 처리하면 지금 고치는 결함을 그대로 재생산하고, 실패로 처리하면 배포 시차 내내 늑대를 외쳐 결국 사람이 검사를 꺼버린다 — **꺼진 검사는 없는 검사다.**

이 구분은 jarvice#1449 덕분에 가능해졌다. 그 전에는 "안 돌았다"와 "너무 낡아서 말 못 한다"가 와이어에서 같은 바이트였다.

## ⚠️ 기존 테스트 2개를 **제거**했다

`tool_firing_verification_passes_when_nothing_dropped` / `..._fails_when_something_dropped` 는 옛 함수와 함께 제거했다. 수정이 아니라 제거인 이유: 전자는 **"아무것도 드롭되지 않으면 통과"** 라는 결함 자체를 명세로 박고 있었다. 남겨두면 결함을 계약으로 승격시키는 셈이다.

살아남아야 할 절반(누출은 여전히 실패해야 한다)은 새 테스트 `verification_still_fails_when_unresolved_tool_calls_leaked` 로 옮겼다.

## 테스트

TDD red→green. 신규 유닛테스트 11개 — 파싱 6개(부재/`[]`/이름 추출/이름 없는 엔트리 카운트/타입 불일치), 판정 5개(통과·명명, 빈 배열 실패, 부재 검증불가, unparsed 통과하되 개수 노출, 누출 실패).

`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` **전부 그린** (14개 스위트).

## 하위호환

- **종료코드 소비자 0건 확인** — `--verify-tool-firing`은 monocle-cli·monocle 양 레포 통틀어 README 문서에만 존재하고, CI 워크플로·스크립트 어디에서도 종료코드를 소비하지 않는다. "non-zero = 툴 미실행"으로 해석하는 곳도 없다. 그래서 `2` 신설이 기존 소비자를 깨지 않는다.
- `Cargo.toml` 버전은 건드리지 않았다(피처 PR 관례).


---

# 추가 (머지 전) — 기대 툴 지정 `--verify-tool-firing[=<tool>]`

> **사람의 지적:** "무슨 툴이 파이어 되기를 익스펙트 하는지 그거가 스펙이 지정이 되어야 되지 않나 … 파이테스트에 raises 뭐 이런 거랑 비슷한 거 같은데요"

## 왜 머지 전에 넣었나

위 본문의 변경만으로는 **"아무 툴이나 하나 돌았으면 통과"** 였다. `web_search`를 기대했는데 `query_chat_history`가 돌아도 초록불이다 — **이 PR이 없애려는 결함의 축소판**이다. 자기가 검사한다고 주장하는 방향으로 실패할 수 없는 구간이 남아 있었다.

약한 계약을 먼저 배포하면 그걸 스크립트에 박은 사람이 생기고, 그 다음에 의미를 또 바꾸게 된다. 이 PR이 아직 미머지라 **지금이 한 번에 정할 수 있는 유일한 시점**이다.

## 계약

```bash
--verify-tool-firing=web_search   # 그 툴이 돌았음을 단언 (권장)
--verify-tool-firing              # 기존대로 "적어도 하나" (무회귀)
```

| exit | 값 없음 (bare) | `=web_search` |
|---|---|---|
| `0` | 아무 툴이나 하나 돌았다 | **`web_search`** 가 돌았다 |
| `1` | 아무것도 안 돌았다, 또는 미해결 tool_calls 누출 | 다른 툴이 돌았다 / 아무것도 안 돌았다 / 누출 |
| `2` | 서버가 `tools_used`를 안 준다 | 위와 같음, **그리고** 엔트리 이름을 못 읽어 `web_search` 여부를 모름 |

**종료 상태 셋을 유지한다.** 기대 툴을 지정했는데 서버가 필드를 안 주면 "기대와 다름(1)"이 아니라 **"판정 불가(2)"** 다. 엔트리는 왔는데 이름을 못 읽은 경우도 2다 — 그 툴이 돌았는지 **모르는** 것이지 안 돌았다고 아는 게 아니고, **모르는 것을 안다고 말하는 것이 이 플래그가 없애려는 결함 그 자체**다. 읽지 못한 엔트리 개수는 어느 경우에도 메시지에 드러낸다.

## 실제 실행 관측 (계약이 바뀌었으므로 다시 했다)

**동일한 서버 응답**(`query_chat_history`가 돌았다)에 대해 값 있는 형태와 없는 형태를 나란히:

```
$ monocle chat --responses --verify-tool-firing=web_search
Here is what I recall.
Thread: thread-stub
✗ tool-firing verification FAILED: expected `web_search`, but these ran instead: query_chat_history
exit=1                                  ← 기대와 다르면 잡는다

$ monocle chat --responses --verify-tool-firing
Here is what I recall.
Thread: thread-stub
✓ tool-firing verification: passed — query_chat_history ran
exit=0                                  ← 값이 없으면 못 잡는다 (그래서 이 변경이 필요했다)
```

나머지 두 케이스:

```
$ monocle chat --responses --verify-tool-firing=web_search      # web_search 가 실제로 돌았을 때
Today is 2026-07-31.
✓ tool-firing verification: passed — web_search ran
exit=0

$ monocle chat --responses --verify-tool-firing=web_search      # 구버전 서버(tools_used 없음)
Hello.
? tool-firing verification: CANNOT VERIFY — this jarvice did not report `tools_used`, so it predates
  the field (jarvice#1441). Absence is not evidence that no tool ran; deploy the server side first.
exit=2                                  ← 1 이 아니다
```

**격리**: 전과 동일하게 `HOME=<임시디렉터리>`로 실제 자격증명과 분리했고, 믿지 않고 **먼저 관측**했다 — 임시 HOME에 자격증명이 없는 상태로 실행해 `Not logged in`이 뜨는 것을 확인한 뒤 더미를 넣었다. 실제 `~/.monocle/credentials.json`은 mtime 변경 없음.

## 구현

- clap: `Option<Option<String>>` + `num_args(0..=1)` → 플래그 부재 / 값 없음 / 값 있음 셋을 구분
- 내부 표현: `ToolFiringExpectation { Any, Named(String) }`
- 값이 선택적이라 **기존 사용법이 그대로 산다** (무회귀 테스트로 고정)

## 테스트

TDD red→green. 신규 7개 — 기대 툴 통과, **기대와 다른 툴이면 실패**(+무엇이 대신 돌았는지 메시지에), 값 없는 형태 무회귀, 부재는 2(1 아님), 아무것도 안 돌면 1, 이름 못 읽으면 2(+개수 노출), 누출은 기대와 무관하게 1.

`cargo fmt --check` / `clippy --all-targets -D warnings` / `cargo test` **전부 그린** (14개 스위트).
