### PR TITLE
feat(image-generate): /v1/images/generations 커맨드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Shows your tenant, user, access/refresh token validity, and whether Claude Code 
 | `monocle audio transcribe-azure [file] [--locale <code>] [--diarization] [--profanity <mode>] [--channels <list>] [--definition <json>]` | Azure Fast transcription |
 | `monocle audio speech [text] -o <path> [--model <id>] [--voice <name>] [--format <fmt>]` | OpenAI-compatible TTS (text arg or stdin) |
 | `monocle audio speech-azure [ssml] -o <path> [--format <fmt>]` | Azure SSML TTS |
+| `monocle image-generate --prompt <text> --model <id> [--size <WxH>] [--quality <q>] [--n <count>]` | Call the image-generation endpoint directly for debugging (text prompt → new image, no input image) |
 | `monocle claude [...args]` | Launch Claude Code through Monocle (args pass through) |
 | `monocle setup` | Globally route plain `claude` through Monocle (opt-in) |
 | `monocle unset` | Remove the global `claude` routing |
@@ -399,6 +400,16 @@ monocle audio speech-azure \
 ```
 
 On failure each command prints the HTTP status and response body to stderr and exits non-zero, which makes it easy to spot bad parameters or backend errors.
+
+## 🖼️ Images
+
+`monocle image-generate` calls chat-proxy's image-generation endpoint (`/v1/images/generations`) directly, printing the raw JSON response to stdout — a one-shot debugging probe, same style as the `audio` commands above (no input image; for that, use an image-editing endpoint/tool instead).
+
+```bash
+monocle image-generate --prompt "a cat wearing a hat" --model gpt-image-1 --size 1024x1024
+```
+
+The response body (printed as-is) carries the image as base64 (`data[].b64_json`), matching the OpenAI Images API shape.
 
 ## ⬆️ Upgrading
 

--- a/src/commands/image_generate.rs
+++ b/src/commands/image_generate.rs
@@ -1,0 +1,151 @@
+//! `monocle image-generate` — a one-shot debugging probe for chat-proxy's
+//! `POST /v1/images/generations`. It sends a text prompt as JSON and prints
+//! the raw response body to stdout, so a human can observe one real
+//! response. Deliberately minimal — the text-to-image twin of `image-edit`
+//! (no input image, no mask; the endpoint itself takes JSON, not multipart,
+//! since there's no file to attach).
+
+use std::io::Write;
+
+use serde_json::{json, Value};
+
+use crate::audio_io::write_api_error_and_exit;
+use crate::auth::get_access_token;
+use crate::credentials::Credentials;
+use crate::endpoints;
+use crate::error::{AppError, Result};
+use crate::net::Client;
+use crate::origin::auth_headers;
+
+pub struct ImageGenerateOptions {
+    pub prompt: String,
+    pub model: String,
+    pub size: Option<String>,
+    pub quality: Option<String>,
+    pub n: Option<String>,
+}
+
+/// The JSON request body: `model` + `prompt` always, everything else only
+/// when the user actually supplied it — mirrors `image_edit::form_fields`'s
+/// sparse-by-default shape, just as a JSON object instead of multipart text
+/// fields (chat-proxy's `/v1/images/generations` route reads a plain JSON
+/// body; see `app/converters/images.py::image_to_chat_format`).
+///
+/// `n` is typed as a JSON integer on the wire (chat-proxy compares it
+/// numerically, e.g. its `n > 1` Gemini guard), so an unparsable `--n` is a
+/// hard error here rather than silently sent as a string or dropped.
+pub fn request_body(options: &ImageGenerateOptions) -> Result<Value> {
+    let mut body = json!({
+        "model": options.model,
+        "prompt": options.prompt,
+    });
+    let obj = body
+        .as_object_mut()
+        .expect("json!({...}) is always an object");
+    if let Some(v) = &options.size {
+        obj.insert("size".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &options.quality {
+        obj.insert("quality".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &options.n {
+        let n: i64 = v
+            .trim()
+            .parse()
+            .map_err(|_| AppError::new(format!("--n must be a positive integer, got \"{v}\"")))?;
+        obj.insert("n".to_string(), Value::from(n));
+    }
+    Ok(body)
+}
+
+pub fn image_generate_command(
+    client: &Client,
+    creds: &Credentials,
+    options: ImageGenerateOptions,
+) -> Result<()> {
+    let body = request_body(&options)?;
+
+    let session = get_access_token(client, creds);
+    let url = format!("{}{}", session.router_url, endpoints::IMAGES_GENERATIONS);
+    // stdout stays pure response data; which host was actually hit goes to stderr.
+    eprintln!("POST {url}");
+
+    let bearer = format!("Bearer {}", session.token);
+    let resp = client.post_json(&url, &auth_headers(&bearer), &body)?;
+
+    if !resp.ok() {
+        write_api_error_and_exit(&resp);
+    }
+
+    let body = resp.text();
+    let mut out = std::io::stdout();
+    out.write_all(body.as_bytes())?;
+    if !body.ends_with('\n') {
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> ImageGenerateOptions {
+        ImageGenerateOptions {
+            prompt: "a cat wearing a hat".to_string(),
+            model: "some-image-model".to_string(),
+            size: None,
+            quality: None,
+            n: None,
+        }
+    }
+
+    #[test]
+    fn request_body_is_sparse_by_default() {
+        let body = request_body(&options()).unwrap();
+        assert_eq!(
+            body,
+            json!({"model": "some-image-model", "prompt": "a cat wearing a hat"})
+        );
+    }
+
+    #[test]
+    fn request_body_includes_only_supplied_options() {
+        let mut opts = options();
+        opts.size = Some("1024x1024".to_string());
+        opts.n = Some("2".to_string());
+
+        let body = request_body(&opts).unwrap();
+        assert_eq!(
+            body,
+            json!({
+                "model": "some-image-model",
+                "prompt": "a cat wearing a hat",
+                "size": "1024x1024",
+                "n": 2,
+            })
+        );
+        // quality was not supplied, so it must not be sent.
+        assert!(body.get("quality").is_none());
+    }
+
+    #[test]
+    fn request_body_sends_n_as_a_json_integer_not_a_string() {
+        let mut opts = options();
+        opts.n = Some("3".to_string());
+        let body = request_body(&opts).unwrap();
+        assert_eq!(body["n"], json!(3));
+        assert!(body["n"].is_number());
+    }
+
+    #[test]
+    fn request_body_rejects_a_non_numeric_n() {
+        let mut opts = options();
+        opts.n = Some("lots".to_string());
+        let err = request_body(&opts).unwrap_err();
+        assert!(
+            err.to_string().contains("--n must be a positive integer"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod audio_transcribe;
 pub mod audio_transcribe_azure;
 pub mod chat;
 pub mod claude;
+pub mod image_generate;
 pub mod login;
 pub mod model_list;
 pub mod repl;

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -6,5 +6,6 @@ pub const MODELS: &str = "/v1/models";
 pub const CHAT_COMPLETIONS: &str = "/v1/chat/completions";
 pub const AUDIO_TRANSCRIPTIONS: &str = "/v1/audio/transcriptions";
 pub const AUDIO_SPEECH: &str = "/v1/audio/speech";
+pub const IMAGES_GENERATIONS: &str = "/v1/images/generations";
 pub const AZURE_SPEECH_TO_TEXT: &str = "/v1/speechtotext/transcriptions:transcribe";
 pub const AZURE_TEXT_TO_SPEECH: &str = "/v1/azure/texttospeech/cognitiveservices/v1";

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use monocle_cli::commands::chat::{
     chat_command, chat_list_command, ChatOptions, ToolFiringExpectation,
 };
 use monocle_cli::commands::claude::claude_command;
+use monocle_cli::commands::image_generate::{image_generate_command, ImageGenerateOptions};
 use monocle_cli::commands::login::login_command;
 use monocle_cli::commands::model_list::model_list_command;
 use monocle_cli::commands::setup::setup_command;
@@ -58,6 +59,9 @@ Commands:
 
   Audio:
     audio    Call audio (STT / TTS) endpoints directly for debugging
+
+  Images:
+    image-generate  Call the image-generate endpoint directly for debugging
 
   Maintenance:
     upgrade  Update monocle to the latest release
@@ -139,6 +143,25 @@ enum Commands {
     Audio {
         #[command(subcommand)]
         command: AudioCommands,
+    },
+    /// Call the image-generate endpoint directly for debugging
+    #[command(name = "image-generate")]
+    ImageGenerate {
+        /// Generation prompt (required)
+        #[arg(long)]
+        prompt: String,
+        /// Model ID (required; the router only allows image-capable models)
+        #[arg(long)]
+        model: String,
+        /// Output size (e.g., 1024x1024)
+        #[arg(long)]
+        size: Option<String>,
+        /// Output quality (model-dependent)
+        #[arg(long)]
+        quality: Option<String>,
+        /// Number of images to generate
+        #[arg(long)]
+        n: Option<String>,
     },
     /// [Deprecated] Use `monocle chat` / `monocle models` instead
     #[command(hide = true)]
@@ -372,6 +395,23 @@ fn main() {
             },
         ),
         Commands::Audio { command } => run_audio(&client, &creds, command),
+        Commands::ImageGenerate {
+            prompt,
+            model,
+            size,
+            quality,
+            n,
+        } => image_generate_command(
+            &client,
+            &creds,
+            ImageGenerateOptions {
+                prompt,
+                model,
+                size,
+                quality,
+                n,
+            },
+        ),
         Commands::Upgrade { check } => upgrade_command(&client, check),
         Commands::Model { command } => {
             match command {
@@ -508,6 +548,48 @@ mod tests {
             }
             _ => panic!("expected Chat command"),
         }
+    }
+
+    #[test]
+    fn image_generate_parses_hyphenated_name_and_required_flags() {
+        let cli = Cli::parse_from([
+            "monocle",
+            "image-generate",
+            "--prompt",
+            "a cat wearing a hat",
+            "--model",
+            "some-image-model",
+        ]);
+        match cli.command {
+            Commands::ImageGenerate {
+                prompt,
+                model,
+                size,
+                ..
+            } => {
+                assert_eq!(prompt, "a cat wearing a hat");
+                assert_eq!(model, "some-image-model");
+                assert!(size.is_none());
+            }
+            _ => panic!("expected ImageGenerate command"),
+        }
+    }
+
+    #[test]
+    fn image_generate_requires_prompt_and_model() {
+        // Both flags are required: neither may silently default.
+        assert!(Cli::try_parse_from(["monocle", "image-generate"]).is_err());
+        assert!(Cli::try_parse_from([
+            "monocle",
+            "image-generate",
+            "--prompt",
+            "a cat wearing a hat"
+        ])
+        .is_err());
+        assert!(
+            Cli::try_parse_from(["monocle", "image-generate", "--model", "some-image-model"])
+                .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## ⚠️ 현재 상태 — 머지 준비 안 됨

- **독립 리뷰 미실시.** 이 PR은 이 세션(작성 세션)이 서브에이전트로 구현한 산출물이라, 같은 세션이 자기 PR을 리뷰할 수 없다는 기준에 따라 아직 어떤 코드리뷰도 거치지 않았습니다.
- **라이브 호출 미검증.** `cargo test`는 전부 통과했지만 실제 chat-proxy `/v1/images/generations` 엔드포인트를 실제로 호출해 본 적은 없습니다(세션 내 라이브 API 콜 금지 정책, 2026-08-07).
- 위 두 가지가 채워지기 전까지 머지 대상이 아닙니다.

## Summary
- `image-generate` 서브커맨드 추가 — 텍스트 프롬프트로 이미지 생성 (`POST /v1/images/generations`, JSON body, 입력 이미지 없음)
- 기존 `image-edit`(#123, 아직 devel에 머지 안 됨) 커맨드의 구조(옵션 파싱, 인증, 에러 처리, 출력 방식)를 개념적으로 미러링 — `feature/image-edit-probe`를 브랜치로 삼지 않고 `devel`에서 직접 분기해 구현
- 입력 파일이 없는 커맨드라 MIME/확장자 테이블 관련 코드는 추가하지 않음 (기존에 지적된 `image-edit`/`attachment.rs` 중복 테이블 이슈와 무관)

## Changes
- `src/commands/image_generate.rs` (신규)
- `src/endpoints.rs` — `IMAGES_GENERATIONS` 상수
- `src/commands/mod.rs` — 모듈 등록
- `src/main.rs` — `image-generate` 서브커맨드(`--prompt`, `--model` 필수, `--size`/`--quality`/`--n` 선택), CLI 파싱 테스트
- `README.md` — 커맨드 표 + 사용법 절

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (182개 기존 유닛 테스트 + 신규 image_generate 유닛 테스트 + CLI 파싱 테스트 전부 통과)
- [ ] 독립 코드리뷰 — 미실시
- [ ] 실제 chat-proxy 호출 관측 — 세션 내 라이브 API 콜 금지 정책(2026-08-07)에 따라 미수행, 별도 승인 필요

🤖 Generated with a Claude Code subagent
