### PR TITLE
image-edit 서브커맨드 추가 — images/edits 실호출 디버깅 프로브

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
 | `monocle audio speech-azure [ssml] -o <path> [--format <fmt>]` | Azure SSML TTS |
+| `monocle image-edit <image> --prompt <text> --model <id> [--size <WxH>] [--quality <q>] [--input-fidelity <f>] [--n <n>] [--content-type <mime>]` | Image editing probe — posts one image to `/v1/images/edits` and prints the raw response |
 | `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
@@ -399,6 +400,43 @@ monocle audio speech-azure \
 ```
 
 On failure each command prints the HTTP status and response body to stderr and exits non-zero, which makes it easy to spot bad parameters or backend errors.
+
+## 🖼️ Image editing
+
+`monocle image-edit` calls `/v1/images/edits` directly — the image counterpart of `monocle audio …`. It is a one-shot debugging probe: one source image plus a prompt go up as multipart, and the **raw response body is printed to stdout** untouched (which host was hit goes to stderr), so you can observe exactly what the router returned.
+
+```bash
+monocle image-edit cat.png --prompt "add a party hat" --model <image-model-id>
+```
+
+`--model` is required — the router only allows image-capable models, and there is no sensible default to guess. `monocle models` lists what your tenant has.
+
+Tune the request with the optional parameters, which are only sent when you pass them:
+
+```bash
+monocle image-edit cat.png \
+  --prompt "add a party hat" \
+  --model <image-model-id> \
+  --size 1024x1024 \
+  --quality high \
+  --input-fidelity high \
+  --n 1
+```
+
+The endpoint only accepts `image/png`, `image/jpeg`, and `image/webp`. The content type is taken from the file extension (`.png` / `.jpg` / `.jpeg` / `.webp`); an unknown extension fails locally with a clear message instead of a server-side 400. Override it when the extension lies or is missing:
+
+```bash
+monocle image-edit blob --prompt "make it warmer" --model <image-model-id> --content-type image/png
+```
+
+The body is printed verbatim, so inspect it first — this command exists to show you what the endpoint actually returns. If it comes back in the OpenAI images shape (base64 in `data[].b64_json`), pipe it rather than reading it raw:
+
+```bash
+monocle image-edit cat.png --prompt "add a party hat" --model <image-model-id> \
+  | jq -r '.data[0].b64_json' | base64 -d > edited.png
+```
+
+Deliberately minimal: one image, no mask, no image arrays. On failure it prints the HTTP status and body to stderr and exits non-zero, like the audio commands.
 
 ## ⬆️ Upgrading
 

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -14,7 +14,7 @@ use crate::error::{AppError, Result};
 /// token before it is treated as a path (e.g. `file:./a.png.` in "...a.png.").
 const TRAILING_PUNCT: [char; 9] = ['.', ',', ';', ':', '!', '?', ')', '\'', '"'];
 
