### PR TITLE
fix: SSE 스트림 조립 시 첫 청크의 빈 model 필드에 영구 고정되는 버그 수정

### DIFF
--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -320,7 +320,10 @@ fn assemble_sse_stream(
             Err(_) => continue,
         };
         if model.is_none() {
-            model = v["model"].as_str().map(String::from);
+            model = v["model"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .map(String::from);
         }
         if usage.is_none() {
             usage = parse_usage(&v);

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -602,6 +602,24 @@ mod tests {
     }
 
     #[test]
+    fn empty_model_in_first_chunk_does_not_lock_out_later_real_model() {
+        let (resp, _deltas) = run_stream(vec![
+            Ok(Some(
+                "data: {\"model\":\"\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}"
+                    .to_string(),
+            )),
+            Ok(Some(
+                "data: {\"model\":\"some-real-model\",\"choices\":[{\"delta\":{\"content\":\"!\"}}]}"
+                    .to_string(),
+            )),
+            Ok(Some("data: [DONE]".to_string())),
+            Ok(None),
+        ]);
+        let resp = resp.expect("normal completion should succeed");
+        assert_eq!(resp.model.as_deref(), Some("some-real-model"));
+    }
+
+    #[test]
     fn truncation_mid_tool_call_drops_the_tool_call() {
         // A partial tool_call delta (name + start of arguments), then a drop.
         let tool_delta = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\


### PR DESCRIPTION
Fixes #120

## 배경

`assemble_sse_stream`의 `model` 결정 가드가 `Some("")`을 "이미 설정됨"으로
취급해, 스트림의 첫 청크가 빈 `model` 필드를 담고 있으면 이후 청크가 실제
모델 id를 보내도 영구히 무시되는 결함이 있었다. 이 이슈는
warmblood-kr/chat-proxy#304 조사 중 발견됐지만, 어떤 backend가 무엇을
보내는지와 무관한 client 자체의 결함이다. chat-proxy#304가 배포되면 이
결함의 실무 재현은 사라지지만, 그것은 가려지는(masked) 것이지 고쳐지는
것이 아니다 — 그래서 이 PR은 backend-independent 합성 재현 테스트로
검증한다.

## 변경

- `src/agent/providers.rs`의 `model.is_none()` 가드에
  `.filter(|s| !s.is_empty())`를 추가해, 빈 문자열을 "값 없음"과 동일하게
  취급하도록 수정.
- 합성(synthetic) SSE 스트림(빈 `model` 청크 → 실제 `model` 청크)을
  `assemble_sse_stream`에 주입하는 회귀 테스트
  `empty_model_in_first_chunk_does_not_lock_out_later_real_model` 추가.

두 커밋으로 분리했다 — 테스트만 추가한 RED 커밋과, 가드를 고친 GREEN 커밋.
RED 커밋 시점에 테스트를 실행하면 실제로 실패한다(assertion mismatch,
컴파일 에러 아님):

```
thread '...' panicked at src/agent/providers.rs:619:9:
assertion `left == right` failed
  left: Some("")
 right: Some("some-real-model")
```

GREEN 커밋 이후 전체 스위트(179 unit + 59 integration) 통과, `cargo fmt
--check` / `cargo clippy --all-targets -- -D warnings` 통과.

## 범위

`assemble_sse_stream`의 `model` 가드와 새 테스트만 건드렸다. 다른 필드
(`finish_reason`, `tool_calls` 등)의 동작은 이 PR의 대상이 아니다(이슈
본문의 비범위와 동일).

## Done 체크리스트 (이슈 #120 기준)

- [x] `model` 결정 로직이 빈 문자열을 값 없음과 동일하게 취급하도록 수정
- [x] 합성 SSE 스트림 기반 회귀 테스트 추가 및 통과
- [ ] 이슈 종료 코멘트에 "합성 재현 테스트로 검증되어 닫는다"는 점을 명시
      (머지 후 이슈 클로징 시 반영 필요)
