### PR TITLE
feat(chat): /diag on|off로 진단 상시 표시 모드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ empty); `--responses` also makes a single blocking call with no incremental delt
 `Time to first byte` has nothing to measure there and is omitted too. Before the first
 turn, `/diag` just prints a hint to send a message first.
 
+`/diag on` makes diagnostics print automatically after every reply, instead of only
+on demand — handy for keeping an eye on token usage as you go. `/diag off` turns it
+back off. The setting is saved to `~/.monocle/config.json` and persists across
+sessions until toggled again.
+
 `/help` re-prints the REPL's onboarding message (the same lines shown when the
 session starts) — handy if you've scrolled past it.
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -13,9 +13,10 @@ use crate::attachment;
 use crate::auth::{get_access_token, jarvice_url_for, try_access_token, AuthSession};
 use crate::commands::model_list::{fetch_model_ids, handle_model_command};
 use crate::commands::repl::{
-    handle_diag_command, mode_banner, run_repl, LoopControl, ModelReplHelper, TurnDiagnostics,
-    PROMPT,
+    format_diag, handle_diag_command, mode_banner, run_repl, LoopControl, ModelReplHelper,
+    TurnDiagnostics, PROMPT,
 };
+use crate::config::{Config, ConfigData};
 use crate::credentials::Credentials;
 use crate::endpoints;
 use crate::error::Result;
@@ -201,6 +202,8 @@ fn chat_help_text() -> String {
         ),
         "/diag shows diagnostics for the last turn (only what the backend reports is shown)."
             .to_string(),
+        "/diag on / /diag off toggles always showing diagnostics after every response (saved to ~/.monocle/config.json)."
+            .to_string(),
         "/help shows this message again.".to_string(),
     ]
     .join("\n")
@@ -217,6 +220,38 @@ fn handle_help_command(trimmed: &str) -> bool {
     true
 }
 
+/// Handle `/diag on` / `/diag off`, or fall through to the shared bare-`/diag`
+/// handler (last-turn display). Persists the preference via `cfg` (best-effort
+/// — a write failure only warns, since the in-session toggle still takes
+/// effect either way) and flips `*always_on` for the rest of this REPL
+/// session. `cfg` is a parameter (not `Config::new()` inline) so tests can
+/// inject a `Config::with_home` pointed at a tempdir instead of writing to
+/// the real `~/.monocle/config.json`.
+fn handle_diag_toggle(
+    trimmed: &str,
+    diagnostics: &Option<TurnDiagnostics>,
+    always_on: &mut bool,
+    cfg: &Config,
+) -> bool {
+    match trimmed {
+        "/diag on" | "/diag off" => {
+            let value = trimmed == "/diag on";
+            *always_on = value;
+            if let Err(e) = cfg.write(&ConfigData {
+                diag_always_on: value,
+            }) {
+                eprintln!("Warning: failed to save diagnostics preference: {e}");
+            }
+            eprintln!(
+                "Diagnostics always-on is now {} (saved to ~/.monocle/config.json).",
+                if value { "ON" } else { "OFF" }
+            );
+            true
+        }
+        _ => handle_diag_command(trimmed, diagnostics),
+    }
+}
+
 /// Dispatch a slash-command line to whichever handler recognizes it (shared
 /// by both REPL loops, so the two don't drift out of sync). Returns
 /// `Some(control)` when `trimmed` was consumed as a recognized command — the