-fn mime_by_ext(ext: &str) -> Option<&'static str> {
+pub(crate) fn mime_by_ext(ext: &str) -> Option<&'static str> {
     match ext {
         "png" => Some("image/png"),
         "jpg" | "jpeg" => Some("image/jpeg"),

--- a/src/commands/image_edit.rs
+++ b/src/commands/image_edit.rs
@@ -1,0 +1,238 @@
+//! `monocle image-edit` — a one-shot debugging probe for chat-proxy's
+//! `POST /v1/images/edits`. It sends one image plus a prompt as multipart and
+//! prints the raw response body to stdout, so a human can observe one real
+//! response. Deliberately minimal (one image, no mask, no image arrays) — the
+//! image twin of the `audio transcribe-azure` / `speech-azure` debug commands.
+
+use std::io::Write;
+use std::path::Path;
+
+use crate::audio_io::write_api_error_and_exit;
+use crate::auth::get_access_token;
+use crate::credentials::Credentials;
+use crate::endpoints;
+use crate::error::{AppError, Result};
+use crate::net::{Client, FilePart};
+use crate::origin::auth_headers;
+
+pub struct ImageEditOptions {
+    pub prompt: String,
+    pub model: String,
+    pub size: Option<String>,
+    pub quality: Option<String>,
+    pub input_fidelity: Option<String>,
+    pub n: Option<String>,
+    pub content_type: Option<String>,
+}
+
+/// The MIME types the images/edits route accepts. Anything else comes back as a
+/// 400 from the server, so an unknown extension is refused here instead of on
+/// the wire. Neither existing table fits: `audio_io`'s is audio-only (a `.png`
+/// falls through to `application/octet-stream`) and `attachment.rs`'s also
+/// allows `image/gif`, which this route rejects.
+fn mime_by_ext(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+/// Content type to send for the image part: an explicit `--content-type` wins,
+/// otherwise it is guessed from the file extension. There is no
+/// `application/octet-stream` fallback on purpose — a wrong content type is a
+/// server-side 400, and failing here says why.
+pub fn content_type_for(path: &str, override_ct: Option<&str>) -> Result<String> {
+    if let Some(ct) = override_ct {
+        return Ok(ct.to_string());
+    }
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+    mime_by_ext(&ext).map(str::to_string).ok_or_else(|| {
+        AppError::new(format!(
+            "unsupported image type (extension \"{ext}\" of {path}); the endpoint accepts image/png, image/jpeg, image/webp — use --content-type to override"
+        ))
+    })
+}
+
+/// The multipart text fields: `model` + `prompt` always, everything else only
+/// when the user actually supplied it. The route rejects unknown scalar fields
+/// with a 400, so this list stays closed — do not add fields casually.
+pub fn form_fields(options: &ImageEditOptions) -> Vec<(&str, &str)> {
+    let mut fields: Vec<(&str, &str)> = vec![
+        ("model", options.model.as_str()),
+        ("prompt", options.prompt.as_str()),
+    ];
+    if let Some(v) = &options.size {
+        fields.push(("size", v));
+    }
+    if let Some(v) = &options.quality {
+        fields.push(("quality", v));
+    }
+    if let Some(v) = &options.input_fidelity {
+        fields.push(("input_fidelity", v));
+    }
+    if let Some(v) = &options.n {
+        fields.push(("n", v));
+    }
+    fields
+}
+
+pub fn image_edit_command(
+    client: &Client,
+    creds: &Credentials,
+    image_path: &str,
+    options: ImageEditOptions,
+) -> Result<()> {
+    let path = Path::new(image_path);
+    if !path.exists() {
+        return Err(AppError::new(format!("Image file not found: {image_path}")));
+    }
+    let content_type = content_type_for(image_path, options.content_type.as_deref())?;
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("image")
+        .to_string();
+    let data = std::fs::read(path)?;
+
+    let session = get_access_token(client, creds);
+    let url = format!("{}{}", session.router_url, endpoints::IMAGES_EDITS);
+    // stdout stays pure response data; which host was actually hit goes to stderr.
+    eprintln!("POST {url}");
+
+    let bearer = format!("Bearer {}", session.token);
+    let resp = client.post_multipart(
+        &url,
+        &auth_headers(&bearer),
+        FilePart {
+            field: "image".to_string(),
+            filename,
+            content_type,
+            data,
+        },
+        &form_fields(&options),
+    )?;
+
+    if !resp.ok() {
+        write_api_error_and_exit(&resp);
+    }
+
+    let body = resp.text();
+    let mut out = std::io::stdout();
+    out.write_all(body.as_bytes())?;
+    if !body.ends_with('\n') {
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> ImageEditOptions {
+        ImageEditOptions {
+            prompt: "make it orange".to_string(),
+            model: "some-image-model".to_string(),
+            size: None,
+            quality: None,
+            input_fidelity: None,
+            n: None,
+            content_type: None,
+        }
+    }
+
+    #[test]
+    fn content_type_guessed_from_extension() {
+        assert_eq!(content_type_for("a.png", None).unwrap(), "image/png");
+        assert_eq!(content_type_for("a.jpg", None).unwrap(), "image/jpeg");
+        assert_eq!(content_type_for("a.jpeg", None).unwrap(), "image/jpeg");
+        assert_eq!(content_type_for("a.webp", None).unwrap(), "image/webp");
+        // Case-insensitive, and path components must not confuse the lookup.
+        assert_eq!(
+            content_type_for("/tmp/Some Dir/A.PNG", None).unwrap(),
+            "image/png"
+        );
+    }
+
+    #[test]
+    fn unsupported_extensions_are_rejected_not_octet_stream() {
+        // gif is a valid image but this route rejects it; audio_io would have
+        // silently produced application/octet-stream for all of these.
+        for path in ["a.gif", "a.bmp", "a.txt", "noextension"] {
+            let err = content_type_for(path, None)
+                .expect_err(&format!("{path} must not resolve to a content type"));
+            assert!(
+                err.to_string().contains("unsupported image type"),
+                "unexpected error for {path}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_content_type_overrides_the_extension() {
+        assert_eq!(
+            content_type_for("a.png", Some("image/webp")).unwrap(),
+            "image/webp"
+        );
+        // …and rescues a file whose extension we cannot map.
+        assert_eq!(
+            content_type_for("blob", Some("image/png")).unwrap(),
+            "image/png"
+        );
+    }
+
+    #[test]
+    fn form_fields_are_sparse_by_default() {
+        let opts = options();
+        let fields = form_fields(&opts);
+        assert_eq!(
+            fields,
+            vec![("model", "some-image-model"), ("prompt", "make it orange")]
+        );
+    }
+
+    #[test]
+    fn form_fields_include_only_supplied_options() {
+        let mut opts = options();
+        opts.size = Some("1024x1024".to_string());
+        opts.n = Some("2".to_string());
+
+        let fields = form_fields(&opts);
+        assert_eq!(
+            fields,
+            vec![
+                ("model", "some-image-model"),
+                ("prompt", "make it orange"),
+                ("size", "1024x1024"),
+                ("n", "2"),
+            ]
+        );
+        // quality / input_fidelity were not supplied, so they must not be sent.
+        let names: Vec<&str> = fields.iter().map(|(k, _)| *k).collect();
+        assert!(!names.contains(&"quality"));
+        assert!(!names.contains(&"input_fidelity"));
+    }
+
+    #[test]
+    fn form_fields_never_send_a_field_outside_the_allowed_set() {
+        // The route 400s on unknown scalar fields — this is the guard rail.
+        const ALLOWED: [&str; 6] = ["model", "prompt", "size", "quality", "input_fidelity", "n"];
+        let mut opts = options();
+        opts.size = Some("1024x1024".to_string());
+        opts.quality = Some("high".to_string());
+        opts.input_fidelity = Some("high".to_string());
+        opts.n = Some("1".to_string());
+
+        let fields = form_fields(&opts);
+        assert_eq!(fields.len(), ALLOWED.len(), "every option should be sent");
+        for (name, _) in &fields {
+            assert!(ALLOWED.contains(name), "unexpected form field: {name}");
+        }
+    }
+}

--- a/src/commands/image_edit.rs
+++ b/src/commands/image_edit.rs
@@ -27,15 +27,14 @@ pub struct ImageEditOptions {
 
 /// The MIME types the images/edits route accepts. Anything else comes back as a
 /// 400 from the server, so an unknown extension is refused here instead of on
-/// the wire. Neither existing table fits: `audio_io`'s is audio-only (a `.png`
-/// falls through to `application/octet-stream`) and `attachment.rs`'s also
-/// allows `image/gif`, which this route rejects.
+/// the wire. Delegates the extension→MIME lookup to `attachment::mime_by_ext`
+/// (the canonical table) but narrows it: that table also maps `gif` →
+/// `image/gif`, which this route rejects, so `gif` is excluded here even
+/// though the shared table would resolve it.
 fn mime_by_ext(ext: &str) -> Option<&'static str> {
-    match ext {
-        "png" => Some("image/png"),
-        "jpg" | "jpeg" => Some("image/jpeg"),
-        "webp" => Some("image/webp"),
-        _ => None,
+    match crate::attachment::mime_by_ext(ext)? {
+        "image/gif" => None,
+        mime => Some(mime),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod audio_transcribe;
 pub mod audio_transcribe_azure;
 pub mod chat;
 pub mod claude;
+pub mod image_edit;
 pub mod login;
 pub mod model_list;
 pub mod repl;

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -6,5 +6,6 @@ pub const MODELS: &str = "/v1/models";
 pub const CHAT_COMPLETIONS: &str = "/v1/chat/completions";
 pub const AUDIO_TRANSCRIPTIONS: &str = "/v1/audio/transcriptions";
 pub const AUDIO_SPEECH: &str = "/v1/audio/speech";
+pub const IMAGES_EDITS: &str = "/v1/images/edits";
 pub const AZURE_SPEECH_TO_TEXT: &str = "/v1/speechtotext/transcriptions:transcribe";
 pub const AZURE_TEXT_TO_SPEECH: &str = "/v1/azure/texttospeech/cognitiveservices/v1";

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use monocle_cli::commands::chat::{
     chat_command, chat_list_command, ChatOptions, ToolFiringExpectation,
 };
 use monocle_cli::commands::claude::claude_command;
+use monocle_cli::commands::image_edit::{image_edit_command, ImageEditOptions};
 use monocle_cli::commands::login::login_command;
 use monocle_cli::commands::model_list::model_list_command;
 use monocle_cli::commands::setup::setup_command;
@@ -58,6 +59,9 @@ Commands:
 
   Audio:
     audio    Call audio (STT / TTS) endpoints directly for debugging
+
+  Images:
+    image-edit  Call the image-edit endpoint directly for debugging
 
   Maintenance:
     upgrade  Update monocle to the latest release
@@ -139,6 +143,33 @@ enum Commands {
     Audio {
         #[command(subcommand)]
         command: AudioCommands,
+    },
+    /// Call the image-edit endpoint directly for debugging
+    #[command(name = "image-edit")]
+    ImageEdit {
+        /// Source image path (png | jpeg | webp)
+        image: String,
+        /// Edit instruction (required)
+        #[arg(long)]
+        prompt: String,
+        /// Model ID (required; the router only allows image-capable models)
+        #[arg(long)]
+        model: String,
+        /// Output size (e.g., 1024x1024)
+        #[arg(long)]
+        size: Option<String>,
+        /// Output quality (model-dependent)
+        #[arg(long)]
+        quality: Option<String>,
+        /// Input fidelity (model-dependent)
+        #[arg(long = "input-fidelity")]
+        input_fidelity: Option<String>,
+        /// Number of images to generate
+        #[arg(long)]
+        n: Option<String>,
+        /// Override MIME type (image/png | image/jpeg | image/webp)
+        #[arg(long = "content-type")]
+        content_type: Option<String>,
     },
     /// [Deprecated] Use `monocle chat` / `monocle models` instead
     #[command(hide = true)]
@@ -372,6 +403,29 @@ fn main() {
             },
         ),
         Commands::Audio { command } => run_audio(&client, &creds, command),
+        Commands::ImageEdit {
+            image,
+            prompt,
+            model,
+            size,
+            quality,
+            input_fidelity,
+            n,
+            content_type,
+        } => image_edit_command(
+            &client,
+            &creds,
+            &image,
+            ImageEditOptions {
+                prompt,
+                model,
+                size,
+                quality,
+                input_fidelity,
+                n,
+                content_type,
+            },
+        ),
         Commands::Upgrade { check } => upgrade_command(&client, check),
         Commands::Model { command } => {
             match command {
@@ -508,6 +562,52 @@ mod tests {
             }
             _ => panic!("expected Chat command"),
         }
+    }
+
+    #[test]
+    fn image_edit_parses_hyphenated_name_and_required_flags() {
+        let cli = Cli::parse_from([
+            "monocle",
+            "image-edit",
+            "cat.png",
+            "--prompt",
+            "add a hat",
+            "--model",
+            "some-image-model",
+        ]);
+        match cli.command {
+            Commands::ImageEdit {
+                image,
+                prompt,
+                model,
+                size,
+                ..
+            } => {
+                assert_eq!(image, "cat.png");
+                assert_eq!(prompt, "add a hat");
+                assert_eq!(model, "some-image-model");
+                assert!(size.is_none());
+            }
+            _ => panic!("expected ImageEdit command"),
+        }
+    }
+
+    #[test]
+    fn image_edit_requires_prompt_and_model() {
+        // Both flags are required: neither may silently default.
+        assert!(Cli::try_parse_from(["monocle", "image-edit", "cat.png"]).is_err());
+        assert!(
+            Cli::try_parse_from(["monocle", "image-edit", "cat.png", "--prompt", "add a hat"])
+                .is_err()
+        );
+        assert!(Cli::try_parse_from([
+            "monocle",
+            "image-edit",
+            "cat.png",
+            "--model",
+            "some-image-model"
+        ])
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## 왜

`chat-proxy` 의 `POST /v1/images/edits`(warmblood-kr/chat-proxy#366, 상위 warmblood-kr/monocle#472)를
**실제로 한 번 호출해 응답을 눈으로 확인**하기 위한 디버깅 프로브입니다. 워커 샌드박스에는 provider
키가 없어 로컬에서 업스트림을 때릴 수 없고, 정수님이 지정하신 경로가 **staging 배포 + CLI 서브커맨드로
실호출 1회 관측**입니다.

기존 `monocle audio transcribe-azure` / `speech-azure` 와 **같은 성격**(엔드포인트를 디버깅 목적으로
직접 호출)이고, `audio_transcribe.rs` 의 multipart 형태를 그대로 따랐습니다.

## 무엇

```bash
monocle image-edit ./cat.png --prompt "add a party hat" --model <image-model-id>
```

- 옵션: `--size` `--quality` `--input-fidelity` `--n` `--content-type`
- **sparse 전송** — 사용자가 실제로 준 필드만 보냅니다. 라우트가 알 수 없는 스칼라 필드를 400 으로
  끊으므로 허용 집합(`model` `prompt` `size` `quality` `input_fidelity` `n`)을 넘지 않습니다.
- **stdout = 응답 본문, stderr = `POST <router_url>...`** — 저장소 불변식(출력 분리)을 지켰습니다.
- 이미지 MIME 은 확장자로 추론(png/jpeg/webp)하고 `--content-type` 으로 덮어쓸 수 있습니다.
  `audio_io` 의 표는 오디오 전용이라 `.png` 가 `application/octet-stream` 으로 떨어지므로 재사용하지
  않았습니다 — 그 값은 라우트가 400 으로 거절합니다.

## 판단이 필요했던 곳

- **`--model` 을 필수로 뒀습니다.** 저장소 전체(`*.rs`/`*.md`/`*.toml`)에 `gpt-image`·`images/edits`
  참조가 **0건**이라 방어할 수 있는 기본값이 없었습니다. **모델명을 발명하지 않았습니다.**
- **mask / 다중 이미지는 넣지 않았습니다.** `net::post_multipart` 가 `FilePart` 를 **하나만** 받습니다.
  관측 1회가 목적이라 파사드를 넓히지 않았습니다. 필요해지면 별건으로.

## 검증

- 게이트 4종 통과: `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` /
  `cargo test`(**189 passed**) / `cargo build --release`
- 새 테스트는 **변이(mutation)로 비공허함을 확인**했습니다 — 예: mime 표에 `gif` 를 추가하면 거절
  테스트가 FAIL, `to_lowercase()` 를 빼면 확장자 테스트가 FAIL, `--model` 에 기본값을 주면 필수
  인자 테스트가 FAIL.

## ⚠️ 아직 안 한 것

- **실호출 관측 전입니다.** `chat-proxy#366` 이 staging 에 배포된 뒤에야 돌릴 수 있습니다.
- 따라서 다음은 **이 저장소 밖 사실이라 미검증**입니다: 파일 파트 이름(`image`), 응답 본문 형태,
  라우트가 실제로 png/jpeg/webp 외를 400 으로 끊는지. 전부 `chat-proxy` 코드 기준으로 맞춘 것입니다.
- **어떤 인증도, 네트워크 호출도 하지 않았습니다.**

> 💡 `~/.monocle/credentials.json` 은 환경별로 분리돼 있지 않아 `--env stg` 로그인이 기존 prod 세션을
> 덮어씁니다. `HOME` 을 격리해 실행하면 건드리지 않는다는 것을 실측 확인했습니다
> (격리 HOME 에서 `monocle status` → "Not logged in", 실제 파일 size·mtime 불변).