@@ -226,6 +261,8 @@ fn dispatch_chat_command(
     trimmed: &str,
     model: &mut String,
     diagnostics: &Option<TurnDiagnostics>,
+    diag_always_on: &mut bool,
+    cfg: &Config,
 ) -> Option<LoopControl> {
     if trimmed == "/quit" || trimmed == "/exit" {
         eprintln!("Bye.");
@@ -236,7 +273,7 @@ fn dispatch_chat_command(
     if handle_model_command(trimmed, model) {
         return Some(LoopControl::Continue);
     }
-    if handle_diag_command(trimmed, diagnostics) {
+    if handle_diag_toggle(trimmed, diagnostics, diag_always_on, cfg) {
         return Some(LoopControl::Continue);
     }
     if handle_help_command(trimmed) {
@@ -406,9 +443,18 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
     // Last turn's diagnostics, shown on demand by `/diag` — `None` until the
     // first successful turn.
     let mut diagnostics: Option<TurnDiagnostics> = None;
+    // Persisted via `/diag on`/`/diag off` (see `handle_diag_toggle`) —
+    // loaded once here so a prior session's preference survives a restart.
+    let cfg = Config::new();
+    let mut diag_always_on = cfg.read().diag_always_on;
+    if diag_always_on {
+        eprintln!("Diagnostics always-on (usage shown after every response).");
+    }
 
     run_repl(helper, history_path, PROMPT, |trimmed| {
-        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+        if let Some(control) =
+            dispatch_chat_command(trimmed, &mut model, &diagnostics, &mut diag_always_on, &cfg)
+        {
             return Ok(control);
         }
 
@@ -481,6 +527,12 @@ fn run_completions_chat(client: &Client, creds: &Credentials, options: ChatOptio
                 let mut out = std::io::stdout();
                 out.write_all(b"\n\n")?;
                 out.flush()?;
+                // `/diag on` mode: print this turn's diagnostics (never the
+                // response body, which already went to stdout above) without
+                // requiring the user to type `/diag`.
+                if diag_always_on {
+                    eprintln!("{}", format_diag(diagnostics.as_ref().unwrap()));
+                }
             }
             Err(e) => {
                 convo.truncate(mark);
@@ -813,6 +865,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     // learns a served model or token usage (see `TurnDiagnostics` docs), so
     // those fields stay `None` for the life of the session.
     let mut diagnostics: Option<TurnDiagnostics> = None;
+    // Persisted via `/diag on`/`/diag off` (see `handle_diag_toggle`) —
+    // loaded once here so a prior session's preference survives a restart.
+    let cfg = Config::new();
+    let mut diag_always_on = cfg.read().diag_always_on;
+    if diag_always_on {
+        eprintln!("Diagnostics always-on (usage shown after every response, when the backend reports it).");
+    }
 
     // Replay prior history for an existing thread, REPL-only (never in the
     // one-shot path above, never on stdout — this repo treats stdout as
@@ -847,7 +906,9 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
     eprintln!("{}", mode_banner("chat", crate::colors::cyan));
 
     run_repl(helper, history_path, PROMPT, |trimmed| {
-        if let Some(control) = dispatch_chat_command(trimmed, &mut model, &diagnostics) {
+        if let Some(control) =
+            dispatch_chat_command(trimmed, &mut model, &diagnostics, &mut diag_always_on, &cfg)
+        {
             return Ok(control);
         }
 
@@ -913,6 +974,13 @@ fn run_responses_chat(client: &Client, creds: &Credentials, options: ChatOptions
                     }
                 }
                 println!();
+                // `/diag on` mode — see the completions path's identical
+                // comment. This path's diagnostics never carry usage (the
+                // backend doesn't report it here), but `format_diag` already
+                // omits absent fields rather than printing "None".
+                if diag_always_on {
+                    eprintln!("{}", format_diag(diagnostics.as_ref().unwrap()));
+                }
             }
             Err(e) => {
                 // A failed turn must not leave stale diagnostics from an
@@ -993,6 +1061,7 @@ mod tests {
     };
     use crate::agent::providers::{FunctionCall, ToolCall};
     use crate::commands::repl::LoopControl;
+    use crate::config::Config;
 
     fn tool_call(name: &str) -> ToolCall {
         ToolCall {
@@ -1214,16 +1283,27 @@ mod tests {
     // `handle_diag_command` already have their own coverage; this just
     // confirms the shared entry point recognizes `/quit`/`/exit` and passes
     // through anything else as ordinary chat input.
+    /// A `Config` rooted at a fresh tempdir — every `dispatch_chat_command`
+    /// test uses this instead of `Config::new()` so no test ever touches the
+    /// real `~/.monocle/config.json`.
+    fn test_config() -> (tempfile::TempDir, Config) {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config::with_home(dir.path());
+        (dir, cfg)
+    }
+
     #[test]
     fn dispatch_chat_command_quit_and_exit_stop_the_repl() {
         let mut model = "monocle-auto".to_string();
         let diagnostics: Option<TurnDiagnostics> = None;
+        let mut always_on = false;
+        let (_dir, cfg) = test_config();
         assert!(matches!(
-            dispatch_chat_command("/quit", &mut model, &diagnostics),
+            dispatch_chat_command("/quit", &mut model, &diagnostics, &mut always_on, &cfg),
             Some(LoopControl::Quit)
         ));
         assert!(matches!(
-            dispatch_chat_command("/exit", &mut model, &diagnostics),
+            dispatch_chat_command("/exit", &mut model, &diagnostics, &mut always_on, &cfg),
             Some(LoopControl::Quit)
         ));
     }
@@ -1232,17 +1312,66 @@ mod tests {
     fn dispatch_chat_command_unrecognized_line_is_chat_input() {
         let mut model = "monocle-auto".to_string();
         let diagnostics: Option<TurnDiagnostics> = None;
-        assert!(dispatch_chat_command("hello there", &mut model, &diagnostics).is_none());
+        let mut always_on = false;
+        let (_dir, cfg) = test_config();
+        assert!(dispatch_chat_command(
+            "hello there",
+            &mut model,
+            &diagnostics,
+            &mut always_on,
+            &cfg
+        )
+        .is_none());
     }
 
     #[test]
     fn dispatch_chat_command_recognizes_help() {
         let mut model = "monocle-auto".to_string();
         let diagnostics: Option<TurnDiagnostics> = None;
+        let mut always_on = false;
+        let (_dir, cfg) = test_config();
         assert!(matches!(
-            dispatch_chat_command("/help", &mut model, &diagnostics),
+            dispatch_chat_command("/help", &mut model, &diagnostics, &mut always_on, &cfg),
             Some(LoopControl::Continue)
         ));
+    }
+
+    #[test]
+    fn dispatch_chat_command_diag_on_off_flips_flag_and_persists() {
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        let mut always_on = false;
+        let (_dir, cfg) = test_config();
+
+        assert!(matches!(
+            dispatch_chat_command("/diag on", &mut model, &diagnostics, &mut always_on, &cfg),
+            Some(LoopControl::Continue)
+        ));
+        assert!(always_on);
+        assert!(cfg.read().diag_always_on);
+
+        assert!(matches!(
+            dispatch_chat_command("/diag off", &mut model, &diagnostics, &mut always_on, &cfg),
+            Some(LoopControl::Continue)
+        ));
+        assert!(!always_on);
+        assert!(!cfg.read().diag_always_on);
+    }
+
+    #[test]
+    fn dispatch_chat_command_bare_diag_still_shows_last_turn() {
+        // `/diag` (no argument) must still fall through to the shared
+        // last-turn display, not be swallowed by the on/off branch.
+        let mut model = "monocle-auto".to_string();
+        let diagnostics: Option<TurnDiagnostics> = None;
+        let mut always_on = false;
+        let (_dir, cfg) = test_config();
+        assert!(matches!(
+            dispatch_chat_command("/diag", &mut model, &diagnostics, &mut always_on, &cfg),
+            Some(LoopControl::Continue)
+        ));
+        // Unaffected by a bare `/diag`.
+        assert!(!always_on);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,121 @@
+//! Persisted user-preference config — `~/.monocle/config.json`.
+//!
+//! Unlike `credentials.rs`, this file carries no backward-compat contract
+//! with the TypeScript CLI (it's new). Best-effort, same posture as
+//! `diag.rs`'s log file: a missing or unparseable file just means defaults,
+//! never a hard error.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::util::home_dir;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ConfigData {
+    /// `monocle chat`'s `/diag on`/`/diag off` — when true, every turn's
+    /// diagnostics (see `commands::repl::format_diag`) print automatically
+    /// instead of only on demand via `/diag`.
+    #[serde(default)]
+    pub diag_always_on: bool,
+}
+
+pub struct Config {
+    home: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self { home: home_dir() }
+    }
+
+    /// Test/seam constructor: root the `.monocle` dir at an arbitrary base.
+    pub fn with_home(home: impl Into<PathBuf>) -> Self {
+        Self { home: home.into() }
+    }
+
+    pub fn dir(&self) -> PathBuf {
+        self.home.join(".monocle")
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.dir().join("config.json")
+    }
+
+    /// A missing or unparseable file yields `ConfigData::default()` — this is
+    /// a best-effort preference store, not the locked-schema
+    /// `credentials.json`, so a corrupt file degrades gracefully rather than
+    /// blocking the REPL from starting. Warns to stderr on a parse failure so
+    /// the degraded state isn't silent.
+    pub fn read(&self) -> ConfigData {
+        let path = self.path();
+        if !path.exists() {
+            return ConfigData::default();
+        }
+        match fs::read_to_string(&path).and_then(|c| {
+            serde_json::from_str::<ConfigData>(&c)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        }) {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("Warning: Failed to read config: {e}");
+                ConfigData::default()
+            }
+        }
+    }
+
+    pub fn write(&self, data: &ConfigData) -> Result<()> {
+        let dir = self.dir();
+        let path = self.path();
+        fs::create_dir_all(&dir)?;
+        let json = serde_json::to_string_pretty(data)?;
+        fs::write(&path, json)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_missing_file_returns_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config::with_home(dir.path());
+        assert_eq!(cfg.read(), ConfigData::default());
+        assert!(!cfg.read().diag_always_on);
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config::with_home(dir.path());
+        cfg.write(&ConfigData {
+            diag_always_on: true,
+        })
+        .unwrap();
+        assert_eq!(
+            cfg.read(),
+            ConfigData {
+                diag_always_on: true
+            }
+        );
+    }
+
+    #[test]
+    fn read_tolerates_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config::with_home(dir.path());
+        fs::create_dir_all(cfg.dir()).unwrap();
+        fs::write(cfg.path(), b"not json").unwrap();
+        assert_eq!(cfg.read(), ConfigData::default());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod audio_io;
 pub mod auth;
 pub mod colors;
 pub mod commands;
+pub mod config;
 pub mod credentials;
 pub mod diag;
 pub mod endpoints;


### PR DESCRIPTION
## 요약
- `monocle chat` REPL에 `/diag on`/`/diag off` 커맨드 추가 — 켜면 매 턴 응답 후 diagnostics(엔드포인트/모델/지연시간/**토큰 사용량**)가 stderr에 자동 출력됨. 응답 바디(stdout)는 그대로, 메타데이터만 추가로 보임.
- on/off 상태는 `~/.monocle/config.json`(신규)에 저장돼 세션 재시작 후에도 유지됨.
- 기존 `/diag`(마지막 턴만 온디맨드로 표시)는 그대로 동작 — 새 기능은 기존 `format_diag`/`TurnDiagnostics` 출력 포맷을 그대로 재사용.
- `--responses` 경로도 동일하게 지원되지만, 이 경로는 서버가 usage/served model을 보고하지 않아 해당 줄은 원래대로 생략됨.
- README에 `/diag on`/`/diag off` 설명 추가.

## `~/.monocle/config.json`의 성격 — 명시
`src/config.rs`는 `src/credentials.rs`와 같은 구조(dir/path/read/write, `with_home` 테스트 시임)를 따르지만, **`credentials.json`과 달리 하위호환 계약이 전혀 없는 best-effort 저장소**다. TS CLI와의 drop-in 호환 요구가 없고, 스키마가 언제든 바뀔 수 있으며, 파일이 없거나 파싱에 실패해도 조용히 기본값(`diag_always_on: false`)으로 폴백한다 — 이 파일을 설정 정본(source of truth)으로 기대하고 다른 기능이 의존하도록 설계되어 있지 않다.

## 보안 검토
diagnostics 출력에 인증 헤더/토큰/자격증명이 섞여 나갈 경로가 있는지 직접 확인함: `Endpoint:` 줄은 `router_url`/`jarvice_url`(OIDC 디스커버리 문서의 `router_url` 필드 또는 `scheme://tenant_domain` 형태의 평문 베이스 URL)로만 구성되고, 쿼리 파라미터나 서명된 URL이 아님. Bearer 토큰은 항상 `Authorization` 헤더로만 전송되고 엔드포인트 문자열에는 절대 포함되지 않음. `ChatResponse`의 다른 필드(content/tool_calls/model/usage)도 인증 관련 값을 담지 않음. 새어나갈 경로 없음.

## 설계 메모
- 커맨드 dispatch는 새 `Config` 파라미터를 주입받도록 해 테스트가 실제 `~/.monocle/config.json`을 건드리지 않고 tempdir로 검증.

## 테스트
- `cargo test --lib`: 183 passed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

🤖 cc-butler 워커(monocle-cli-diagnostics 토픽)가 생성 — 스튜어드 리뷰 승인됨